### PR TITLE
Lima Fixes

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -11,7 +11,6 @@
 		#include "map_files\KiloStation\KiloStation.dmm"
 		#include "map_files\MetaStation\MetaStation.dmm"
 		#include "map_files\IceBoxStation\IceBoxStation.dmm"
-		#include "map_files\LimaStation\Lima.dmm"
 
 		#ifdef CIBUILDING
 			#include "templates.dm"

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -2865,7 +2865,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aqu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -2947,7 +2947,7 @@
 "arv" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "arw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
@@ -3436,11 +3436,6 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/chapel/main)
-"atY" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/aisat)
 "auf" = (
 /obj/machinery/door/airlock{
 	name = "Crematorium";
@@ -4703,9 +4698,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aCq" = (
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "aCs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -5525,6 +5517,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"aJL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "aJQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -5789,9 +5791,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/fore)
-"aMd" = (
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
 "aMl" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -6558,7 +6557,7 @@
 "aRr" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space/nearstation)
+/area/tcommsat/server)
 "aRt" = (
 /obj/structure/chair/sofa{
 	name = "plush sofa"
@@ -10164,7 +10163,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space)
+/area/tcommsat/server)
 "blq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -10695,7 +10694,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "bwn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -11385,7 +11384,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "bTF" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall,
@@ -11551,13 +11550,6 @@
 "bYN" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
-"bYS" = (
-/obj/structure/cable,
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
-/turf/open/floor/circuit,
-/area/aisat)
 "bZD" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plasteel,
@@ -11632,7 +11624,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "cbG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -11654,7 +11646,7 @@
 	dir = 6
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/aft)
+/area/bridge)
 "ccg" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -12026,7 +12018,7 @@
 	dir = 6
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "cmm" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -12209,7 +12201,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "csU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -12460,7 +12452,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cAP" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenobiology Maintenance";
@@ -12522,7 +12514,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space)
+/area/tcommsat/server)
 "cDi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -12671,9 +12663,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cLj" = (
-/turf/open/space/basic,
-/area/tcommsat/server)
 "cLV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/machinery/meter,
@@ -12926,7 +12915,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "cSr" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 8
@@ -12997,7 +12986,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/space/nearstation)
+/area/ai_monitored/turret_protected/aisat_interior)
 "cUC" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
@@ -13169,7 +13158,7 @@
 /obj/structure/table/reinforced,
 /obj/item/phone,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "cZu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -13291,7 +13280,7 @@
 	dir = 1
 	},
 /turf/open/floor/circuit,
-/area/aisat)
+/area/ai_monitored/turret_protected/ai)
 "dcD" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -13372,7 +13361,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "deM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
@@ -13390,7 +13379,7 @@
 	dir = 1
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "dfs" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office";
@@ -13803,7 +13792,7 @@
 /obj/structure/transit_tube/crossing/horizontal,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/tcommsat/computer)
+/area/space/nearstation)
 "dsA" = (
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer";
@@ -13817,7 +13806,7 @@
 "dsI" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "dtd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13993,7 +13982,7 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "dxe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14152,7 +14141,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "dzZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -14375,7 +14364,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/aisat_interior)
 "dDF" = (
 /obj/machinery/vending/boozeomat,
 /obj/machinery/light{
@@ -15174,7 +15163,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "dZv" = (
 /obj/structure/flora/junglebush/b,
 /obj/item/toy/plush/snakeplushie,
@@ -15383,14 +15372,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ehJ" = (
-/obj/structure/showcase/cyborg/old{
-	dir = 8;
-	pixel_x = 9;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "ehQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -15449,7 +15430,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space)
+/area/tcommsat/server)
 "eiS" = (
 /obj/structure/table,
 /obj/item/storage/lockbox/loyalty,
@@ -15518,9 +15499,6 @@
 /obj/item/pen/red,
 /turf/open/floor/carpet/orange,
 /area/lawoffice)
-"elH" = (
-/turf/open/space/basic,
-/area/maintenance/aft)
 "elJ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -15635,7 +15613,7 @@
 "eqS" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
-/area/space/nearstation)
+/area/tcommsat/computer)
 "eqX" = (
 /obj/structure/table/wood/poker,
 /obj/item/clothing/glasses/monocle,
@@ -16074,7 +16052,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "eCP" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
@@ -16181,7 +16159,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "eJk" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -16412,7 +16390,7 @@
 	dir = 8
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "ePA" = (
 /obj/machinery/camera{
 	c_tag = "Courtroom North";
@@ -16516,7 +16494,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit,
-/area/aisat)
+/area/ai_monitored/turret_protected/ai)
 "eRN" = (
 /obj/structure/transit_tube/station/reverse{
 	dir = 1
@@ -16525,7 +16503,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/aft)
+/area/bridge)
 "eSp" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16801,7 +16779,7 @@
 	dir = 9
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "fby" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -17077,7 +17055,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "fig" = (
 /obj/structure/window{
 	dir = 4
@@ -17184,7 +17162,7 @@
 "fkd" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "fkC" = (
 /obj/structure/chair/sofa/right,
 /obj/item/toy/plush/beeplushie,
@@ -17228,7 +17206,7 @@
 "flQ" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "flU" = (
 /obj/machinery/light{
 	dir = 8
@@ -17264,7 +17242,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space)
+/area/tcommsat/server)
 "fng" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/plasteel/cafeteria,
@@ -17278,7 +17256,7 @@
 "fnJ" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "fnK" = (
 /turf/closed/wall,
 /area/medical/storage)
@@ -17329,7 +17307,7 @@
 	dir = 5
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "fpF" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -17609,7 +17587,7 @@
 	},
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "fxo" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /obj/effect/turf_decal/stripes/line{
@@ -17617,10 +17595,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/explab)
-"fxw" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/ai_monitored/storage/satellite)
 "fxy" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "telelab";
@@ -17738,7 +17712,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "fAC" = (
 /obj/machinery/gravity_generator/main/station,
 /turf/open/floor/plasteel/dark,
@@ -17753,7 +17727,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "fAP" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 10
@@ -17924,7 +17898,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "fDD" = (
 /obj/structure/chair{
 	dir = 1
@@ -18107,9 +18081,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"fJG" = (
-/turf/open/space/basic,
-/area/ai_monitored/turret_protected/ai)
 "fJZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -18119,7 +18090,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "fKe" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/showroomfloor,
@@ -18309,7 +18280,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space/nearstation)
+/area/tcommsat/server)
 "fPN" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
 	dir = 1
@@ -18468,7 +18439,7 @@
 	network = list("minisat")
 	},
 /turf/open/space/basic,
-/area/tcommsat/computer)
+/area/space)
 "fUT" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Telecommunications";
@@ -18482,7 +18453,7 @@
 	},
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "fVb" = (
 /obj/machinery/light{
 	dir = 4
@@ -18564,7 +18535,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/tcommsat/computer)
 "fWF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -18642,9 +18613,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
-"fYy" = (
-/turf/open/space/basic,
-/area/tcommsat/computer)
 "fYR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -18753,11 +18721,11 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/tcommsat/computer)
 "gaU" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "gbh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -19133,7 +19101,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat_interior)
 "gnu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -19306,7 +19274,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space/nearstation)
+/area/ai_monitored/turret_protected/aisat_interior)
 "gtr" = (
 /obj/structure/safe,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
@@ -19385,13 +19353,13 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "gud" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "gue" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "O2 to Airmix"
@@ -19735,7 +19703,7 @@
 /obj/effect/landmark/blobstart,
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "gCC" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plasteel/dark,
@@ -19862,7 +19830,7 @@
 "gHt" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "gIl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -19993,7 +19961,7 @@
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "gNZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -20011,7 +19979,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "gOn" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/poster/official/random{
@@ -20116,7 +20084,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "gRo" = (
 /obj/structure/table/wood,
 /obj/item/storage/lockbox/medal,
@@ -20483,7 +20451,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "hbq" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Fore Port";
@@ -20796,7 +20764,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "hmf" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -20871,7 +20839,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "hou" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine,
@@ -20901,9 +20869,6 @@
 "hoU" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"hpe" = (
-/turf/closed/wall/r_wall,
-/area/maintenance/aft)
 "hpf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -20919,7 +20884,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/aisat_interior)
 "hpS" = (
 /obj/structure/window{
 	dir = 8
@@ -21455,7 +21420,7 @@
 "hHw" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/space/nearstation)
+/area/tcommsat/server)
 "hHx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -21501,12 +21466,6 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
-"hIS" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat/foyer)
 "hJH" = (
 /obj/machinery/air_sensor/atmos/mix_tank{
 	id_tag = "mix2_sensor"
@@ -21565,7 +21524,7 @@
 "hLt" = (
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "hLE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -21582,7 +21541,7 @@
 	},
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "hMw" = (
 /obj/effect/turf_decal/loading_area,
 /obj/effect/turf_decal/tile/yellow{
@@ -21652,7 +21611,7 @@
 	dir = 8
 	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "hOU" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -21777,7 +21736,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "hTE" = (
 /obj/structure/closet/toolcloset,
 /obj/item/radio/intercom{
@@ -21851,7 +21810,7 @@
 /obj/structure/transit_tube/horizontal,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/aft)
+/area/space/nearstation)
 "hXX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22128,7 +22087,7 @@
 /area/medical/exam_room)
 "iiy" = (
 /turf/open/floor/plasteel/showroomfloor,
-/area/space/nearstation)
+/area/tcommsat/computer)
 "ijy" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -22379,11 +22338,6 @@
 /obj/item/paper/guides/jobs/hydroponics,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
-"itc" = (
-/obj/structure/transit_tube/horizontal,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
 "itf" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
@@ -22643,22 +22597,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"iAQ" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
 "iCc" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -22691,7 +22629,7 @@
 	req_access_txt = "65"
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "iDr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -22723,7 +22661,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "iEb" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -22759,7 +22697,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "iED" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22842,7 +22780,7 @@
 "iHs" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
-/area/maintenance/aft)
+/area/bridge)
 "iHL" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/light,
@@ -22938,7 +22876,7 @@
 	dir = 8
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "iLc" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -22965,7 +22903,7 @@
 	},
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space)
+/area/tcommsat/computer)
 "iLT" = (
 /turf/closed/wall/r_wall,
 /area/medical/chemistry)
@@ -23005,13 +22943,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"iNo" = (
-/obj/structure/cable,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "iNx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -23039,11 +22970,6 @@
 "iOP" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
-"iOR" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
 "iPn" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -23072,7 +22998,7 @@
 	},
 /obj/item/book/manual/wiki/tcomms,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "iPX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -23129,7 +23055,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "iSm" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -23424,7 +23350,7 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/plasteel/dark,
-/area/aisat)
+/area/ai_monitored/turret_protected/ai)
 "iZs" = (
 /obj/machinery/atmospherics/miner/toxins,
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -23629,7 +23555,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "jhE" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -23740,7 +23666,7 @@
 "jkW" = (
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/space/nearstation)
+/area/tcommsat/server)
 "jlf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -23816,7 +23742,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit,
-/area/aisat)
+/area/ai_monitored/turret_protected/ai)
 "joR" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -24651,7 +24577,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space/nearstation)
+/area/tcommsat/server)
 "jSx" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
@@ -24679,7 +24605,7 @@
 	},
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space)
+/area/tcommsat/computer)
 "jTD" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/seven,
@@ -25342,12 +25268,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kpr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "kpz" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -25369,18 +25289,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/item/beacon,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space/nearstation)
+/area/tcommsat/computer)
 "kqj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"kqG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/nearstation)
 "kre" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 1
@@ -25399,7 +25313,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "krw" = (
 /obj/structure/closet/crate/hydroponics{
 	name = "Prison Hydroponics Crate"
@@ -25650,11 +25564,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/lab)
-"kwP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/space)
 "kxP" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -25819,9 +25728,6 @@
 "kDD" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"kDI" = (
-/turf/open/floor/plasteel/dark,
-/area/space)
 "kDK" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -25854,7 +25760,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "kEB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -25925,7 +25831,7 @@
 	req_one_access_txt = "32;19"
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "kGs" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -26104,7 +26010,7 @@
 "kKP" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space/nearstation)
+/area/tcommsat/server)
 "kKX" = (
 /obj/machinery/camera{
 	c_tag = "Turbine Room";
@@ -26324,7 +26230,7 @@
 "kPu" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "kPK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/biohazard,
@@ -26402,10 +26308,6 @@
 "kTy" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
-"kTE" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/space)
 "kTF" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -26459,7 +26361,7 @@
 	req_one_access_txt = "32;19"
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "kWh" = (
 /obj/machinery/light{
 	dir = 8
@@ -26591,12 +26493,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"ldQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/showroomfloor,
-/area/space)
 "leo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -26816,7 +26712,7 @@
 	amount = 35
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "lko" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/royalblue,
@@ -27134,7 +27030,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "lrG" = (
 /obj/machinery/light{
 	dir = 4
@@ -27289,7 +27185,7 @@
 	network = list("minisat")
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/ai)
+/area/space/nearstation)
 "lwr" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/aft";
@@ -27462,7 +27358,7 @@
 "lCc" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "lCN" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -27491,14 +27387,14 @@
 	start_active = 1
 	},
 /turf/open/space/basic,
-/area/tcommsat/computer)
+/area/space)
 "lEl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "lEE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -27888,9 +27784,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"lQQ" = (
-/turf/open/space/basic,
-/area/ai_monitored/storage/satellite)
 "lQX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28063,10 +27956,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lXm" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Telecommunications";
-	req_access_txt = "61"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
@@ -28074,8 +27963,12 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/command/glass{
+	name = "Telecomms and AI";
+	req_access_txt = "19"
+	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/aft)
+/area/bridge)
 "lYe" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -28097,7 +27990,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "lYM" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/red,
@@ -28215,7 +28108,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "mej" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -28225,7 +28118,7 @@
 	dir = 8
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "meB" = (
 /obj/machinery/button/door{
 	id = "stationawaygate";
@@ -28346,7 +28239,7 @@
 "mgM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "mhN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -28511,7 +28404,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "mmn" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -28602,7 +28495,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/space/nearstation)
+/area/ai_monitored/storage/satellite)
 "moj" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable/layer1,
@@ -28665,7 +28558,7 @@
 "mpM" = (
 /obj/machinery/telecomms/bus/preset_four,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/space/nearstation)
+/area/tcommsat/server)
 "mpO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28860,7 +28753,7 @@
 "mwm" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "mwn" = (
 /obj/machinery/door/window/southleft{
 	dir = 4;
@@ -29115,7 +29008,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/aisat_interior)
 "mFd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -29299,7 +29192,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/aft)
+/area/bridge)
 "mML" = (
 /turf/open/floor/engine/air,
 /area/engine/atmos)
@@ -29339,7 +29232,7 @@
 	cable_layer = 1
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "mOE" = (
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/open/floor/engine,
@@ -29385,7 +29278,7 @@
 "mQu" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space/nearstation)
+/area/tcommsat/computer)
 "mQA" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -29410,6 +29303,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
+"mRm" = (
+/obj/structure/cable/layer1,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/tcommsat/server)
 "mRp" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -29636,7 +29533,7 @@
 	},
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "mWN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -29647,7 +29544,7 @@
 /obj/effect/turf_decal/tile/blue,
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat_interior)
 "mWS" = (
 /obj/machinery/light{
 	dir = 8
@@ -29873,10 +29770,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"ncw" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/ai_monitored/turret_protected/aisat_interior)
 "ncW" = (
 /turf/open/floor/grass,
 /area/science/genetics)
@@ -29937,7 +29830,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space/nearstation)
+/area/tcommsat/server)
 "nfi" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -29981,7 +29874,7 @@
 "nfD" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/aft)
+/area/bridge)
 "nfM" = (
 /obj/machinery/computer/security/hos{
 	dir = 4
@@ -30010,7 +29903,7 @@
 "ngH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "ngV" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/HFR_core,
@@ -30046,7 +29939,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "nio" = (
 /obj/machinery/camera{
 	c_tag = "Ian's Room";
@@ -30313,7 +30206,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "nsU" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -30479,11 +30372,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"nxB" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/tcommsat/computer)
 "nxK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -30507,9 +30395,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"nyx" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/space)
 "nyU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
@@ -30546,12 +30431,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/fore)
-"nAe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/space/nearstation)
 "nAA" = (
 /turf/closed/wall,
 /area/storage/primary)
@@ -30633,7 +30512,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "nCW" = (
 /obj/machinery/vending/security,
 /turf/open/floor/plasteel/showroomfloor,
@@ -30803,7 +30682,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "nIf" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/cable,
@@ -31189,7 +31068,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space/nearstation)
+/area/tcommsat/server)
 "nUR" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/effect/turf_decal/stripes/line{
@@ -31334,7 +31213,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "nYk" = (
 /obj/machinery/camera{
 	c_tag = "Kitchen";
@@ -31615,7 +31494,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/multitool,
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "ohu" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -31840,7 +31719,7 @@
 "onb" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/space)
+/area/tcommsat/server)
 "onR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -31866,7 +31745,7 @@
 "ooP" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/aft)
+/area/bridge)
 "ooZ" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/port/aft";
@@ -31946,7 +31825,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "oqU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -32081,7 +31960,7 @@
 "oxj" = (
 /obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "oxT" = (
 /obj/structure/closet/secure_closet/exile,
 /obj/machinery/camera{
@@ -32223,11 +32102,6 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/chapel/office)
-"oAC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "oAU" = (
 /obj/structure/chair{
 	dir = 1
@@ -32247,11 +32121,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"oBm" = (
-/obj/structure/transit_tube/horizontal,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/tcommsat/computer)
 "oBJ" = (
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
@@ -32343,7 +32212,7 @@
 "oFA" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/aft)
+/area/bridge)
 "oGh" = (
 /obj/machinery/power/apc{
 	areastring = "/area/quartermaster/qm";
@@ -32734,7 +32603,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/aft)
+/area/bridge)
 "oVi" = (
 /obj/structure/sign/poster/ripped,
 /turf/closed/wall,
@@ -33441,7 +33310,7 @@
 	},
 /mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/aisat_interior)
 "psZ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -33640,7 +33509,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "pxG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -33789,10 +33658,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
-"pBM" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/ai_monitored/turret_protected/ai)
 "pCh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -33897,7 +33762,7 @@
 "pHi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/aft)
+/area/bridge)
 "pHR" = (
 /obj/machinery/button/door{
 	desc = "A remote control switch for the medbay foyer.";
@@ -34167,12 +34032,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"pPx" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
 "pPE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -34357,7 +34216,7 @@
 "pWw" = (
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space/nearstation)
+/area/tcommsat/computer)
 "pWG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -34432,7 +34291,7 @@
 	dir = 5
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "qay" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -34442,7 +34301,7 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/aisat_interior)
 "qaz" = (
 /obj/structure/displaycase/labcage,
 /turf/open/floor/plasteel/dark,
@@ -35225,10 +35084,6 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port)
-"qzl" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/tcommsat/server)
 "qzX" = (
 /turf/open/floor/carpet/black,
 /area/security/prison)
@@ -35625,7 +35480,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "qNh" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Treatment Center";
@@ -35964,7 +35819,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/bridge)
 "qZN" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -35983,7 +35838,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space)
+/area/tcommsat/server)
 "rae" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -36173,10 +36028,6 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood,
 /area/library)
-"rdi" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/aisat)
 "rdO" = (
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel,
@@ -36188,7 +36039,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/aft)
+/area/bridge)
 "rek" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/vault,
@@ -36327,7 +36178,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "riG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Maintenance";
@@ -36483,7 +36334,7 @@
 /obj/structure/transit_tube/horizontal,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/space)
+/area/tcommsat/computer)
 "rpt" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
@@ -36659,7 +36510,7 @@
 	pixel_y = 22
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/aisat_interior)
 "rta" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/plasteel/dark,
@@ -36728,7 +36579,7 @@
 	req_one_access_txt = "32;19"
 	},
 /turf/open/floor/plasteel/dark,
-/area/space/nearstation)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "rwr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -36831,7 +36682,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/bridge)
 "rza" = (
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -36910,7 +36761,7 @@
 "rCW" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space/nearstation)
+/area/tcommsat/computer)
 "rDp" = (
 /obj/structure/grille/broken,
 /obj/structure/disposalpipe/segment{
@@ -37095,9 +36946,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"rHL" = (
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
 "rIH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -37132,7 +36980,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/bridge)
 "rKn" = (
 /obj/structure/window{
 	dir = 4
@@ -37204,7 +37052,7 @@
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
-/area/space/nearstation)
+/area/ai_monitored/turret_protected/aisat_interior)
 "rLO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -37388,7 +37236,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "rSU" = (
 /obj/machinery/door/airlock{
 	name = "Bar Storage";
@@ -37458,11 +37306,11 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/circuit/green,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "rUF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "rUN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -37742,7 +37590,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat_interior)
 "sdI" = (
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/white,
@@ -37899,7 +37747,7 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/circuit/green,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "sgN" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -38044,7 +37892,7 @@
 	dir = 8
 	},
 /turf/open/floor/circuit,
-/area/aisat)
+/area/ai_monitored/turret_protected/ai)
 "slI" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -38618,7 +38466,7 @@
 	},
 /mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/plasteel/dark,
-/area/space/nearstation)
+/area/ai_monitored/turret_protected/aisat_interior)
 "sCZ" = (
 /turf/closed/wall,
 /area/quartermaster/qm)
@@ -38865,7 +38713,7 @@
 	},
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "sJu" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -39421,11 +39269,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/psychology)
-"sZJ" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "taa" = (
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/plasteel/cafeteria,
@@ -39443,28 +39286,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"tbu" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "tbB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "tbE" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio3";
@@ -39600,9 +39427,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
-"tep" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "teK" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -39685,7 +39509,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "thA" = (
 /obj/machinery/light,
 /obj/machinery/power/apc{
@@ -39803,7 +39627,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "tkl" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
@@ -40811,7 +40635,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "tMU" = (
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
@@ -41188,7 +41012,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/bridge)
 "tZZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -41233,7 +41057,7 @@
 	dir = 8
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "ucg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -41296,7 +41120,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "udM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
@@ -41342,6 +41166,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/prison)
+"uei" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai)
 "ueQ" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/tile/green{
@@ -41404,7 +41234,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "ugC" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -41569,6 +41399,11 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/bridge)
+"umy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "umz" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
@@ -41598,7 +41433,7 @@
 	req_access_txt = "16"
 	},
 /turf/open/floor/circuit/green,
-/area/space)
+/area/ai_monitored/turret_protected/ai)
 "umM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41703,7 +41538,7 @@
 	network = list("aicore")
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "uop" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
@@ -42005,9 +41840,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"uAh" = (
-/turf/open/space/basic,
-/area/aisat)
 "uAo" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -42213,7 +42045,7 @@
 "uDT" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/aisat_interior)
 "uER" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
@@ -42843,7 +42675,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "uWy" = (
 /obj/machinery/biogenerator{
 	pixel_x = 2
@@ -42923,7 +42755,7 @@
 /area/space/nearstation)
 "uZb" = (
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "uZo" = (
 /obj/effect/mapping_helpers/dead_body_placer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -43042,29 +42874,13 @@
 	dir = 4
 	},
 /area/hallway/secondary/entry)
-"vcR" = (
-/obj/machinery/porta_turret/ai{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "vdm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "vdD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/medical/glass{
@@ -43248,20 +43064,6 @@
 "vla" = (
 /turf/closed/wall/r_wall,
 /area/security/processing)
-"vli" = (
-/obj/machinery/porta_turret/ai,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space/nearstation)
 "vlz" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -43282,7 +43084,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "vlW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -43510,7 +43312,7 @@
 	network = list("minisat")
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/space/nearstation)
+/area/tcommsat/computer)
 "vqE" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -43567,7 +43369,7 @@
 "vrT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel/showroomfloor,
-/area/maintenance/aft)
+/area/bridge)
 "vsh" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -43649,7 +43451,7 @@
 "vsS" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "vsX" = (
 /obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/plasteel/dark,
@@ -43727,7 +43529,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "vuN" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -44106,7 +43908,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "vEc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -44175,7 +43977,7 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space)
+/area/space/nearstation)
 "vFF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
@@ -44197,7 +43999,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/aisat_interior)
 "vGF" = (
 /obj/structure/closet/radiation,
 /obj/machinery/light{
@@ -44282,7 +44084,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "vJe" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -44365,7 +44167,7 @@
 /obj/effect/turf_decal/tile/blue,
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/aisat_interior)
 "vKO" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
@@ -44395,7 +44197,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "vLY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -44510,7 +44312,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "vPD" = (
 /obj/machinery/light,
 /obj/machinery/portable_atmospherics/canister,
@@ -44600,7 +44402,7 @@
 	},
 /obj/machinery/holopad/secure,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "vSt" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -44760,7 +44562,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/aisat_interior)
 "vXD" = (
 /obj/structure/cable,
 /turf/open/floor/plating{
@@ -44801,7 +44603,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/space/nearstation)
+/area/ai_monitored/turret_protected/aisat_interior)
 "vYM" = (
 /obj/machinery/smartfridge/organ,
 /turf/closed/wall,
@@ -44913,7 +44715,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space/nearstation)
+/area/tcommsat/computer)
 "wdx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -45013,7 +44815,7 @@
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/storage/satellite)
 "whq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -45161,7 +44963,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/tcommsat/computer)
 "wkU" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -45224,7 +45026,7 @@
 "wmO" = (
 /obj/structure/transit_tube/station/reverse/flipped,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "wnE" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
@@ -45293,11 +45095,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
-"wpK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "wpL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -45307,7 +45104,7 @@
 	},
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "wpS" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -45702,11 +45499,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"wBO" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/tcommsat/server)
 "wBR" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Storage Maintenance";
@@ -45889,7 +45681,7 @@
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "wHS" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -45921,7 +45713,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/ai_monitored/turret_protected/ai)
 "wJe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -46323,7 +46115,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "wTv" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -46548,9 +46340,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/tcommsat/computer)
-"wZk" = (
-/turf/open/space/basic,
-/area/ai_monitored/turret_protected/aisat_interior)
 "wZK" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
@@ -46976,7 +46765,7 @@
 	pixel_y = 22
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/ai_monitored/turret_protected/ai)
 "xmL" = (
 /obj/structure/closet/wardrobe,
 /turf/open/floor/plasteel/dark,
@@ -46996,7 +46785,7 @@
 	network = list("minisat")
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/space/nearstation)
 "xnh" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -47072,7 +46861,7 @@
 "xoM" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space/nearstation)
+/area/tcommsat/computer)
 "xoP" = (
 /obj/structure/sign/poster/official/love_ian{
 	pixel_y = -32
@@ -47282,11 +47071,6 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"xsW" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/ai_monitored/turret_protected/ai)
 "xtg" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -47423,7 +47207,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/space/nearstation)
+/area/ai_monitored/turret_protected/aisat_interior)
 "xuR" = (
 /obj/machinery/light{
 	dir = 4
@@ -47966,7 +47750,7 @@
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/aisat_interior)
 "xLw" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -48067,7 +47851,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "xPV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48363,7 +48147,7 @@
 "xZa" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plasteel/showroomfloor,
-/area/space)
+/area/tcommsat/computer)
 "xZv" = (
 /obj/machinery/power/solar{
 	id = "foreportsolar";
@@ -48901,7 +48685,7 @@
 "yjU" = (
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/telecomms/mainframe,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "ykm" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -88214,8 +87998,8 @@ hcN
 dZA
 iHs
 lXm
-hpe
-hpe
+dZA
+dZA
 fsz
 gfQ
 gfQ
@@ -88472,7 +88256,7 @@ dvT
 vrT
 mLZ
 nfD
-hpe
+dZA
 gfQ
 gfQ
 gfQ
@@ -88729,12 +88513,12 @@ dZA
 pHi
 rei
 ooP
-hpe
-elH
-elH
-btp
-btp
-btp
+dZA
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -88986,9 +88770,9 @@ dZA
 ccb
 oUM
 eRN
-hpe
-elH
-elH
+dZA
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -89241,12 +89025,12 @@ qAC
 aOP
 dZA
 rKi
-wpK
+iDr
 oFA
-hpe
-elH
-elH
-btp
+dZA
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -89498,13 +89282,13 @@ cND
 bXY
 dZA
 ryV
-wpK
+iDr
 tZR
 iHs
-elH
-elH
-btp
-btp
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -89755,12 +89539,12 @@ uZE
 iDr
 dZA
 qZr
-wpK
+iDr
 hXV
-elH
-elH
-elH
-btp
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -90013,11 +89797,7 @@ wmJ
 gfQ
 hOS
 ssp
-oBm
-fYy
-elH
-fYy
-fYy
+hXV
 gfQ
 gfQ
 gfQ
@@ -90027,7 +89807,11 @@ gfQ
 gfQ
 gfQ
 gfQ
+btp
 gfQ
+gfQ
+gfQ
+btp
 gfQ
 gfQ
 gfQ
@@ -90270,24 +90054,24 @@ gfQ
 gfQ
 hOS
 ssp
-oBm
-fYy
-fYy
-fYy
-fYy
+hXV
 gfQ
 gfQ
-iOR
-iOR
-mfS
+gfQ
+gfQ
+gfQ
+gfQ
+sHc
+sHc
+fsz
 vFu
 vFu
 vFu
 vFu
 vFu
-mfS
-iOR
-iOR
+fsz
+sHc
+sHc
 gfQ
 gfQ
 gfQ
@@ -90528,23 +90312,23 @@ gfQ
 hOS
 ssp
 dsw
-fYy
-fYy
-fYy
-fYy
-gfQ
-gfQ
-iOR
-gfQ
-gfQ
-mfS
 gfQ
 gfQ
 gfQ
-mfS
 gfQ
 gfQ
-iOR
+gfQ
+sHc
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
+sHc
 gfQ
 gfQ
 gfQ
@@ -90784,25 +90568,25 @@ gfQ
 gfQ
 hOS
 ssp
-oBm
-fYy
-fYy
-fYy
-fYy
+hXV
 gfQ
 gfQ
-iOR
+gfQ
+gfQ
+gfQ
+gfQ
+sHc
 gfQ
 hbq
-tep
+idc
 mgM
 mgM
 mgM
-tep
+idc
 nfy
 gfQ
-mfS
-mfS
+fsz
+fsz
 gfQ
 gfQ
 gfQ
@@ -91042,24 +90826,24 @@ gfQ
 hOS
 ssp
 dsw
-fYy
-fYy
-fYy
-fYy
 gfQ
 gfQ
-iOR
 gfQ
-tep
-tep
+gfQ
+gfQ
+gfQ
+sHc
+gfQ
+idc
+idc
 bvD
 fif
 ogN
-tep
-tep
+idc
+idc
 gfQ
 gfQ
-iOR
+sHc
 gfQ
 gfQ
 gfQ
@@ -91298,26 +91082,26 @@ gfQ
 gfQ
 hOS
 ssp
-oBm
-fYy
-fYy
-fYy
-fYy
+hXV
 gfQ
-sZJ
-iOR
 gfQ
-tep
+gfQ
+gfQ
+gfQ
+xlO
+sHc
+gfQ
+idc
 rUF
-kDI
-kDI
-kDI
+uhX
+uhX
+uhX
 ljV
-tep
-mfS
-mfS
-iOR
-mfS
+idc
+fsz
+fsz
+sHc
+fsz
 gfQ
 gfQ
 gfQ
@@ -91555,25 +91339,25 @@ gfQ
 gfQ
 hOS
 ssp
-oBm
-fYy
-fYy
-btp
+hXV
 gfQ
 gfQ
 gfQ
-mfS
 gfQ
-tep
+gfQ
+gfQ
+fsz
+gfQ
+idc
 fxj
 ngH
 uWf
 tbB
 whm
-tep
+idc
 gfQ
 gfQ
-iOR
+sHc
 gfQ
 gfQ
 gfQ
@@ -91809,29 +91593,29 @@ gfQ
 gfQ
 gfQ
 gfQ
-kTE
+eqS
 wkn
-kwP
-itc
-btp
-btp
-btp
+oiJ
+hXV
 gfQ
 gfQ
 gfQ
-mfS
 gfQ
-tep
+gfQ
+gfQ
+fsz
+gfQ
+idc
 mlW
-iNo
+mnV
 rip
 mnV
 whm
-tep
+idc
 gfQ
-btp
-mfS
-mfS
+gfQ
+fsz
+fsz
 gfQ
 gfQ
 gfQ
@@ -92066,30 +91850,30 @@ gfQ
 gfQ
 gfQ
 gfQ
-tep
+xBZ
 fWC
-kwP
+oiJ
 rpp
 eqS
-xIg
-xIg
+xBZ
+xBZ
 gfQ
-tep
-tep
-tep
-tep
-tep
-xIg
-xIg
+khn
+khn
+khn
+khn
+khn
+kTy
+kTy
 gtj
-xIg
-xIg
-xIg
-btp
-btp
-btp
+kTy
+kTy
+kTy
+gfQ
+gfQ
+gfQ
 sHc
-btp
+gfQ
 gfQ
 gfQ
 gfQ
@@ -92323,30 +92107,30 @@ gfQ
 gfQ
 gfQ
 gfQ
-tep
+xBZ
 gay
-kwP
+oiJ
 xZa
 mQu
 xoM
-xIg
+xBZ
 gfQ
-tep
+khn
 cbo
 udK
 vIg
-tep
+khn
 rLL
 gnl
 vXh
 xuz
 mWN
-tep
-tep
-btp
+kTy
+kTy
 gfQ
-iOR
-btp
+gfQ
+sHc
+gfQ
 gfQ
 gfQ
 gfQ
@@ -92580,31 +92364,31 @@ gfQ
 gfQ
 xAV
 gfQ
-tep
+xBZ
 oqG
 fJZ
 wmO
 iiy
 vqs
 eqS
-tep
-tep
+khn
+khn
 jgU
 lrE
 vDN
-tep
+khn
 sCR
-kDI
-rip
-kpr
+xEM
+aJL
+cof
 vKH
-idc
-idc
-fxw
-mfS
-iOR
+kTy
+kTy
 fsz
-btp
+fsz
+sHc
+fsz
+gfQ
 gfQ
 gfQ
 gfQ
@@ -92837,10 +92621,10 @@ fsz
 gfQ
 gfQ
 gfQ
-tep
+xBZ
 dZb
 nsS
-ldQ
+wda
 kqd
 wda
 rwq
@@ -92856,12 +92640,12 @@ xLf
 qay
 mEX
 uDT
-idc
-lQQ
-lQQ
-iOR
+kTy
 gfQ
-btp
+gfQ
+sHc
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -93094,32 +92878,32 @@ gfQ
 gfQ
 gfQ
 gfQ
-tep
-nyx
+xBZ
+iiy
 hLU
-nyx
+iiy
 iiy
 iiy
 eqS
-tep
-tep
+khn
+khn
 eJj
 nhU
 iCZ
-tep
+khn
 vYI
-kDI
+xEM
 vGB
 dDu
 hpP
-idc
-idc
-lQQ
-lQQ
+kTy
+kTy
+gfQ
+gfQ
 fsz
 fsz
-btp
-btp
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -93351,31 +93135,31 @@ fsz
 gfQ
 gfQ
 gfQ
-tep
-kTE
+xBZ
+eqS
 fUT
-kTE
-xIg
-xIg
-xIg
+eqS
+xBZ
+xBZ
+xBZ
 gfQ
-tep
+khn
 vlR
 iRR
 gaU
-tep
-vli
-kDI
-prU
-uhX
+khn
 aqs
-idc
-idc
-lQQ
-lQQ
+xEM
+prU
+xEM
+aqs
+kTy
+kTy
 gfQ
-iOR
-btp
+gfQ
+gfQ
+sHc
+gfQ
 gfQ
 gfQ
 gfQ
@@ -93609,31 +93393,31 @@ gfQ
 gfQ
 gfQ
 gfQ
-tep
+xBZ
 ugo
 xBZ
-fYy
-fYy
-btp
 gfQ
-tep
-tep
-tep
-tep
-tep
-xIg
-ehJ
+gfQ
+gfQ
+gfQ
+khn
+khn
+khn
+khn
+khn
+kTy
+cAJ
 vGB
 cAJ
-idc
-idc
-idc
-lQQ
-lQQ
+kTy
+kTy
+kTy
 gfQ
-iOR
-btp
-btp
+gfQ
+gfQ
+sHc
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -93865,32 +93649,32 @@ gfQ
 gfQ
 gfQ
 gfQ
-mfS
-tep
+fsz
+xBZ
 hLU
 xBZ
-fYy
-fYy
-fYy
-fYy
-fYy
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 lDV
-tep
-khn
-khn
-khn
-khn
+iQl
+iQl
+kTy
+kTy
+kTy
 rsI
 kTy
 kTy
 kTy
-kTy
-kTy
+iQl
+iQl
 xmS
-mfS
-iOR
-mfS
-btp
+fsz
+sHc
+fsz
+gfQ
 gfQ
 gfQ
 gfQ
@@ -94119,35 +93903,35 @@ xsd
 fsz
 gfQ
 gfQ
-tep
-tep
-tep
-tep
-tep
+xBZ
+xBZ
+xBZ
+xBZ
+xBZ
 hLU
 xBZ
 xBZ
 xBZ
 xBZ
 xBZ
-fYy
-xBZ
-tep
-khn
+gfQ
+iQl
+iQl
+dCk
 mWA
 lYo
-rHL
+jey
 csT
 uol
 hbo
 vOM
-kTy
-kTy
-kTy
-wZk
-iOR
+dCk
+iQl
+iQl
 gfQ
-btp
+sHc
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -94376,9 +94160,9 @@ xsd
 fsz
 fsz
 gfQ
-tep
+xBZ
 mwm
-nyx
+iiy
 hTx
 thn
 wpL
@@ -94387,25 +94171,25 @@ cBq
 lqV
 fBo
 xBZ
-fYy
-xBZ
-khn
-khn
+gfQ
+iQl
+iQl
+dCk
 cZc
-pPx
+gud
 fDB
 vSd
-cof
+uei
 gud
 kEw
-kTy
-kTy
-kTy
-wZk
+dCk
+iQl
+iQl
+gfQ
 sHc
-btp
-btp
-btp
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -94633,7 +94417,7 @@ xsd
 gfQ
 gfQ
 gfQ
-tep
+xBZ
 iPM
 vuD
 rST
@@ -94644,24 +94428,24 @@ jEw
 sHx
 dNm
 xBZ
-fYy
-khn
-khn
-khn
-aMd
+gfQ
+iQl
+iQl
+dCk
+uZb
 cmf
 qMT
 iDZ
 bTm
 qav
 uZb
-kTy
-kTy
-kTy
-wZk
-iOR
+dCk
+iQl
+iQl
 gfQ
-btp
+sHc
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -94890,36 +94674,36 @@ xsd
 gfQ
 gfQ
 gfQ
-tep
+xBZ
 gQY
-nyx
-kqG
-kwP
+iiy
+rST
+oiJ
 iLO
 oiJ
 ctO
 nBq
 oXS
 xBZ
-fYy
-xBZ
-khn
-khn
-iAQ
+gfQ
+iQl
+iQl
+dCk
+ieH
 fAO
-hIS
+tMD
 wIT
 tMD
 ePz
-tbu
-kTy
-kTy
-kTy
-ncw
-iOR
-mfS
-btp
-btp
+ieH
+dCk
+iQl
+iQl
+fsz
+sHc
+fsz
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -95147,36 +94931,36 @@ xsd
 gfQ
 gfQ
 gfQ
-tep
+xBZ
 rCW
 iiy
-nAe
-oAC
+skG
+oiJ
 pWw
 oiJ
 ptI
 skG
 iwe
 xBZ
-fYy
-xBZ
-tep
-khn
+gfQ
+iQl
+iQl
+dCk
 dzX
 fAO
-khn
-khn
-kTy
+dCk
+dCk
+dCk
 ePz
 wTl
-kTy
-kTy
-kTy
-wZk
-iOR
+dCk
+iQl
+iQl
+gfQ
+sHc
 gfQ
 gfQ
-btp
+gfQ
 gfQ
 gfQ
 gfQ
@@ -95404,36 +95188,36 @@ xsd
 gfQ
 gfQ
 gfQ
-tep
-tep
-kwP
-kwP
-kwP
+iOP
+iOP
+umy
+umy
+umy
 jTv
-kwP
-oiJ
-oiJ
+umy
+umy
+umy
+iOP
 xBZ
-tep
 gfQ
-tep
-tep
-khn
-rHL
+iQl
+iQl
+dCk
+jey
 fAO
-khn
+dCk
 sgI
-kTy
+dCk
 ePz
-xEM
-kTy
-kTy
-kTy
-wZk
-iOR
+jey
+dCk
+iQl
+iQl
+gfQ
+sHc
 gfQ
 gfQ
-btp
+gfQ
 gfQ
 gfQ
 gfQ
@@ -95661,20 +95445,20 @@ xsd
 fsz
 gfQ
 gfQ
-tep
+iOP
 nff
 blp
 kKP
 rac
-pWw
+mRm
 aRr
 fnJ
 eCM
 sJn
-tep
+xBZ
 gfQ
-tep
-tep
+iQl
+iQl
 umz
 xmj
 eRC
@@ -95684,14 +95468,14 @@ guc
 mej
 wHl
 rUj
-kTy
-kTy
-uAh
-atY
-btp
-btp
-btp
-btp
+iQl
+iQl
+gfQ
+sHc
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -95918,7 +95702,7 @@ fLa
 fsz
 gfQ
 gfQ
-tep
+iOP
 nUJ
 cCs
 lEl
@@ -95929,11 +95713,11 @@ fpc
 mdS
 hlT
 xBZ
-fYy
-xBZ
-xBZ
-tep
-aCq
+gfQ
+iQl
+iQl
+dCk
+jey
 joO
 dCk
 vMk
@@ -95941,13 +95725,13 @@ dCk
 qpi
 jey
 dCk
-dCk
-dCk
-pBM
-atY
-rdi
+iQl
+iQl
+fsz
+sHc
+fsz
 gfQ
-btp
+gfQ
 gfQ
 gfQ
 gfQ
@@ -96175,7 +95959,7 @@ xsd
 fsz
 gfQ
 gfQ
-tep
+iOP
 jkW
 onb
 iKS
@@ -96186,10 +95970,10 @@ iKS
 dsI
 fkd
 xBZ
-fYy
-xBZ
-xBZ
-tep
+gfQ
+iQl
+iQl
+dCk
 dcy
 joO
 jey
@@ -96198,13 +95982,13 @@ jey
 qpi
 mko
 dCk
-dCk
-dCk
-fJG
-atY
-uAh
+iQl
+iQl
 gfQ
-btp
+sHc
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -96432,7 +96216,7 @@ fLa
 fsz
 gfQ
 gfQ
-xIg
+iOP
 mpM
 hHw
 iKS
@@ -96443,11 +96227,11 @@ iKS
 kPu
 gHt
 xBZ
-fYy
-fYy
-xBZ
-tep
-vcR
+gfQ
+gfQ
+iQl
+dCk
+ieH
 slB
 jey
 hNF
@@ -96455,13 +96239,13 @@ jey
 sDv
 ieH
 dCk
-dCk
-fJG
-fJG
-rdi
-uAh
+iQl
 gfQ
-btp
+gfQ
+fsz
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -96689,7 +96473,7 @@ fLa
 fsz
 fsz
 gfQ
-tep
+iOP
 fPI
 eiQ
 vdm
@@ -96700,26 +96484,26 @@ fbm
 vKQ
 den
 xBZ
-fYy
-fYy
-xBZ
-tep
+gfQ
+gfQ
 iQl
-bYS
+dCk
+dCk
+mjw
 bcT
 ccg
 veU
 mjw
 dCk
 dCk
-dCk
-fJG
-xsW
-uAh
-uAh
-btp
-btp
-btp
+iQl
+gfQ
+sHc
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -96946,7 +96730,7 @@ fsz
 fsz
 gfQ
 gfQ
-tep
+iOP
 jSp
 fmK
 lCc
@@ -96957,25 +96741,25 @@ arv
 dwV
 cSc
 xBZ
-fYy
-fYy
-fUR
-tep
-iQl
-iQl
-dCk
-dCk
-dCk
-dCk
-dCk
-dCk
-lvR
-fJG
-xsW
-rdi
-uAh
 gfQ
-btp
+gfQ
+fUR
+iQl
+iQl
+iQl
+iQl
+iQl
+iQl
+iQl
+iQl
+iQl
+lvR
+gfQ
+sHc
+fsz
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -97203,36 +96987,36 @@ fsz
 gfQ
 gfQ
 gfQ
-xIg
-xIg
-tep
+iOP
+iOP
+iOP
+iOP
+iOP
 iOP
 iOP
 iOP
 iOP
 iOP
 xBZ
-iOP
-iOP
-cLj
-cLj
-fYy
+gfQ
+gfQ
+gfQ
 gfQ
 iQl
 iQl
-dCk
-dCk
-dCk
-dCk
-dCk
-pBM
-pBM
-xsW
-xsW
-uAh
-uAh
+iQl
+iQl
+iQl
+iQl
+iQl
+mfS
+fsz
+sHc
+sHc
 gfQ
-btp
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -97460,36 +97244,36 @@ gfQ
 gfQ
 gfQ
 gfQ
-btp
-btp
-btp
-qzl
-cLj
-cLj
-cLj
-cLj
-qzl
-cLj
-cLj
-cLj
-cLj
-fYy
 gfQ
-rdi
-uAh
-fJG
-fJG
-fJG
-fJG
-pBM
-fJG
-fJG
-pBM
-fJG
-uAh
-uAh
 gfQ
-btp
+gfQ
+fsz
+gfQ
+gfQ
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -97716,38 +97500,38 @@ gfQ
 gfQ
 gfQ
 gfQ
-mfS
-iOR
+fsz
 sHc
-iOR
-wBO
-wBO
-wBO
-wBO
-wBO
-wBO
-wBO
-wBO
-qzl
-qzl
-nxB
-iOR
-atY
-atY
-xsW
-xsW
-xsW
-xsW
-xsW
-xsW
-xsW
-pBM
-fJG
-uAh
-uAh
-btp
-btp
-btp
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+fsz
+fsz
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -97975,35 +97759,35 @@ gfQ
 gfQ
 gfQ
 gfQ
-btp
 gfQ
-qzl
-cLj
-cLj
-cLj
-cLj
-qzl
-cLj
-cLj
-cLj
-cLj
-fYy
 gfQ
-rdi
-uAh
-fJG
-fJG
-fJG
-fJG
-pBM
-fJG
-fJG
-fJG
-fJG
-uAh
-uAh
+fsz
 gfQ
-btp
+gfQ
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -98232,35 +98016,35 @@ gfQ
 gfQ
 gfQ
 gfQ
-btp
-gfQ
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-fYy
 gfQ
 gfQ
-uAh
-fJG
-fJG
-fJG
-fJG
-fJG
-fJG
-fJG
-fJG
-fJG
-uAh
 gfQ
 gfQ
-btp
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -98488,35 +98272,35 @@ gfQ
 gfQ
 gfQ
 gfQ
-btp
-btp
-btp
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-fYy
 gfQ
 gfQ
-uAh
-fJG
-fJG
-fJG
-fJG
-fJG
-fJG
-fJG
-fJG
-fJG
-uAh
 gfQ
-btp
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -98746,35 +98530,35 @@ gfQ
 gfQ
 gfQ
 gfQ
-btp
-gfQ
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-fYy
 gfQ
 gfQ
 gfQ
-uAh
-uAh
-uAh
-uAh
-uAh
-uAh
-uAh
-uAh
-uAh
-btp
 gfQ
-btp
-btp
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -99003,34 +98787,34 @@ gfQ
 gfQ
 gfQ
 gfQ
-btp
-gfQ
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-cLj
-fYy
 gfQ
 gfQ
 gfQ
 gfQ
-uAh
-uAh
-uAh
-uAh
-uAh
-uAh
-uAh
 gfQ
-btp
-btp
-btp
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -99260,16 +99044,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-btp
-gfQ
-gfQ
-gfQ
-btp
-gfQ
-gfQ
-gfQ
-gfQ
-btp
 gfQ
 gfQ
 gfQ
@@ -99277,16 +99051,26 @@ gfQ
 gfQ
 gfQ
 gfQ
-btp
 gfQ
 gfQ
 gfQ
 gfQ
 gfQ
-btp
 gfQ
 gfQ
-btp
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -99517,33 +99301,33 @@ gfQ
 gfQ
 gfQ
 gfQ
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
 gfQ
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
-btp
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -99778,12 +99562,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-btp
-gfQ
-gfQ
-gfQ
-gfQ
-btp
 gfQ
 gfQ
 gfQ
@@ -99791,13 +99569,19 @@ gfQ
 gfQ
 gfQ
 gfQ
-btp
 gfQ
 gfQ
 gfQ
 gfQ
 gfQ
-btp
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -1183,7 +1183,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "ahP" = (
 /obj/structure/closet/athletic_mixed,
@@ -1559,6 +1559,13 @@
 	},
 /obj/item/radio/intercom{
 	pixel_y = -30
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -4266,16 +4273,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aEe" = (
@@ -4737,16 +4734,13 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/item/clothing/gloves/color/latex,
 /obj/structure/table/glass,
 /obj/item/clothing/mask/surgical,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aJa" = (
@@ -4788,12 +4782,6 @@
 /turf/open/floor/plating,
 /area/hydroponics)
 "aJq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/door/window/westleft{
 	base_state = "right";
 	dir = 1;
@@ -4801,6 +4789,12 @@
 	name = "Brig Infirmary"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aJt" = (
@@ -5035,6 +5029,12 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "aLU" = (
@@ -5278,6 +5278,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "aOk" = (
@@ -5287,6 +5296,13 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "aOm" = (
@@ -5406,13 +5422,13 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aPd" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aPm" = (
@@ -5420,15 +5436,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "aPn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/iv_drip,
 /obj/item/radio/intercom{
 	pixel_x = 29
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -5522,16 +5538,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aPU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /obj/item/folder/red,
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -5560,7 +5573,7 @@
 "aQi" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/bombcloset/security,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aQk" = (
 /obj/effect/turf_decal/tile/blue{
@@ -5809,6 +5822,10 @@
 	req_access_txt = "63";
 	specialfunctions = 4
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aRG" = (
@@ -5897,6 +5914,10 @@
 "aSD" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aSE" = (
@@ -6012,14 +6033,11 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "aTz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/bodycontainer/morgue,
 /obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aTD" = (
@@ -6029,13 +6047,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aTG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aTJ" = (
@@ -6246,14 +6264,11 @@
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "aUG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aUI" = (
@@ -6651,6 +6666,12 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aXN" = (
@@ -6696,6 +6717,12 @@
 "aYc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aYe" = (
@@ -6711,6 +6738,12 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aYp" = (
@@ -6755,6 +6788,12 @@
 "aYB" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6836,6 +6875,13 @@
 	},
 /obj/item/clothing/ears/earmuffs{
 	pixel_y = 7
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/range)
@@ -7029,7 +7075,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aZG" = (
 /obj/structure/chair/office,
@@ -7037,12 +7083,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
-"aZJ" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aZK" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/red,
@@ -7173,6 +7216,12 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "baA" = (
@@ -7238,7 +7287,10 @@
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "bbq" = (
 /obj/effect/turf_decal/bot,
@@ -7246,7 +7298,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "bbt" = (
 /obj/structure/cable,
@@ -7292,6 +7344,11 @@
 "bbP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Visitation";
+	name = "Perma Camera";
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -7343,17 +7400,17 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/table/glass,
 /obj/item/storage/box/bodybags,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /obj/item/reagent_containers/syringe{
 	name = "steel point"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -7361,13 +7418,13 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bcj" = (
@@ -7381,7 +7438,10 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/flashlight/seclite,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "bcv" = (
 /obj/machinery/seed_extractor,
@@ -7432,7 +7492,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "bcQ" = (
 /obj/effect/landmark/start/assistant,
@@ -7555,6 +7615,10 @@
 /area/science/nanite)
 "bdS" = (
 /obj/machinery/computer/crew,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "bdX" = (
@@ -7564,6 +7628,9 @@
 /obj/effect/turf_decal/tile/red,
 /obj/item/radio/intercom{
 	pixel_x = 29
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -8044,7 +8111,10 @@
 /area/storage/tech)
 "bht" = (
 /obj/machinery/computer/card/minor/hos,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "bhC" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -8092,7 +8162,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "bhL" = (
 /obj/machinery/door/airlock/engineering{
@@ -8233,6 +8303,12 @@
 /area/engine/engineering)
 "biP" = (
 /obj/structure/bed/dogbed/mcgriff,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "biS" = (
@@ -8600,14 +8676,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bku" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/bed,
 /obj/item/clothing/suit/straight_jacket,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bkA" = (
@@ -8716,7 +8792,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "blo" = (
 /turf/open/floor/plasteel/freezer,
@@ -8730,13 +8809,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "blq" = (
@@ -8758,6 +8830,16 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/security/courtroom)
+"blG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "blU" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -8921,6 +9003,10 @@
 "bqY" = (
 /obj/machinery/computer/security{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -9254,7 +9340,10 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "bvu" = (
 /obj/machinery/status_display/evac,
@@ -9277,6 +9366,12 @@
 /obj/machinery/camera{
 	c_tag = "Brig Prison Hallway North West";
 	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -9302,6 +9397,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -9361,7 +9460,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "bzt" = (
 /obj/machinery/door/airlock/maintenance{
@@ -9398,16 +9497,29 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "bAi" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
+"bAz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "bAE" = (
 /obj/structure/sign/directions/evac{
@@ -9849,7 +9961,7 @@
 /obj/machinery/microwave{
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "bSQ" = (
 /obj/structure/table/wood,
@@ -9877,6 +9989,12 @@
 /obj/machinery/camera{
 	c_tag = "Security Cells West";
 	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -10091,6 +10209,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "ccg" = (
@@ -10474,7 +10599,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "cmf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -10551,7 +10677,8 @@
 	pixel_y = 4
 	},
 /obj/item/inspector,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "cqB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -10689,6 +10816,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/bridge)
+"cuY" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "cvX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10904,13 +11035,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -11445,7 +11569,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cXi" = (
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "cXn" = (
 /obj/structure/disposalpipe/segment{
@@ -11695,6 +11822,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ddh" = (
@@ -11764,6 +11895,10 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dfj" = (
@@ -11803,6 +11938,15 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/bridge)
+"dfH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "dfS" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -12388,13 +12532,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "dxa" = (
@@ -12833,6 +12970,18 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"dEG" = (
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "dEU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue,
@@ -13165,7 +13314,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "dME" = (
 /obj/structure/disposalpipe/segment,
@@ -13856,7 +14005,10 @@
 "egL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "egQ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -13888,6 +14040,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -13941,13 +14099,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "ejv" = (
@@ -14034,6 +14185,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "enk" = (
@@ -14592,15 +14747,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "eCP" = (
@@ -14632,7 +14778,8 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/clothing/mask/gas/sechailer,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "eEE" = (
 /obj/structure/chair{
@@ -14667,12 +14814,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "eHF" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
 	},
-/obj/machinery/door/window/southleft,
-/obj/machinery/door/window/northright,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "eIX" = (
@@ -14778,10 +14928,6 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -14800,10 +14946,6 @@
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -14811,14 +14953,19 @@
 /area/ai_monitored/security/armory)
 "eLX" = (
 /obj/effect/turf_decal/bot,
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Sergent Armsky"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
+	},
+/mob/living/simple_animal/bot/secbot{
+	arrest_type = 1;
+	health = 45;
+	icon_state = "secbot1";
+	idcheck = 1;
+	name = "Sergeant-at-Armsky";
+	weaponscheck = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -15529,6 +15676,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ffN" = (
@@ -15865,13 +16015,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "fnb" = (
@@ -16165,16 +16308,6 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fvA" = (
@@ -16269,6 +16402,10 @@
 	pixel_y = -24
 	},
 /obj/machinery/light,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "fxU" = (
@@ -16552,6 +16689,12 @@
 /area/science/xenobiology)
 "fHW" = (
 /obj/machinery/light,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "fIb" = (
@@ -16786,15 +16929,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -17751,7 +17885,7 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "gqf" = (
 /obj/machinery/power/smes,
@@ -18110,7 +18244,7 @@
 /area/engine/atmos)
 "gyC" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "gzl" = (
 /obj/structure/table/reinforced,
@@ -18229,6 +18363,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"gDq" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "gDZ" = (
 /obj/structure/chair,
 /obj/item/radio/intercom{
@@ -18319,13 +18463,9 @@
 	req_access_txt = "3"
 	},
 /obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/spawner/lootdrop/armory_contraband/metastation,
 /obj/item/circuitboard/computer/advanced_camera,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -18479,6 +18619,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18866,7 +19010,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "gVQ" = (
 /obj/structure/cable,
@@ -19001,6 +19145,10 @@
 /obj/item/gun/energy/laser/practice{
 	pixel_x = 2;
 	pixel_y = -2
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/range)
@@ -19373,13 +19521,6 @@
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -19758,7 +19899,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "hyo" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -20585,10 +20727,6 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -20761,6 +20899,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ihj" = (
@@ -20912,6 +21054,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "imS" = (
@@ -21095,6 +21241,9 @@
 "isl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/range)
@@ -21391,6 +21540,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"iAD" = (
+/obj/structure/chair/plastic,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "iBp" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -21521,6 +21677,13 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "iJy" = (
@@ -21925,6 +22088,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "iWs" = (
@@ -21978,6 +22147,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"iYh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iYi" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "IsolationCell";
@@ -22112,7 +22297,10 @@
 /area/security/prison)
 "jbF" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "jbI" = (
 /obj/machinery/vending/cigarette,
@@ -22122,7 +22310,7 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/storage/secure/briefcase,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "jbR" = (
 /obj/effect/landmark/event_spawn,
@@ -22236,6 +22424,11 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"jeK" = (
+/obj/structure/grille/broken,
+/obj/effect/loot_site_spawner,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "jfV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -22272,9 +22465,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"jhu" = (
-/turf/closed/wall,
-/area/security/execution/transfer)
 "jhE" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -22292,11 +22482,6 @@
 "jhS" = (
 /obj/structure/sign/poster/official/obey{
 	pixel_x = 30
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Garden";
-	name = "Perma Camera";
-	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -22343,6 +22528,10 @@
 	c_tag = "Security Armory Exterior";
 	dir = 8;
 	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -22470,6 +22659,12 @@
 /obj/machinery/camera{
 	c_tag = "Security Cells East";
 	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -22985,7 +23180,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "jCj" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23044,6 +23239,10 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jFo" = (
@@ -23285,6 +23484,14 @@
 /obj/item/stack/license_plates/empty/fifty,
 /turf/open/floor/plating,
 /area/security/prison/safe)
+"jNn" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jNr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -23390,13 +23597,6 @@
 /area/hydroponics)
 "jSp" = (
 /obj/machinery/telecomms/server/presets/engineering,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -23551,7 +23751,10 @@
 "jVL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "jVV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -23682,12 +23885,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/engine/atmos)
 "kbg" = (
@@ -23787,12 +23984,6 @@
 "kfC" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -23950,6 +24141,12 @@
 "kji" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kjj" = (
@@ -24045,6 +24242,12 @@
 	name = "Firing Range Gear Crate";
 	req_access_txt = "1"
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "klu" = (
@@ -24078,6 +24281,13 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"kmC" = (
+/obj/structure/chair/plastic,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kmG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -24308,6 +24518,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"ksz" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ksS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -24399,12 +24619,6 @@
 "kwa" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -24512,6 +24726,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/orange,
 /area/vacant_room/office)
+"kyC" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "kyH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24746,6 +24967,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kGn" = (
@@ -25279,7 +25504,7 @@
 "kVM" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "kWh" = (
 /obj/machinery/light{
@@ -25547,6 +25772,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "lgW" = (
@@ -25681,7 +25907,10 @@
 /area/bridge)
 "lkK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "lkO" = (
 /obj/effect/turf_decal/stripes/line{
@@ -25733,6 +25962,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"llM" = (
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/machinery/door/window/southleft,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "lmk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
@@ -26476,10 +26714,17 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "lKO" = (
-/obj/machinery/camera{
-	c_tag = "Security Visitation";
-	dir = 1;
-	network = list("ss13","prison")
+/obj/machinery/button/door{
+	id = "visitation";
+	name = "Visitation Shutters";
+	pixel_x = 6;
+	pixel_y = -25;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/flasher{
+	id = "visitorflash";
+	pixel_x = -6;
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -26559,6 +26804,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"lME" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lMI" = (
 /obj/structure/chair{
 	dir = 8
@@ -26613,13 +26871,13 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "lND" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/structure/chair/office{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -26923,7 +27181,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "lWC" = (
 /obj/machinery/camera{
@@ -26996,7 +27257,7 @@
 	name = "Security Office";
 	req_one_access_txt = "1;4"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "lYY" = (
 /obj/structure/table,
@@ -27111,13 +27372,6 @@
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -27273,6 +27527,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"mhS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mhV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -27399,16 +27662,6 @@
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 9
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -27541,7 +27794,10 @@
 "mnZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "moj" = (
 /obj/effect/landmark/event_spawn,
@@ -27669,6 +27925,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/xenobiology)
+"mqQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "msF" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -28101,6 +28366,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"mFB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mGj" = (
 /obj/machinery/door/airlock/research{
 	name = "Closet";
@@ -28228,6 +28502,15 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/lawoffice)
+"mKc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "mKA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -28256,6 +28539,10 @@
 /area/quartermaster/office)
 "mLm" = (
 /obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -28406,9 +28693,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
 "mRd" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southleft,
-/obj/machinery/door/window/northright,
+/obj/structure/table,
+/obj/machinery/door/poddoor/shutters{
+	id = "visitation";
+	name = "Visitation Shutters"
+	},
+/obj/machinery/door/window/southright,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "mRi" = (
@@ -28501,6 +28791,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mTk" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "mTn" = (
 /obj/structure/window{
 	dir = 4
@@ -28674,6 +28971,13 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"mWM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "mWN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -28763,6 +29067,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"mZg" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "mZF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -28906,6 +29216,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ndN" = (
@@ -28950,15 +29264,6 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -29258,7 +29563,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "npX" = (
 /obj/structure/chair,
@@ -29289,7 +29597,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nqF" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/security/execution/education)
 "nqS" = (
 /obj/structure/disposalpipe/segment{
@@ -29486,6 +29794,12 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"nvx" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "nvW" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -29646,7 +29960,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "nCm" = (
 /obj/effect/turf_decal/stripes/box,
@@ -29665,13 +29982,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "nCq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "nCs" = (
@@ -30121,6 +30438,12 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig"
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nQQ" = (
@@ -30206,7 +30529,10 @@
 /area/engine/engineering)
 "nTC" = (
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "nTJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -30239,13 +30565,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "nUR" = (
@@ -30260,6 +30579,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30351,6 +30676,12 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nXA" = (
@@ -30381,7 +30712,7 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "nXT" = (
 /obj/machinery/camera{
@@ -30665,6 +30996,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"ofA" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Visitation Exterior";
+	dir = 4;
+	name = "Perma Camera";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ofC" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -30852,6 +31192,12 @@
 	c_tag = "Warden's Office";
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "olU" = (
@@ -30879,6 +31225,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30936,16 +31286,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "omL" = (
@@ -31206,6 +31546,15 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/hop)
+"owh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "owt" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot{
@@ -31383,6 +31732,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"oAl" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "oAn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
@@ -31648,7 +32008,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/hydroponics)
 "oHK" = (
-/obj/structure/chair,
+/obj/structure/chair/plastic,
+/obj/machinery/flasher{
+	id = "visitorflash";
+	pixel_x = -24
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "oHS" = (
@@ -31698,6 +32062,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"oJV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oKE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -31717,6 +32093,13 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics)
+"oLc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "oLk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -31945,7 +32328,10 @@
 "oSx" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "oSJ" = (
 /obj/structure/chair/office/light{
@@ -32139,7 +32525,7 @@
 /area/science/robotics/lab)
 "oZu" = (
 /obj/machinery/vending/security,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "oZS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -32913,7 +33299,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "pxc" = (
 /obj/structure/chair/stool,
@@ -33236,6 +33622,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/library)
+"pJt" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "pJH" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
@@ -33314,16 +33706,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "pLz" = (
@@ -34017,6 +34399,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"qik" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "qin" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -34464,6 +34853,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qwu" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "qwB" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
@@ -34537,6 +34936,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/bridge)
+"qAw" = (
+/obj/structure/chair/plastic,
+/obj/machinery/flasher{
+	id = "visitorflash";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "qAC" = (
 /obj/structure/chair/office,
 /turf/open/floor/plasteel,
@@ -34970,7 +35377,8 @@
 	pixel_x = 29;
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "qQc" = (
 /obj/effect/turf_decal/tile/blue{
@@ -35149,15 +35557,15 @@
 	},
 /area/crew_quarters/bar)
 "qWD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/bed,
 /obj/item/clothing/suit/straight_jacket,
 /obj/structure/window/reinforced,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "qXp" = (
@@ -35374,12 +35782,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -35468,16 +35870,6 @@
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -35660,6 +36052,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
+"riy" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "riG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Maintenance";
@@ -35729,7 +36127,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "rla" = (
 /obj/machinery/computer/mech_bay_power_console{
@@ -36032,6 +36430,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ruP" = (
@@ -36216,7 +36618,7 @@
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "rBt" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -36372,6 +36774,22 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/hydroponics)
+"rHh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "rHj" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/dark,
@@ -36898,6 +37316,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/prison)
+"rXc" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "rXk" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -36982,7 +37406,7 @@
 "rYZ" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/secequipment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "rZd" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -37193,7 +37617,7 @@
 "sfI" = (
 /obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "sfL" = (
 /obj/structure/cable/layer1,
@@ -37332,6 +37756,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "skp" = (
@@ -37768,16 +38196,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "swp" = (
@@ -37948,6 +38366,12 @@
 	name = "Security RC";
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sBH" = (
@@ -37959,6 +38383,7 @@
 /area/security/brig)
 "sBT" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "sCb" = (
@@ -38229,13 +38654,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "sJu" = (
@@ -38496,7 +38914,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "sQO" = (
 /obj/structure/closet/firecloset,
@@ -39124,7 +39545,7 @@
 "tia" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "tif" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -39185,7 +39606,7 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/assembly/flash/handheld,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "tjP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -39423,6 +39844,15 @@
 "tqr" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/item/clothing/under/rank/security/warden/grey,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "tqB" = (
@@ -39508,12 +39938,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/engine/atmos)
 "trF" = (
@@ -39592,6 +40016,10 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tuj" = (
@@ -40123,6 +40551,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
+"tHg" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "tIA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40237,17 +40672,17 @@
 /turf/open/floor/carpet/black,
 /area/maintenance/starboard/aft)
 "tLS" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/door/window/westleft{
 	base_state = "right";
 	dir = 2;
 	icon_state = "right";
 	name = "Brig Infirmary"
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -40402,7 +40837,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "tRr" = (
 /obj/structure/window/reinforced{
@@ -40641,6 +41076,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tZR" = (
@@ -40880,6 +41319,10 @@
 /area/crew_quarters/bar)
 "ugW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uhD" = (
@@ -41008,6 +41451,13 @@
 	},
 /area/maintenance/department/electrical)
 "ult" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "ulu" = (
@@ -41182,7 +41632,10 @@
 /area/crew_quarters/kitchen)
 "uoI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "upp" = (
 /obj/structure/table/reinforced,
@@ -41356,6 +41809,13 @@
 /obj/machinery/bluespace_beacon,
 /turf/open/floor/plasteel,
 /area/teleporter)
+"uux" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uuC" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
@@ -41388,13 +41848,19 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "uwj" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin/carbon,
 /obj/item/pen/fountain,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "uwy" = (
 /obj/machinery/atmospherics/pipe/simple/supply{
@@ -41988,7 +42454,7 @@
 "uMa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "uMd" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -42050,7 +42516,7 @@
 /area/science/test_area)
 "uOh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "uOm" = (
 /obj/structure/chair/office{
@@ -42094,16 +42560,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uOT" = (
@@ -42171,16 +42627,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uRk" = (
@@ -42191,6 +42637,12 @@
 "uRu" = (
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -42277,6 +42729,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uUx" = (
@@ -42411,6 +42870,10 @@
 "uWM" = (
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"uXR" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uXS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -42637,6 +43100,14 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vff" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vfG" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
@@ -42758,7 +43229,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "vkf" = (
 /obj/machinery/computer/operating{
@@ -42917,7 +43391,8 @@
 /area/maintenance/starboard)
 "vnK" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "vnX" = (
 /obj/structure/disposalpipe/segment{
@@ -42931,12 +43406,6 @@
 "vol" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -43551,6 +44020,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"vAK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vAS" = (
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
@@ -43619,6 +44104,12 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/science/test_area)
+"vDi" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "vDs" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/ansible,
@@ -43706,6 +44197,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vEG" = (
@@ -43872,6 +44369,10 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"vII" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "vJe" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -43974,15 +44475,6 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -44280,6 +44772,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"vUV" = (
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vUW" = (
 /turf/open/floor/carpet/red,
 /area/chapel/main)
@@ -44288,7 +44793,10 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "vVk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -44303,6 +44811,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -44384,6 +44898,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "vXD" = (
@@ -44445,6 +44962,13 @@
 	},
 /obj/machinery/recharger{
 	pixel_x = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -44619,7 +45143,10 @@
 "wfm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "wfT" = (
 /obj/effect/turf_decal/tile/blue{
@@ -44719,6 +45246,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/atmos)
+"wiO" = (
+/obj/structure/closet/secure_closet/brig{
+	name = "Prisoner Locker"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "wjr" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Custodial Maintenance";
@@ -45063,6 +45603,13 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wrE" = (
@@ -45273,6 +45820,11 @@
 /area/crew_quarters/kitchen)
 "wyY" = (
 /obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Security Visitation";
+	dir = 1;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "wzD" = (
@@ -45577,7 +46129,10 @@
 	dir = 1;
 	network = list("ss13","prison")
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "wHS" = (
 /obj/machinery/conveyor{
@@ -46144,6 +46699,10 @@
 "wWd" = (
 /obj/effect/landmark/start/warden,
 /obj/structure/chair/office,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "wWn" = (
@@ -47410,6 +47969,25 @@
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
+"xDa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "xDh" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/closet/crate/coffin,
@@ -47716,7 +48294,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "xLM" = (
 /obj/machinery/door/airlock/external{
@@ -48064,7 +48642,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/machinery/light,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "xYa" = (
 /obj/machinery/flasher/portable,
@@ -48195,14 +48773,8 @@
 	pixel_x = 4;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "ybc" = (
 /obj/machinery/rnd/bepis,
@@ -48622,6 +49194,25 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/cmo)
+"yjp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "yjw" = (
 /obj/machinery/button/door{
 	id = "camdola_containment";
@@ -61162,11 +61753,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-jhu
+ihX
 ioL
 eqD
 jes
-jhu
+ihX
 jes
 eqD
 ioL
@@ -61419,11 +62010,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-jhu
+ihX
 agA
 nhD
 miZ
-jhu
+ihX
 sKJ
 fXO
 mWf
@@ -61676,7 +62267,7 @@ yin
 oFo
 oFo
 oFo
-jhu
+ihX
 qpl
 hdJ
 mLq
@@ -61933,7 +62524,7 @@ yin
 mYo
 iKe
 dWM
-jhu
+ihX
 qlb
 mPW
 vvX
@@ -62190,7 +62781,7 @@ yin
 qRb
 fnb
 kTf
-jhu
+ihX
 wwo
 ftA
 gQk
@@ -62447,7 +63038,7 @@ yin
 wGq
 irD
 wgJ
-jhu
+ihX
 way
 sdf
 bQE
@@ -62704,8 +63295,8 @@ yin
 fhr
 ngN
 ngN
-jhu
-jhu
+ihX
+ihX
 ihX
 wFG
 ihX
@@ -62964,14 +63555,14 @@ wAs
 lYY
 woq
 nqF
-asr
-bez
-bez
+yjp
+bfv
+bfv
 ehE
-bez
+ksz
 hFs
 aOi
-ult
+owh
 ccc
 hFs
 aYO
@@ -63222,7 +63813,7 @@ klu
 klu
 vyj
 uUm
-ymh
+mFB
 ymh
 iof
 kGh
@@ -63482,12 +64073,12 @@ nqF
 nXh
 bez
 ick
-bez
+fDa
 hFs
 aOk
 hao
 mLm
-ult
+tHg
 ult
 xrN
 sOt
@@ -63993,10 +64584,10 @@ yin
 tlF
 lFh
 nqF
-uRu
-bez
-ick
-bez
+wiO
+iMd
+lME
+fDa
 aIO
 aPU
 aUG
@@ -64242,7 +64833,7 @@ xlD
 xlD
 wUf
 xlD
-xlD
+ofA
 xlD
 yin
 yin
@@ -64253,7 +64844,7 @@ xke
 xke
 xke
 nUR
-bez
+fDa
 bcd
 lND
 aPd
@@ -64761,13 +65352,13 @@ yin
 yin
 bbP
 aJk
-oHK
+kmC
 eHF
 hmb
 ciu
 sBH
-ick
-bez
+iYh
+fDa
 bcf
 bku
 aPn
@@ -65018,13 +65609,13 @@ tHd
 yin
 sSG
 aye
-oHK
-eHF
+iAD
+dEG
 hmb
 wyY
 xke
-ick
-fHW
+iYh
+vff
 xIr
 xIr
 xIr
@@ -65275,24 +65866,24 @@ vHY
 yin
 jhS
 aye
-oHK
-eHF
+qAw
+llM
 hmb
 ciu
 xke
 azA
-bez
+fDa
 bcZ
 aQi
 gpV
-uwe
-cXi
+riy
+aXs
 rkY
 aZD
-uwe
+uux
 cXi
 tRl
-cXi
+uXR
 uwe
 bSK
 xIr
@@ -65540,13 +66131,13 @@ xke
 oHf
 rtK
 kiu
-cXi
-cXi
-cXi
-cXi
-cXi
+aXs
+aXs
+aXs
+aXs
+aXs
 bcN
-cXi
+uXR
 bht
 dMx
 qPY
@@ -65795,19 +66386,19 @@ aFk
 gQW
 eDb
 azD
-bez
+fDa
 bcZ
 tia
-cXi
+cuY
 jVL
 wfm
 vkd
-bcN
-cXi
+oLc
+vDi
 uwj
 pwV
 vnK
-cXi
+rXc
 wHJ
 xIr
 nuO
@@ -66052,18 +66643,18 @@ mpE
 aym
 bTh
 qLe
-bez
+fDa
 bcZ
 tia
-cXi
+uXR
 yaY
 nXR
 sPG
 hym
-uoI
+mWM
 uoI
 xLx
-nTC
+kyC
 nTC
 oSx
 xIr
@@ -66309,11 +66900,11 @@ aFk
 avN
 eDb
 pex
-bez
+fDa
 bcZ
 tia
-cXi
-vnK
+uXR
+vII
 uMa
 cXi
 aZG
@@ -66569,7 +67160,7 @@ azF
 jFn
 xIr
 jCe
-cXi
+uXR
 kVM
 uMa
 cXi
@@ -66823,18 +67414,18 @@ gfQ
 gfQ
 xke
 azJ
-bez
+fDa
 bcZ
 tia
-cXi
+mZg
 egL
 mnZ
 lkK
 cme
-nCk
+oAl
 nCk
 lWv
-buV
+qwu
 buV
 cXi
 rhI
@@ -67080,20 +67671,20 @@ gfQ
 gfQ
 xke
 azM
-bez
+fDa
 bcZ
 tia
-cXi
-cXi
-cXi
-cXi
+aXs
+aXs
+aXs
+aXs
 bll
 jbF
 npS
-tRl
-cXi
-cXi
-cXi
+rHh
+pJt
+pJt
+nvx
 dmp
 nuO
 obY
@@ -67340,9 +67931,9 @@ lsr
 tZP
 bcZ
 gyC
-cXi
+aXs
 oZu
-cXi
+aXs
 sfI
 rYZ
 bbq
@@ -67851,20 +68442,20 @@ avV
 veT
 gny
 pex
-bez
-bez
-bez
-bez
-bez
-bez
-bez
-bez
-bez
-tPP
-sHE
-bez
-bez
 cXp
+bfv
+bfv
+bfv
+bfv
+bfv
+bfv
+bfv
+bfv
+oJV
+xDa
+bfv
+bfv
+bfv
 bfv
 bfv
 bfv
@@ -68129,11 +68720,11 @@ asr
 bez
 bez
 bez
-tPP
+mhS
 nQs
-bez
-bez
-bez
+bfv
+bfv
+bfv
 fHW
 xke
 waV
@@ -68366,13 +68957,13 @@ xke
 xke
 lgV
 imN
-ymh
-ymh
+blG
+blG
 gLx
-ymh
-ymh
+blG
+mFB
 aYR
-ndz
+jNn
 deM
 ihf
 olZ
@@ -68629,7 +69220,7 @@ vQo
 vQo
 kji
 sHE
-aZJ
+kcR
 jdC
 gbh
 gbh
@@ -68884,16 +69475,16 @@ ocz
 aMA
 ciu
 bbR
-bez
+mqQ
 sHE
 kcR
 gbh
 tqr
 olN
-uIx
+dfH
 iVV
-uIx
-uIx
+dfH
+dfH
 akz
 jdC
 xke
@@ -69398,16 +69989,16 @@ igv
 aRc
 ciu
 vQo
-bez
+mqQ
 sHE
 oJO
 mkQ
-sBT
+gDq
 sBT
 aRE
 bdS
 wWd
-uIx
+mTk
 bqY
 jdC
 bea
@@ -69655,11 +70246,11 @@ xvP
 xvP
 xvP
 xvP
-bez
+mqQ
 sHE
 kcR
 gbh
-uIx
+mKc
 aSD
 jdC
 bRx
@@ -69912,12 +70503,12 @@ eYe
 aRK
 pnf
 gZr
-bez
+mqQ
 cUY
 aZK
 gbh
-uIx
-uIx
+mKc
+qik
 bRx
 cwE
 axU
@@ -70414,11 +71005,11 @@ xvi
 xvi
 xvi
 xvi
-xyp
-xyp
-xyp
-xyp
-xyp
+aAb
+aAb
+aAb
+aAb
+aAb
 cly
 kbG
 mKN
@@ -70426,7 +71017,7 @@ bSQ
 nGv
 vwg
 gZr
-bez
+mqQ
 sHE
 kcR
 jdC
@@ -70675,7 +71266,7 @@ awm
 rIH
 rIH
 uJa
-adu
+jeK
 cly
 lie
 gGM
@@ -70933,13 +71524,13 @@ uJa
 xyp
 xyp
 xyp
-uJa
-aAb
-xke
-xke
-xke
-xke
-xke
+cly
+cly
+cly
+cly
+cly
+cly
+cly
 aXM
 sHE
 kcR
@@ -71197,7 +71788,7 @@ kIP
 aSR
 kIP
 xke
-bez
+mqQ
 bbI
 nqn
 pGp
@@ -72482,8 +73073,8 @@ uJa
 uJa
 foq
 xke
-aYB
-xPV
+vUV
+bAz
 mnh
 ecm
 bkL
@@ -72740,7 +73331,7 @@ uJa
 aUV
 xke
 xke
-asr
+vAK
 aZM
 xke
 pWR

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -8309,6 +8309,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/mob/living/simple_animal/pet/dog/pug/mcgriff,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "biS" = (
@@ -12325,6 +12326,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"dse" = (
+/obj/item/storage/secure/safe{
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "dsw" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /obj/structure/lattice/catwalk,
@@ -13404,6 +13411,9 @@
 	c_tag = "Arrivals Middle - West";
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -14290,6 +14300,9 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Middle East";
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
@@ -18469,6 +18482,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/armory_contraband/metastation,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "gGM" = (
@@ -36056,6 +36070,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -29
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "riG" = (
@@ -39214,6 +39231,9 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -29
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "sXv" = (
@@ -39632,7 +39652,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "tke" = (
 /obj/machinery/requests_console{
@@ -43278,6 +43298,7 @@
 /area/medical/medbay/central)
 "vla" = (
 /obj/structure/bed/dogbed/lia,
+/mob/living/simple_animal/hostile/carp/cayenne/lia,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "vlz" = (
@@ -66401,7 +66422,7 @@ vnK
 rXc
 wHJ
 xIr
-nuO
+dse
 sXu
 nuO
 nuO

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -29,18 +29,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aan" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "aao" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -57,37 +45,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/airless,
 /area/space/nearstation)
-"aaz" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 8;
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/item/paper_bin,
-/obj/item/folder/red,
-/turf/open/floor/plating,
-/area/security/brig)
-"aaB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	dir = 8;
-	name = "Brig Desk";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/machinery/recharger{
-	pixel_x = 8
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "aaG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -198,73 +155,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"abg" = (
-/obj/structure/closet/crate,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/glass/beaker,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_official,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/plating,
-/area/security/prison)
-"abi" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/obey{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"abj" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_x = 12
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Visiting Room";
-	name = "Perma Camera";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"abn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"abr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = -29
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"abs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "abw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden,
@@ -625,23 +515,6 @@
 /obj/structure/flora/grass/green,
 /turf/open/floor/grass,
 /area/quartermaster/qm)
-"acR" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/warden";
-	dir = 8;
-	name = "Brig Control APC";
-	pixel_x = -25
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_x = -20;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "acU" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -649,13 +522,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/red,
 /area/chapel/main)
-"acZ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ade" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod A";
@@ -818,32 +684,6 @@
 /obj/structure/table_frame,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"aed" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aee" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aeg" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1074,13 +914,6 @@
 	dir = 8
 	},
 /area/hallway/secondary/entry)
-"afk" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/security/execution)
 "afo" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -1133,17 +966,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/airless,
 /area/space/nearstation)
-"afE" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Perma Brig Processing";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "afF" = (
 /obj/effect/decal/cleanable/robot_debris/old,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1290,6 +1112,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"agA" = (
+/obj/structure/table,
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/item/storage/box/prisoner,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "agI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -1382,24 +1212,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"ahL" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"ahN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
 /area/security/prison)
 "ahP" = (
 /obj/structure/closet/athletic_mixed,
@@ -1530,12 +1342,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"ajc" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/prisoner,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "aje" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -1589,15 +1395,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"ajw" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/plasteel/grimy,
 /area/security/prison)
 "ajA" = (
@@ -1785,13 +1582,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "akz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/computer/prisoner/management{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "akD" = (
 /obj/machinery/light{
 	dir = 1
@@ -1855,10 +1650,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ale" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/lawoffice)
 "alf" = (
@@ -1928,18 +1723,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"alF" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "alG" = (
 /obj/machinery/camera{
 	c_tag = "Permabrig Cellblock A - North";
@@ -1967,27 +1750,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"alK" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "alL" = (
 /turf/open/space,
 /area/space)
 "alM" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
 	req_access_txt = "10; 13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
@@ -2046,15 +1818,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"alX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "alY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -2064,18 +1827,6 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"amc" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Cell 3"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
 /area/security/prison)
 "amd" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -2114,17 +1865,6 @@
 /obj/structure/table,
 /obj/item/paper_bin/bundlenatural,
 /obj/item/pen,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aml" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/item/radio/intercom{
-	pixel_x = -29
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "amm" = (
@@ -2235,18 +1975,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
 /area/security/prison)
-"amD" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Cell 4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "amH" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -2279,27 +2007,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"amN" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"amO" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/grimy,
 /area/security/prison)
 "amP" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -2349,12 +2056,6 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/science/server)
-"amW" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "amZ" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway - Sec Checkpoint";
@@ -2420,16 +2121,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ant" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "anu" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
@@ -2581,15 +2272,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
-"aop" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "aow" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
@@ -2611,15 +2293,6 @@
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"aoG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "aoH" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
@@ -2768,18 +2441,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"apB" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Cell 2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "apC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2790,12 +2451,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
-"apE" = (
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "apG" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -2883,18 +2538,6 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/sepia,
 /area/chapel/office)
-"aqX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"ard" = (
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/turf/open/floor/plating,
-/area/security/prison)
 "ark" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
@@ -2921,10 +2564,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aro" = (
-/obj/machinery/gulag_teleporter,
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
 "arp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
@@ -3135,6 +2774,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"asr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ass" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3157,19 +2806,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"asA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "asD" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3190,12 +2826,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "asJ" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	name = "Firing Range";
+	req_one_access_txt = "1;4"
 	},
-/turf/open/floor/plating,
-/area/security/execution)
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "asK" = (
 /obj/machinery/camera{
 	c_tag = "Permabrig Recreation Wing";
@@ -3402,12 +3038,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"atR" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Storage"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "atS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel/sepia,
@@ -3457,21 +3087,15 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "auk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/item/storage/box/trackimp{
+	pixel_x = -3
 	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
+/obj/item/storage/lockbox/loyalty,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aul" = (
 /obj/effect/turf_decal/stripes/line,
@@ -3614,38 +3238,16 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/chapel/main)
-"avt" = (
-/obj/machinery/computer/card/minor/hos{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hos";
-	dir = 8;
-	name = "Head of Security's Office APC";
-	pixel_x = -25
-	},
-/obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_x = -20;
-	pixel_y = 11
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
 "avw" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Head of Security";
-	req_access_txt = "58"
+/obj/machinery/door/airlock/external{
+	name = "Security External Airlock";
+	req_access_txt = "1"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/hos)
+/turf/open/floor/plating,
+/area/security/brig)
 "avx" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -3680,64 +3282,38 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"avJ" = (
-/obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+"avN" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	pixel_x = 26;
+	req_access_txt = "2"
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"avK" = (
-/obj/item/paint/anycolor,
-/turf/open/floor/plating,
-/area/security/prison)
-"avN" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"avO" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8;
-	pixel_x = 12
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"avP" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/area/security/brig)
 "avT" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/fans/tiny/invisible,
+/turf/open/space/basic,
+/area/space)
 "avV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/fans/tiny/invisible,
+/turf/open/space/basic,
+/area/space)
 "avX" = (
 /obj/docking_port/stationary/random{
 	dir = 8;
@@ -3987,14 +3563,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"axF" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_official,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/plating,
-/area/security/prison)
 "axO" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -4048,29 +3616,21 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aym" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"ayn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"ayo" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Permabrig Prisoner Processing";
-	dir = 1;
-	name = "Perma Camera";
-	network = list("ss13","prison")
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
+"ayo" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/security/brig)
 "ayq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -4142,19 +3702,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ayH" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Perma Brig Processing";
-	req_access_txt = "2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ayK" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/light/small{
@@ -4206,71 +3753,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"azr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/rack,
-/obj/item/tank/internals/oxygen/red{
-	pixel_x = 3
-	},
-/obj/item/tank/internals/anesthetic{
-	pixel_x = -3;
-	pixel_y = 1
-	},
-/obj/machinery/button/door{
-	id = "executionfireblast";
-	name = "Transfer Area Lockdown";
-	pixel_x = -25;
-	pixel_y = -5;
-	req_access_txt = "2"
-	},
-/obj/machinery/button/flasher{
-	id = "executionflash";
-	pixel_x = -24;
-	pixel_y = 5
-	},
-/obj/machinery/button/door{
-	id = "executionspaceblast";
-	name = "Vent to Space";
-	pixel_x = 5;
-	pixel_y = 25;
-	req_access_txt = "7"
-	},
-/obj/machinery/button/ignition{
-	id = "executionburn";
-	pixel_x = -5;
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
-"azs" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/electropack,
-/obj/item/assembly/signaler,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
-"azu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "azA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -4278,11 +3760,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/folder/red,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "azD" = (
 /obj/machinery/light{
 	dir = 1
@@ -4293,11 +3773,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/folder/red,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "azF" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -4309,14 +3787,14 @@
 	c_tag = "Brig Prison Hallway North";
 	network = list("ss13","prison")
 	},
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	name = "Security RC";
-	pixel_y = 30
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "azJ" = (
 /obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 30
@@ -4327,8 +3805,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "azM" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -4336,28 +3815,15 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	name = "Security RC";
+	pixel_y = 30
+	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"azN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "azS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/caution/white{
@@ -4369,19 +3835,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"azX" = (
-/obj/machinery/door/airlock/security{
-	name = "Interrogation";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "azZ" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -4707,12 +4160,6 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/chapel/main)
-"aCw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "aCz" = (
 /obj/item/clothing/under/rank/prisoner,
 /obj/item/clothing/under/rank/prisoner,
@@ -4727,11 +4174,14 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aCA" = (
-/obj/item/radio/intercom{
-	pixel_x = -29
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aCC" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -4784,34 +4234,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aDn" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"aDt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "aDx" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"aDz" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "aDA" = (
 /obj/structure/noticeboard{
 	dir = 1;
@@ -4828,24 +4254,10 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aDI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aDL" = (
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
 /area/library)
-"aDN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aDT" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -4858,23 +4270,6 @@
 /obj/item/paper_bin,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"aDU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "hosspace";
-	name = "space shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
-"aDV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aDZ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -4923,10 +4318,6 @@
 "aEw" = (
 /turf/closed/wall,
 /area/ai_monitored/storage/eva)
-"aEz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "aED" = (
 /obj/structure/displaycase/trophy{
 	pixel_y = 5
@@ -4978,13 +4369,13 @@
 	},
 /area/maintenance/central)
 "aFk" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
 	},
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "aFm" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault{
@@ -4999,13 +4390,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
-"aFo" = (
-/obj/machinery/flasher/portable,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "aFv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5040,15 +4424,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aFY" = (
-/obj/machinery/door/airlock{
-	name = "Law Office";
-	req_access_txt = "38"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/door/airlock{
+	name = "Law Office";
+	req_access_txt = "38"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
@@ -5206,12 +4590,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"aHs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "aHt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -5286,16 +4664,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/primary)
-"aHY" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"aHZ" = (
-/obj/structure/bed,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "aIa" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -5353,14 +4721,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
-"aIA" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/security/sec,
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "aIB" = (
 /obj/machinery/vending/games,
 /turf/open/floor/plasteel,
@@ -5374,11 +4734,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aIM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	name = "Firing Range";
+	req_one_access_txt = "1;4"
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/security/execution)
+/area/security/range)
 "aIN" = (
 /obj/structure/closet,
 /obj/item/clothing/under/misc/burial,
@@ -5392,9 +4755,21 @@
 /turf/open/floor/plasteel/sepia,
 /area/chapel/main)
 "aIO" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/item/clothing/gloves/color/latex,
+/obj/structure/table/glass,
+/obj/item/clothing/mask/surgical,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "aJa" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/glass,
@@ -5414,15 +4789,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/hydroponics)
-"aJj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aJk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -5442,68 +4808,31 @@
 /obj/item/pen,
 /turf/open/floor/plating,
 /area/hydroponics)
-"aJo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/sparker{
-	id = "executionburn";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "aJq" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 1;
+	icon_state = "right";
+	name = "Brig Infirmary"
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "aJt" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
-"aJw" = (
-/obj/machinery/door/airlock/security{
-	aiControlDisabled = 1;
-	name = "Execution Chamber";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aJy" = (
 /obj/machinery/shower{
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"aJB" = (
-/obj/machinery/door/window/westright{
-	name = "Transfer Room";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "executionfireblast"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/execution)
 "aJF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5553,13 +4882,6 @@
 /obj/effect/landmark/start/chaplain,
 /turf/open/floor/carpet/red,
 /area/chapel/main)
-"aKa" = (
-/obj/machinery/door/airlock/security{
-	name = "Solitary Confinement";
-	req_access_txt = "63; 42"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aKb" = (
 /obj/machinery/light{
 	dir = 8
@@ -5585,14 +4907,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/hydroponics)
-"aKn" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "aKp" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -5606,6 +4920,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/hydroponics)
 "aKq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -5618,7 +4933,6 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aKu" = (
@@ -5769,44 +5083,16 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/dorms)
-"aLP" = (
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"aLR" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "aLT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
-/area/security/execution)
+/area/security/range)
 "aLU" = (
 /obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/fore)
-"aMl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aMn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6026,36 +5312,31 @@
 /turf/closed/wall,
 /area/medical/pharmacy)
 "aOh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
-"aOi" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/flasher{
-	dir = 1;
-	id = "executionflash";
-	pixel_y = -25
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
-"aOk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "executionfireblast"
-	},
-/turf/open/floor/plating,
-/area/security/execution)
-"aOm" = (
-/turf/open/floor/plasteel/white,
-/area/security/prison)
-"aOn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
+"aOi" = (
+/obj/machinery/airalarm{
+	pixel_y = 28
+	},
 /turf/open/floor/plasteel/dark,
+/area/security/range)
+"aOk" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/range)
+"aOm" = (
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "aOo" = (
 /obj/structure/disposalpipe/segment,
@@ -6171,23 +5452,32 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "aPd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "aPm" = (
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "aPn" = (
-/turf/closed/wall/r_wall,
-/area/security/execution)
-"aPs" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "aPu" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -6218,13 +5508,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/medical/medbay/lobby)
-"aPE" = (
-/obj/structure/table,
-/obj/item/canvas/twentythree_twentythree,
-/obj/item/canvas/twentythree_twentythree,
-/obj/item/storage/crayons,
-/turf/open/floor/plating,
-/area/security/prison)
 "aPF" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced{
@@ -6285,11 +5568,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aPU" = (
-/obj/structure/chair{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/folder/red,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "aQa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6311,34 +5600,11 @@
 /obj/item/storage/fancy/rollingpapers,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"aQh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/execution";
-	name = "Prisoner Transfer Centre";
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "aQi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/bombcloset/security,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/main)
 "aQk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -6361,12 +5627,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"aQo" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/prison)
 "aQr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -6407,13 +5667,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
-"aQz" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "aQA" = (
 /obj/structure/sign/departments/botany,
 /turf/closed/wall,
@@ -6575,18 +5828,34 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aRE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	desc = "Controls the shutters over the brig windows.";
+	id = "briglockdown";
+	name = "Brig Lockdown Control";
+	pixel_x = 6;
+	pixel_y = 7;
+	req_access = null;
+	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/machinery/button/door{
+	desc = "Controls the blast doors in front of the prison wing.";
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	pixel_y = -3;
+	req_access_txt = "2"
 	},
-/obj/item/radio/intercom{
-	pixel_y = -30
+/obj/machinery/button/door{
+	desc = "Controls the shutters over the cell windows.";
+	id = "Secure Gate";
+	name = "Cell Window Control";
+	pixel_x = -6;
+	pixel_y = 7;
+	req_access_txt = "63";
+	specialfunctions = 4
 	},
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "aRG" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -6617,7 +5886,7 @@
 	network = list("interrogation")
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/prison)
+/area/security/brig)
 "aRW" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -6628,9 +5897,6 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"aSc" = (
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
 "aSi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -6719,15 +5985,6 @@
 /obj/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aTd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "rabbitcontainment";
-	name = "privacy shutter"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "aTf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -6755,37 +6012,11 @@
 /obj/item/bikehorn/golden,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aTo" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/execution)
 "aTp" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aTt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Security Locker Room";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "aTu" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -6817,53 +6048,31 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "aTz" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = -8
-	},
-/turf/open/floor/plating,
-/area/security/execution)
-"aTD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"aTE" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/processing)
-"aTG" = (
-/obj/machinery/door/window/southleft{
-	base_state = "right";
-	dir = 1;
-	icon_state = "right";
-	name = "Execution Gas";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	layer = 2.4
-	},
-/turf/open/floor/plating,
-/area/security/execution)
-"aTI" = (
-/obj/machinery/computer/security/telescreen/interrogation{
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/bodycontainer/morgue,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
+"aTD" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"aTG" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "aTJ" = (
 /obj/structure/closet,
@@ -7064,14 +6273,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/pharmacy)
-"aUD" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/item/flashlight/lamp,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "aUE" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -7081,31 +6282,29 @@
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "aUG" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/folder/red{
-	pixel_x = 3
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/item/storage/box/bodybags,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
-"aUH" = (
-/obj/structure/rack,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop,
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "aUI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aUJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aUK" = (
@@ -7294,15 +6493,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/atmos)
-"aVZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aWe" = (
 /obj/structure/sink{
 	dir = 8;
@@ -7343,25 +6533,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"aWo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aWp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/security/glass{
 	name = "Evidence Storage";
 	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aWq" = (
@@ -7513,13 +6691,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aXs" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plating,
-/area/security/execution)
-"aXt" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel/dark,
 /area/security/main)
 "aXA" = (
 /obj/machinery/door/airlock/atmos{
@@ -7530,16 +6702,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/atmos)
-"aXE" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/brig";
-	dir = 1;
-	name = "Brig APC";
-	pixel_y = 23
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aXG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -7736,49 +6898,43 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aYO" = (
-/obj/machinery/computer/security/labor,
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
-"aYP" = (
-/obj/structure/table,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/item/paper_bin,
-/obj/item/folder/red,
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
-"aYQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/security/execution)
+/area/security/range)
+"aYP" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_y = 7
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/security/range)
+"aYQ" = (
+/obj/machinery/camera{
+	c_tag = "Security - EVA Storage";
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "aYR" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aYS" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aYT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aYU" = (
@@ -7946,54 +7102,20 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"aZz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"aZB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"aZC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "aZD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/prison)
-"aZE" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/bombcloset/security,
-/turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "aZG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"aZH" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"aZI" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig Locker Room";
-	req_access_txt = "63; 42"
+/obj/structure/chair/office,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel,
 /area/security/main)
 "aZJ" = (
 /obj/effect/turf_decal/tile/red,
@@ -8007,24 +7129,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aZL" = (
-/obj/machinery/door_timer{
-	id = "Cell 2";
-	name = "Cell 2";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aZM" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	name = "Cell 2";
+	pixel_y = -32
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aZN" = (
@@ -8155,25 +7269,10 @@
 "baC" = (
 /turf/open/floor/vault,
 /area/security/nuke_storage)
-"baD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "baE" = (
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"baJ" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/closet/secure_closet/hos,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "baK" = (
 /obj/structure/cable,
 /turf/open/floor/plating{
@@ -8194,11 +7293,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
-"baO" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/l3closet/security,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "bbc" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white/side{
@@ -8222,10 +7316,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bbj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/plasteel,
 /area/security/main)
 "bbt" = (
 /obj/structure/cable,
@@ -8245,16 +7339,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
-"bbA" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "bbB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -8265,48 +7349,16 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"bbC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"bbF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
+"bbI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bbH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"bbI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -8314,27 +7366,7 @@
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/dark,
-/area/security/prison)
-"bbN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"bbO" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig Locker Room";
-	req_access_txt = "63; 42"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
+/area/security/brig)
 "bbP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -8388,41 +7420,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"bca" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bcb" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/item/clothing/gloves/color/latex,
-/obj/structure/table/glass,
-/obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "bcd" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8441,23 +7438,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"bce" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 1;
-	icon_state = "right";
-	name = "Brig Infirmary"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "bcf" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -8471,24 +7451,6 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"bcg" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 1";
-	name = "Cell 1"
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"bch" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bcj" = (
 /obj/structure/window{
 	dir = 4
@@ -8496,16 +7458,11 @@
 /obj/structure/flora/grass/green,
 /turf/open/floor/grass,
 /area/chapel/main)
-"bcr" = (
-/turf/open/floor/plating,
-/area/security/processing)
 "bcs" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/table/reinforced,
+/obj/item/folder/red,
+/obj/item/flashlight/seclite,
+/turf/open/floor/plasteel,
 /area/security/main)
 "bcv" = (
 /obj/machinery/seed_extractor,
@@ -8515,6 +7472,22 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"bcA" = (
+/obj/structure/rack,
+/obj/item/gun/energy/disabler{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "bcB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -8536,31 +7509,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "bcN" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel,
 /area/security/main)
 "bcQ" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"bcR" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/processing";
-	dir = 8;
-	name = "Labor Shuttle Dock APC";
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bcT" = (
 /obj/structure/cable,
 /obj/machinery/camera{
@@ -8678,15 +7635,6 @@
 /obj/machinery/computer/crew,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"bdW" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bdX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -8694,9 +7642,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/item/radio/intercom{
 	pixel_x = 29
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -8773,10 +7718,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bex" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "bez" = (
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -8841,15 +7782,6 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psychology)
-"beS" = (
-/obj/machinery/computer/shuttle/labor{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
 "beV" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -8865,13 +7797,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"beY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/processing)
 "beZ" = (
 /obj/machinery/door/window/eastright{
 	name = "Kitchen Delivery";
@@ -8901,120 +7826,12 @@
 "bff" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/central)
-"bfh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"bfi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "bfj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Labor Shuttle Dock";
-	dir = 1;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/machinery/computer/card/minor/hos{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"bfk" = (
-/obj/machinery/door/airlock/security{
-	name = "Labor Shuttle";
-	req_access_txt = "2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
-"bfl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"bfm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"bfp" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"bfq" = (
-/obj/vehicle/ridden/secway,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"bfr" = (
-/obj/structure/rack,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/teargas{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/key/security,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "bfv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -9081,34 +7898,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bfT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"bfU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "bfZ" = (
 /obj/machinery/vending/autodrobe,
 /obj/machinery/light{
@@ -9340,33 +8132,8 @@
 /turf/closed/wall/r_wall,
 /area/storage/tech)
 "bht" = (
-/obj/machinery/camera{
-	c_tag = "Brig Prison Hallway South";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/computer/card/minor/hos,
 /turf/open/floor/plasteel,
-/area/security/prison)
-"bhB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "bhC" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -9405,25 +8172,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bhG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office";
+	req_one_access_txt = "1;4"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_x = 22;
-	pixel_y = 11
-	},
-/obj/machinery/power/apc{
-	area = "/area/security/main";
-	dir = 4;
-	name = "Security Office APC";
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/turf/open/floor/plasteel,
 /area/security/main)
 "bhL" = (
 /obj/machinery/door/airlock/engineering{
@@ -9534,18 +8291,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"biB" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "biD" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/floor/plasteel,
@@ -9587,20 +8332,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "biP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/structure/bed/dogbed/mcgriff,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "biQ" = (
 /obj/machinery/power/apc{
 	areastring = "/area/chapel/main";
@@ -9620,21 +8354,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"biU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "biW" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel,
@@ -10010,25 +8729,6 @@
 /obj/item/clothing/suit/straight_jacket,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"bkx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"bky" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
-	name = "Cell 2 Locker"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bkA" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/tile/green,
@@ -10052,22 +8752,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"bkH" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
-	name = "Cell 1 Locker"
-	},
+"bkL" = (
+/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"bkL" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -10119,12 +8810,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ble" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 24;
+	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/security/brig)
 "blf" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -10139,9 +8832,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
 "bll" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "blo" = (
 /turf/open/floor/plasteel/freezer,
@@ -10183,30 +8877,12 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/security/courtroom)
-"blN" = (
-/obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "blU" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"blW" = (
-/obj/machinery/camera{
-	c_tag = "Security Checkpoint - Sec";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/obj/machinery/button/door{
-	id = "briggate";
-	name = "Brig Shutter Control";
-	pixel_x = 26;
-	req_access_txt = "1"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bmr" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -10301,15 +8977,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"boP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bpd" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -10328,6 +8995,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bpR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "bqb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -10355,6 +9032,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"bqY" = (
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "bqZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -10678,17 +9361,16 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"buV" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "bvu" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"bvv" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prisoner Processing";
-	req_access_txt = "2"
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "bvD" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -10721,12 +9403,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"bxy" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/secequipment,
-/obj/machinery/light,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "bxK" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -10741,16 +9417,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"bxW" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = 8
-	},
-/obj/machinery/recharger{
-	pixel_x = -8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "bxZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -10766,23 +9432,17 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
 "bzj" = (
-/obj/machinery/rnd/production/techfab/department/security,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
-"bzo" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office";
+	req_one_access_txt = "1;4"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/main)
 "bzt" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -10800,26 +9460,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"bzZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"bzC" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prisoner Processing";
+	req_access_txt = "2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"bAe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "bAf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -10868,29 +9515,16 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bAP" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /obj/machinery/door_timer{
 	id = "Cell 1";
 	name = "Cell 1";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
-/area/security/brig)
-"bBs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/iv_drip,
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "bBW" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -10901,25 +9535,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"bCo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bCu" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/effect/landmark/start/security_officer,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+"bCa" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "bDt" = (
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -10938,11 +9559,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bES" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_x = 29
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/machinery/flasher{
+	id = "Cell 3";
+	pixel_x = 24;
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -11218,29 +9840,11 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"bPo" = (
-/obj/machinery/gulag_item_reclaimer{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
 "bPu" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/hydroponics)
-"bPT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "bQg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/biohazard,
@@ -11255,18 +9859,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bQk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "bQv" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/space_heater,
@@ -11276,9 +9868,20 @@
 /turf/closed/wall,
 /area/science/storage)
 "bQE" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Labor Shuttle Dock";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
+"bQF" = (
+/turf/open/floor/plasteel,
+/area/security/range)
 "bRe" = (
 /obj/machinery/camera{
 	c_tag = "Permabrig Library";
@@ -11288,6 +9891,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"bRx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "briglockdown";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
 "bSh" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -11302,33 +9913,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
-"bSp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "bSs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "bSw" = (
 /obj/machinery/shower{
 	dir = 4
@@ -11342,26 +9929,13 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/fitness)
-"bSy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bSK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/main)
 "bSQ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/sunglasses,
@@ -11371,37 +9945,12 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"bTh" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "bTm" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"bTF" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall,
-/area/security/main)
-"bTT" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/bodycontainer/morgue,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
 "bUm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
@@ -11410,6 +9959,11 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/aft)
+"bUD" = (
+/obj/structure/tank_dispenser/oxygen,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "bUR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -11429,30 +9983,6 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
-"bVy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
-"bVH" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bVR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
 	dir = 1
@@ -11463,18 +9993,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"bWO" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bXe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -11539,14 +10057,6 @@
 /obj/item/transfer_valve,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing)
-"bYw" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
 "bYN" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
@@ -11580,21 +10090,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"caY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Brig Desk";
-	req_access_txt = "1"
+"caT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/plating,
-/area/security/brig)
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "cbj" = (
 /obj/structure/chair{
 	dir = 8
@@ -11647,6 +10148,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/bridge)
+"ccc" = (
+/obj/machinery/camera{
+	c_tag = "Firing Range";
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "ccg" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -11718,6 +10226,22 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/bridge)
+"cdG" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/execution";
+	name = "Prisoner Transfer Centre";
+	pixel_y = -23
+	},
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = -22
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "cdQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
 	dir = 8
@@ -11804,6 +10328,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"cgp" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "cgq" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -11916,13 +10446,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cjC" = (
-/obj/machinery/door/window/brigdoor/security/holding{
-	id = "Holding Cell";
-	name = "Gulag Holding A"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
 "cjL" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -11931,6 +10454,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ckf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "cki" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -11960,14 +10490,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "cln" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_y = -30
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "clp" = (
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
@@ -11993,16 +10520,6 @@
 /obj/item/trash/can/food/beans,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"clP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "cma" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
@@ -12062,21 +10579,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"coi" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cos" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
@@ -12086,21 +10588,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"coF" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "coG" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -12110,23 +10597,15 @@
 "cpP" = (
 /turf/closed/wall,
 /area/engine/engineering)
-"cqe" = (
-/obj/machinery/plate_press,
-/turf/open/floor/plating,
-/area/security/prison)
 "cqA" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/inspector{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/item/inspector,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/main)
 "cqB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
@@ -12137,41 +10616,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cqC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	name = "Security RC";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cqL" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"crc" = (
-/obj/machinery/camera{
-	c_tag = "Security Hallway";
-	network = list("ss13","prison")
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "crC" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -12219,17 +10668,13 @@
 /turf/open/space/basic,
 /area/engine/atmos)
 "ctz" = (
-/obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
-	pixel_x = 33
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "ctG" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
@@ -12244,6 +10689,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"ctV" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cuq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -12320,10 +10773,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "cwH" = (
@@ -12336,6 +10785,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"cwX" = (
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "cxf" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit)
@@ -12428,21 +10883,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"cAF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "cAJ" = (
@@ -12515,16 +10955,25 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"cDi" = (
-/obj/effect/turf_decal/tile/red{
+"cDu" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
+"cDF" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Cell 3"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "cDT" = (
 /obj/structure/grille/broken,
 /obj/structure/disposalpipe/segment{
@@ -12599,13 +11048,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cIB" = (
-/obj/machinery/computer/prisoner/gulag_teleporter_computer,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
 "cIK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12654,6 +11096,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/bridge)
+"cKG" = (
+/obj/structure/table,
+/obj/item/storage/box/prisoner{
+	pixel_y = 8
+	},
+/obj/item/storage/box/prisoner,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "cKN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -12663,6 +11113,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"cLn" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cLV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/machinery/meter,
@@ -12741,6 +11196,12 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"cOf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "cOy" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard)
@@ -12873,12 +11334,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cRf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
 "cRp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -12965,12 +11420,6 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/chapel/main)
-"cUn" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "cUt" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel,
@@ -12988,19 +11437,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cUC" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/security/processing)
-"cVk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "cVt" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -13017,6 +11456,12 @@
 /obj/item/banner/command/mundane,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cVW" = (
+/obj/machinery/computer/secure_data{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "cWu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -13045,29 +11490,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cXi" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Prison Wing";
-	req_access_txt = "2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/security/brig)
-"cXj" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Prison Gate";
-	name = "prison blast door"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/main)
 "cXn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13099,15 +11523,6 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"cXv" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/machinery/camera{
-	c_tag = "East Hallway - Sec"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "cXz" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -13308,6 +11723,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/captain)
+"dcN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "ddh" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -13364,12 +11791,6 @@
 /area/tcommsat/server)
 "deM" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -13431,6 +11852,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"dge" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "dgo" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -13514,21 +11940,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"dkE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
-"dkG" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
 "dla" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -13561,21 +11972,13 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "dmp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor{
-	name = "Armory Desk";
+/obj/machinery/door/airlock/security{
+	name = "Armory";
 	req_access_txt = "3"
 	},
-/obj/machinery/door/window/southleft{
-	dir = 1;
-	name = "Reception Desk";
-	req_access_txt = "63"
-	},
-/obj/item/paper_bin,
-/obj/item/folder/red,
-/turf/open/floor/plasteel,
-/area/security/warden)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "dmt" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/plasteel/dark,
@@ -13608,14 +12011,6 @@
 /obj/item/paper/pamphlet/gateway,
 /turf/open/floor/plasteel/dark,
 /area/gateway)
-"dnd" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dnN" = (
 /obj/structure/sign/poster/random{
 	pixel_x = -32
@@ -13648,15 +12043,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"dom" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	dir = 4;
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "dou" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -13674,6 +12060,13 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/atmos)
+"dpz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "dpG" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -13706,9 +12099,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dqN" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "dqR" = (
@@ -13752,6 +12152,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "drj" = (
@@ -13762,19 +12165,16 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "drV" = (
+/obj/structure/cable,
 /obj/machinery/power/apc{
 	areastring = "/area/lawoffice";
 	dir = 1;
 	name = "Law Office APC";
 	pixel_y = 23
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "drZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -13786,6 +12186,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "dsw" = (
@@ -14061,6 +12464,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"dxP" = (
+/obj/structure/table,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/canvas/twentythree_twentythree,
+/obj/item/storage/crayons,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "dyz" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -14179,16 +12589,6 @@
 /obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"dAQ" = (
-/obj/machinery/button/door{
-	id = "hosspace";
-	name = "Space Shutters Control";
-	pixel_x = -26;
-	pixel_y = 34
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
 "dAU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14585,12 +12985,34 @@
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "dKC" = (
-/obj/machinery/computer/prisoner/management,
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "dKL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14653,12 +13075,22 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dLK" = (
-/obj/machinery/computer/security,
-/obj/machinery/airalarm{
-	pixel_y = 24
+/obj/structure/rack,
+/obj/item/storage/box/flashbangs{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/teargas{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/key/security,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "dMc" = (
 /obj/structure/table,
 /obj/machinery/requests_console{
@@ -14682,6 +13114,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"dMx" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/main)
 "dME" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -14700,29 +13142,28 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dMW" = (
-/obj/machinery/suit_storage_unit/security,
-/obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor"
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = -29
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "dMY" = (
-/obj/machinery/computer/secure_data,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	name = "Security RC";
-	pixel_y = 30
+/obj/vehicle/ridden/secway,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "dNe" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dNk" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -14737,16 +13178,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"dNN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "dOl" = (
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -14757,16 +13188,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"dOr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "dOK" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -14794,22 +13215,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"dOP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "dOQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
@@ -14878,9 +13283,6 @@
 	name = "security sorting disposal pipe";
 	sortType = 7
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dQJ" = (
@@ -14920,6 +13322,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"dRj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "dRA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -14933,12 +13342,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"dSu" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
+"dSh" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Cell 1"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
+"dSu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -14983,11 +13404,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dTp" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -15091,14 +13512,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"dWM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "dWR" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "dXm" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "dXn" = (
@@ -15264,16 +13691,22 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/lab)
-"eaW" = (
-/obj/item/food/donut/chaos,
-/turf/open/floor/plating,
-/area/security/prison)
 "ecl" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
 /area/bridge)
+"ecm" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 1";
+	name = "Cell 1"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ecN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -15357,8 +13790,13 @@
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/hop)
 "egQ" = (
-/turf/open/floor/plasteel,
-/area/security/processing)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "hosspace";
+	name = "space shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "eha" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -15432,10 +13870,9 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "eiS" = (
-/obj/structure/table,
-/obj/item/storage/lockbox/loyalty,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/obj/machinery/flasher/portable,
+/turf/open/space/basic,
+/area/space)
 "ejv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -15464,16 +13901,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"ekN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "ekR" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -15505,12 +13932,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"emn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "emy" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -15525,11 +13946,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "emM" = (
-/obj/effect/landmark/start/security_officer,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "enk" = (
@@ -15565,6 +13985,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "enY" = (
@@ -15610,6 +14035,17 @@
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"eqD" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "eqS" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
@@ -15844,6 +14280,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"ewP" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Storage"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "exn" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -15880,6 +14322,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"ezc" = (
+/obj/item/target/syndicate,
+/obj/structure/training_machine,
+/turf/open/floor/plasteel,
+/area/security/range)
 "ezh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -16016,6 +14463,19 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"eCf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "eCi" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -16059,20 +14519,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"eDb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "eEe" = (
 /obj/machinery/rnd/destructive_analyzer,
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "eEi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/folder/red,
+/obj/item/clothing/mask/gas/sechailer,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/main)
 "eEE" = (
 /obj/structure/chair{
 	dir = 1
@@ -16110,37 +14581,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"eIT" = (
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/structure/rack,
-/obj/machinery/light{
+"eHF" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/northright,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
+/area/security/brig)
 "eIX" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -16160,30 +14609,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"eJk" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "eJJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
@@ -16195,14 +14620,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "eJX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
+/obj/structure/rack,
+/obj/item/gun/energy/ionrifle,
+/obj/item/clothing/suit/hooded/ablative,
+/obj/item/gun/energy/temperature/security,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "eJZ" = (
 /obj/machinery/conveyor{
@@ -16237,16 +14659,16 @@
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "eLb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "eLC" = (
@@ -16259,28 +14681,50 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "eLO" = (
-/obj/structure/cable,
-/obj/structure/bed/dogbed/mcgriff,
-/mob/living/simple_animal/pet/dog/pug/mcgriff,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "eLP" = (
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "eLR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/structure/closet/secure_closet{
+	name = "contraband locker";
+	req_access_txt = "3"
+	},
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/spawner/lootdrop/armory_contraband/metastation,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/obj/item/circuitboard/computer/advanced_camera,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "eLX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/bot,
+/mob/living/simple_animal/bot/secbot/beepsky{
+	name = "Sergent Armsky"
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "eMq" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
@@ -16550,6 +14994,14 @@
 	},
 /turf/open/floor/plating,
 /area/medical/pharmacy)
+"eTS" = (
+/obj/structure/cable,
+/obj/machinery/power/solar{
+	id = "foreportsolar";
+	name = "Fore/Port Solar Array"
+	},
+/turf/open/floor/plasteel/airless/solarpanel,
+/area/maintenance/solars/port/fore)
 "eUg" = (
 /obj/item/book/random,
 /turf/open/floor/plating,
@@ -16585,6 +15037,14 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing)
+"eUB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "eVc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
@@ -17007,6 +15467,7 @@
 	pixel_y = 25
 	},
 /obj/item/book/manual/wiki/grenades,
+/obj/item/book/manual/wiki/chemistry,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/pharmacy)
 "fho" = (
@@ -17018,6 +15479,19 @@
 	},
 /turf/open/floor/grass,
 /area/medical/medbay/central)
+"fhr" = (
+/obj/machinery/door/window/westright{
+	name = "Transfer Room";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "executionfireblast"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/education)
 "fhB" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
@@ -17054,6 +15528,7 @@
 /obj/machinery/computer/monitor{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "fig" = (
@@ -17117,6 +15592,34 @@
 "fjt" = (
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
+"fjv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/flasher{
+	id = "Cell 1";
+	pixel_x = 24;
+	pixel_y = -8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "fjF" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -17207,6 +15710,10 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"flS" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "flU" = (
 /obj/machinery/light{
 	dir = 8
@@ -17243,6 +15750,10 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"fnb" = (
+/obj/structure/bed,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "fng" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/plasteel/cafeteria,
@@ -17413,6 +15924,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"ftA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "ftQ" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/belt/medical{
@@ -17481,14 +15998,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fuR" = (
-/obj/structure/table,
-/obj/item/radio/intercom{
-	pixel_y = 25
+"fuQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/item/storage/box/prisoner,
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "fuX" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 5
@@ -17604,15 +16123,11 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "fxF" = (
-/obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
-	name = "Cell 3 Locker"
+/obj/machinery/computer/secure_data{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "fxU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -17650,16 +16165,6 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fyi" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fyr" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -17742,18 +16247,6 @@
 /obj/item/multitool,
 /turf/open/floor/plasteel/showroomfloor,
 /area/tcommsat/computer)
-"fBq" = (
-/obj/structure/rack,
-/obj/item/gun/energy/temperature/security,
-/obj/item/gun/energy/ionrifle{
-	pixel_y = 6
-	},
-/obj/item/clothing/suit/hooded/ablative,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -31
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "fBs" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
@@ -17778,16 +16271,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/fore)
-"fBS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "fBU" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /obj/item/cartridge/chemistry{
@@ -17811,30 +16294,6 @@
 /obj/effect/spawner/lootdrop/maintenance/five,
 /turf/open/floor/plasteel,
 /area/maintenance/central)
-"fCj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
-"fCm" = (
-/obj/structure/table,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/security/prison";
-	dir = 4;
-	name = "Prison Wing APC";
-	pixel_x = 25
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fCn" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -17853,29 +16312,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"fCq" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"fCB" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/warden)
 "fCN" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_y = -30
@@ -17912,16 +16348,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fDV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "fEc" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -17945,69 +16371,10 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fFH" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "Prison Gate";
-	name = "Prison Wing Lockdown";
-	pixel_x = 8;
-	pixel_y = -27;
-	req_access_txt = "2"
-	},
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_x = -8;
-	pixel_y = -27
-	},
-/obj/effect/landmark/start/warden,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "fFL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
-"fGp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	name = "Armory Desk";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/southleft{
-	dir = 4;
-	name = "Reception Desk";
-	req_access_txt = "63"
-	},
-/obj/item/paper_bin,
-/obj/item/folder/red,
-/turf/open/floor/plasteel,
-/area/security/warden)
-"fGs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/requests_console{
-	department = "Security";
-	departmentType = 5;
-	name = "Security RC";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "fGK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -18044,14 +16411,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"fIz" = (
-/obj/machinery/light/small,
-/obj/structure/closet/secure_closet{
-	name = "Gulag Prisoner Storage";
-	req_access = "2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/processing)
 "fIJ" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/engine,
@@ -18095,6 +16454,19 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing)
+"fKk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "fKs" = (
 /obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/vacuum,
@@ -18301,6 +16673,9 @@
 /obj/machinery/shower,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"fRl" = (
+/turf/open/floor/plating,
+/area/security/brig)
 "fRs" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -18406,13 +16781,13 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "fTH" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
 "fTQ" = (
@@ -18478,6 +16853,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"fVD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "fVP" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/closet,
@@ -18604,6 +16988,9 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"fXO" = (
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "fYi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -18747,6 +17134,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/maintenance/starboard/aft)
+"gbL" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "gbO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -19028,6 +17424,18 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"gjH" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "gjL" = (
 /obj/item/banner/engineering/mundane,
 /turf/open/floor/plating,
@@ -19079,14 +17487,14 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "gnk" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
+	},
+/obj/structure/chair{
+	dir = 4
 	},
 /turf/open/floor/carpet/orange,
 /area/security/detectives_office)
@@ -19108,6 +17516,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"gny" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Two"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "gnC" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/five,
@@ -19188,14 +17602,10 @@
 /turf/closed/wall,
 /area/quartermaster/storage)
 "gpV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/l3closet/security,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/main)
 "gqf" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -19218,6 +17628,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"gqX" = (
+/obj/item/paint/anycolor,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "grH" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
@@ -19528,51 +17942,6 @@
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"gyd" = (
-/obj/machinery/camera/motion{
-	c_tag = "Armory - External";
-	dir = 8;
-	network = list("ss13","prison")
-	},
-/turf/open/space/basic,
-/area/space)
-"gye" = (
-/obj/structure/rack,
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = -29
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "gyl" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -19591,37 +17960,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"gyP" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"gzl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/mob/living/simple_animal/bot/secbot/beepsky{
-	name = "Sergent Armsky"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+"gyC" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/plasteel,
+/area/security/main)
+"gzl" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/flashlight/seclite,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "gzu" = (
 /obj/machinery/button/ticket_machine{
@@ -19648,10 +18007,6 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"gAq" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "gAr" = (
 /turf/closed/wall,
 /area/maintenance/solars/starboard/aft)
@@ -19665,13 +18020,19 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "gBo" = (
-/obj/machinery/door/window/southleft{
-	dir = 8;
-	name = "Armory";
-	req_access_txt = "3"
+/obj/structure/rack,
+/obj/item/storage/box/flashes{
+	pixel_x = 3
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/item/storage/box/teargas{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/item/gun/grenadelauncher,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "gBx" = (
 /obj/structure/table_frame/wood,
@@ -19680,9 +18041,14 @@
 	},
 /area/maintenance/starboard/aft)
 "gBJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "gBO" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -19704,10 +18070,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel/showroomfloor,
 /area/tcommsat/computer)
-"gCC" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "gCI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -19801,6 +18163,25 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gGI" = (
+/obj/structure/rack,
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "gGT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -19893,6 +18274,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"gKM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gLf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
@@ -20067,13 +18456,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"gQU" = (
-/obj/structure/chair{
-	dir = 8
+"gQW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/brig)
 "gQY" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -20412,6 +18803,22 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/pharmacy)
+"hao" = (
+/obj/structure/rack,
+/obj/item/gun/energy/laser/practice{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/gun/energy/laser/practice{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/gun/energy/laser/practice{
+	pixel_x = 2;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "har" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -20522,6 +18929,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"hej" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hev" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -20765,6 +19189,12 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"hmb" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hmf" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -20791,10 +19221,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"hnt" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "hnE" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Central";
@@ -20945,16 +19371,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/explab)
-"hrM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "hsb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
@@ -21041,10 +19457,14 @@
 	},
 /area/maintenance/port/aft)
 "huR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "hvp" = (
 /obj/effect/turf_decal/stripes/line{
@@ -21361,6 +19781,9 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/carpet/red,
 /area/chapel/office)
+"hFs" = (
+/turf/closed/wall/r_wall,
+/area/security/range)
 "hFQ" = (
 /obj/machinery/power/apc{
 	areastring = "/area/construction/mining/aux_base";
@@ -21377,13 +19800,6 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"hGp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "hGr" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/requests_console{
@@ -21393,6 +19809,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"hGX" = (
+/obj/item/food/donut/chaos,
+/turf/open/floor/plating,
+/area/security/brig)
 "hGZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21510,6 +19930,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"hLe" = (
+/obj/structure/bed,
+/obj/item/bedsheet,
+/obj/machinery/flasher{
+	id = "Cell 1";
+	pixel_x = 24;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "hLk" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -21586,19 +20016,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"hOd" = (
-/obj/structure/table,
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
-/obj/item/storage/box/trackimp{
-	pixel_x = -3
-	},
-/obj/item/storage/box/chemimp{
-	pixel_x = 6
+"hOO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	name = "Armory";
+	req_access_txt = "3"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -21612,18 +20034,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"hOU" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/structure/window/reinforced,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "hOZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -21641,17 +20051,16 @@
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"hPL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"hPS" = (
+/obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/security/prison";
+	dir = 4;
+	name = "Prison Wing APC";
+	pixel_x = -26
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
+/area/security/prison)
 "hQc" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -21691,20 +20100,20 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "hRi" = (
-/obj/structure/closet/secure_closet/contraband/armory,
-/obj/effect/spawner/lootdrop/armory_contraband,
-/obj/effect/spawner/lootdrop/armory_contraband,
-/obj/item/circuitboard/computer/advanced_camera,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "hRJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/orange,
 /area/lawoffice)
 "hSL" = (
@@ -21712,12 +20121,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engine/engine_smes)
-"hTd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "hTo" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -21745,11 +20148,19 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "hUo" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/ai_monitored/security/armory";
+	dir = 4;
+	name = "Armory APC";
+	pixel_x = 24
+	},
+/obj/machinery/light_switch{
+	pixel_x = 22;
+	pixel_y = 11
+	},
+/obj/machinery/flasher/portable,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "hUH" = (
 /obj/machinery/atmospherics/miner/n2o,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -21788,6 +20199,18 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/bridge)
+"hWW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "East Hallway - Sec"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "hXc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -21830,14 +20253,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "hZE" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
+	},
+/obj/item/radio/intercom{
+	pixel_y = -30
 	},
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -21854,6 +20277,23 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hZQ" = (
+/obj/structure/table,
+/obj/item/clothing/under/rank/prisoner/skirt{
+	pixel_x = -13;
+	pixel_y = 5
+	},
+/obj/item/clothing/under/rank/prisoner/skirt{
+	pixel_x = 9;
+	pixel_y = 5
+	},
+/obj/item/clothing/under/rank/prisoner{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hZX" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood,
@@ -21884,6 +20324,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"ibb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Reception Window"
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	name = "Brig Control Desk";
+	req_access_txt = "3"
+	},
+/obj/item/paper,
+/obj/machinery/door/firedoor,
+/obj/item/storage/fancy/donut_box,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briglockdown";
+	name = "Warden Desk Shutters"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "ibr" = (
 /obj/structure/musician/piano{
 	icon_state = "piano"
@@ -21893,6 +20355,23 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
+"ibE" = (
+/obj/structure/rack,
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = 6
+	},
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = 3
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ibM" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
@@ -22034,6 +20513,24 @@
 /obj/machinery/griddle,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"ihf" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"ihj" = (
+/obj/item/radio/intercom{
+	pixel_x = -29
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ihq" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -22082,6 +20579,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"ihX" = (
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 "iie" = (
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
@@ -22110,7 +20610,6 @@
 /area/hallway/primary/central)
 "ijL" = (
 /obj/structure/table/glass,
-/obj/item/book/manual/wiki/chemistry,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/pharmacy)
 "ikU" = (
@@ -22121,21 +20620,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"ilC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southleft{
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/restraints/handcuffs,
-/obj/item/restraints/handcuffs,
-/turf/open/floor/plating,
-/area/security/brig)
 "ilJ" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -22244,6 +20728,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/bridge)
+"ioL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/docking,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "ipn" = (
 /obj/structure/bookcase/random/reference,
 /obj/machinery/camera{
@@ -22282,6 +20771,17 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"irD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 1;
+	frequency = 1441;
+	id = "inc_in"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "irM" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -22597,6 +21097,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"iBp" = (
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_official,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "iCc" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -22666,31 +21174,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"iEc" = (
-/obj/structure/table,
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
-/obj/item/storage/box/firingpins{
-	pixel_x = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
-"iEd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "iEr" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -22698,47 +21181,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"iED" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
-"iEN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "iFd" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"iFv" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/security/armory";
-	dir = 4;
-	name = "Armory APC";
-	pixel_x = 24
-	},
-/obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_x = 22;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "iGt" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -22746,46 +21192,10 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"iGP" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas/sechailer,
-/obj/structure/sign/warning/electricshock{
-	pixel_x = -32
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"iHc" = (
-/obj/structure/closet/secure_closet/warden,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
-"iHj" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "iHs" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/bridge)
-"iHL" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/light,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "iIf" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/starboard";
@@ -22796,19 +21206,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"iIH" = (
-/obj/structure/table,
-/obj/machinery/recharger{
-	pixel_x = -8
-	},
-/obj/machinery/recharger{
-	pixel_x = 8
-	},
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/warden)
 "iIJ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/showroomfloor,
@@ -22854,6 +21251,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"iKe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "iKA" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/bridge";
@@ -22883,6 +21286,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"iLM" = (
+/obj/machinery/door/airlock/external{
+	name = "Labor Camp Shuttle Airlock";
+	req_access_txt = "2";
+	shuttledocked = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "iLN" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -22959,6 +21373,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"iNJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "rabbitcontainment";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "iOj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -22967,6 +21389,11 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port)
+"iOp" = (
+/obj/structure/table,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iOP" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
@@ -23250,14 +21677,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"iXY" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Visiting Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "iYf" = (
 /obj/structure/table,
 /obj/item/toy/prize/phazon{
@@ -23266,16 +21685,18 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "iYi" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/airlock/security{
+	id_tag = "IsolationCell";
+	name = "Isolation Cell";
+	req_access_txt = "2"
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "iYj" = (
 /obj/machinery/power/apc{
@@ -23379,16 +21800,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"jbs" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
 "jbu" = (
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium{
@@ -23400,19 +21811,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jbF" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/main)
 "jbI" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "jbL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/table/reinforced,
+/obj/item/folder/red,
+/obj/item/storage/secure/briefcase,
+/turf/open/floor/plasteel,
 /area/security/main)
 "jbR" = (
 /obj/effect/landmark/event_spawn,
@@ -23507,6 +21918,10 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/medical/psychology)
+"jes" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "jeu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -23514,12 +21929,6 @@
 "jey" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"jfI" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "jfV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -23556,6 +21965,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"jhu" = (
+/turf/closed/wall,
+/area/security/execution/transfer)
 "jhE" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -23563,6 +21975,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"jhS" = (
+/obj/structure/sign/poster/official/obey{
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jig" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -23911,6 +22329,10 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/xenobiology)
+"jtM" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "jtX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -24092,15 +22514,31 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"jzL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+"jAq" = (
+/obj/structure/table,
+/obj/item/clothing/shoes/sneakers/orange{
+	pixel_x = -6;
+	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/item/clothing/shoes/sneakers/orange{
+	pixel_x = -6;
+	pixel_y = -2
 	},
+/obj/item/clothing/shoes/sneakers/orange{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/clothing/shoes/sneakers/orange{
+	pixel_x = -6;
+	pixel_y = -8
+	},
+/obj/item/clothing/under/rank/prisoner{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
 "jAB" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
@@ -24246,6 +22684,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"jFn" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jFo" = (
 /obj/machinery/power/shieldwallgen,
 /obj/effect/turf_decal/bot,
@@ -24384,6 +22830,15 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"jJJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "jKs" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -24436,6 +22891,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"jMr" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "jMy" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 5
@@ -24457,6 +22924,13 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/maintenance/solars/starboard/aft)
+"jMR" = (
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "jNr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -24500,10 +22974,10 @@
 /turf/open/floor/wood,
 /area/library)
 "jOj" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
 "jOm" = (
@@ -24714,15 +23188,6 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
-"jVU" = (
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/item/paper_bin,
-/obj/item/folder/red,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "jVW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -24777,10 +23242,10 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "jYf" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
 "jYl" = (
@@ -24802,6 +23267,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"jYK" = (
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "jYL" = (
 /obj/structure/closet/firecloset,
 /obj/structure/cable,
@@ -24810,7 +23281,7 @@
 "jYP" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
-/area/security/prison)
+/area/security/brig)
 "jYX" = (
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Control"
@@ -25048,15 +23519,13 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
 "kiu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office";
+	req_one_access_txt = "1;4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/security/prison)
+/area/security/main)
 "kiL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25113,12 +23582,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"kjK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
 "kjT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25164,6 +23627,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"klr" = (
+/obj/item/target,
+/obj/item/target,
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/item/target/clown,
+/obj/item/target/clown,
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/obj/structure/closet/crate/secure{
+	desc = "A secure crate containing various materials for building a customised test-site.";
+	name = "Firing Range Gear Crate";
+	req_access_txt = "1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "klF" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -25295,6 +23774,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"kqr" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/security/range)
 "kre" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 1
@@ -25430,6 +23913,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/xenobiology)
+"ktR" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "ktY" = (
 /obj/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -25472,24 +23961,21 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kvd" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/landmark/start/prisoner,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "kvt" = (
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office";
-	req_access_txt = "4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office";
+	req_access_txt = "4"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/grimy,
@@ -25742,7 +24228,22 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"kDY" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "kEt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -25750,9 +24251,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "kEw" = (
@@ -25893,20 +24391,6 @@
 /obj/item/poster/random_contraband,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"kIQ" = (
-/obj/machinery/camera{
-	c_tag = "HoS' Room";
-	network = list("ss13","prison")
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Security's Desk";
-	departmentType = 5;
-	name = "Head of Security RC";
-	pixel_y = 30
-	},
-/turf/open/floor/carpet/red,
-/area/crew_quarters/heads/hos)
 "kJd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26125,6 +24609,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"kNf" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "kNm" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod D";
@@ -26178,26 +24671,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"kOo" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/hos)
-"kPg" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "rabbitcontainment";
-	name = "privacy shutter"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "kPn" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -26214,19 +24687,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"kPs" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	name = "hos sorting disposal pipe";
-	sortType = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kPu" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -26299,6 +24759,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"kTf" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/flasher{
+	dir = 1;
+	id = "executionflash";
+	pixel_y = -25
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "kTp" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -26362,6 +24832,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"kVM" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel,
+/area/security/main)
 "kWh" = (
 /obj/machinery/light{
 	dir = 8
@@ -26385,6 +24860,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"kYl" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "kYD" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -26602,15 +25089,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"lgS" = (
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = -24
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
 "lgW" = (
 /obj/machinery/shower{
 	dir = 1
@@ -26838,21 +25316,6 @@
 "lnr" = (
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"lnx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lnD" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
@@ -27062,16 +25525,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"lrX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lsb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -27282,10 +25735,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "lzo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/carpet/orange,
 /area/lawoffice)
 "lzG" = (
@@ -27337,11 +25790,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"lAG" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "lAQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	external_pressure_bound = 120;
@@ -27409,6 +25857,16 @@
 /obj/machinery/vending/engivend,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lEY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
+"lFh" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plating,
+/area/security/execution/education)
 "lFk" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -27435,26 +25893,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/genetics)
-"lFR" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "lGq" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -27642,6 +26080,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"lMI" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Prisoner Processing";
+	dir = 1;
+	name = "Perma Camera";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lMQ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -27684,24 +26134,23 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "lND" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "lNJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"lNN" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lNY" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -27740,6 +26189,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lPE" = (
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "lPO" = (
 /obj/structure/table/wood,
 /obj/item/papercutter{
@@ -27760,6 +26213,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lQn" = (
+/obj/structure/closet/secure_closet/injection,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "lQu" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood,
@@ -27802,16 +26265,16 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "lRW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "lRX" = (
@@ -27907,6 +26370,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"lVC" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "lVG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -27931,6 +26398,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"lWs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "lWt" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -27995,6 +26468,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
+"lYV" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office";
+	req_one_access_txt = "1;4"
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
+"lYY" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "lZk" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -28210,6 +26695,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"mgf" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "mgy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -28238,8 +26727,24 @@
 /area/maintenance/port/aft)
 "mgM" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"mgQ" = (
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/glass/beaker,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_official,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "mhN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -28247,24 +26752,16 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "mhV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
 	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
+/turf/open/floor/plating,
+/area/security/brig)
 "mik" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mio" = (
@@ -28277,16 +26774,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
-"mit" = (
-/obj/machinery/washing_machine,
-/obj/machinery/camera{
-	c_tag = "Permabrig Laundry";
-	dir = 1;
-	name = "Perma Camera";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "miB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -28302,6 +26789,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port)
+"miZ" = (
+/obj/machinery/computer/shuttle/labor{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "mjq" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -28448,6 +26944,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -28549,12 +27047,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "mpE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mpM" = (
 /obj/machinery/telecomms/bus/preset_four,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -28614,15 +27114,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"msM" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "mte" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -28777,13 +27268,13 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/engineering)
 "mwP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/morgue{
 	name = "Private Study";
 	req_access_txt = "37"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/library)
 "mwV" = (
@@ -28925,16 +27416,16 @@
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "mAP" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
 "mBt" = (
@@ -28976,6 +27467,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/break_room)
+"mDZ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Cell 2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "mEb" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -29175,6 +27678,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"mLq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "mLC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/white,
@@ -29206,6 +27716,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"mNi" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/landmark/start/prisoner,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "mNX" = (
 /obj/structure/table/wood,
 /obj/item/hand_tele,
@@ -29291,6 +27810,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
+"mRd" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southleft,
+/obj/machinery/door/window/northright,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "mRi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -29410,6 +27935,15 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"mTz" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "mTA" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
@@ -29526,6 +28060,12 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mWf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "mWA" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue{
@@ -29617,28 +28157,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/server)
+"mYo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "mZF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"mZO" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/closet/crate,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/poster/random_contraband,
-/obj/item/poster/random_official,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/plating,
-/area/security/prison)
 "nab" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Server Room";
@@ -29850,13 +28380,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "nfu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/library)
 "nfy" = (
@@ -29875,13 +28405,6 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plasteel/showroomfloor,
 /area/bridge)
-"nfM" = (
-/obj/machinery/computer/security/hos{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
 "ngr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -29904,6 +28427,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
+"ngN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "executionfireblast"
+	},
+/turf/open/floor/plating,
+/area/security/execution/education)
 "ngV" = (
 /obj/structure/table,
 /obj/item/circuitboard/machine/HFR_core,
@@ -29928,6 +28458,12 @@
 "nhw" = (
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
+"nhD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "nhE" = (
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
@@ -29959,11 +28495,11 @@
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
 "niD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "niR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -30108,6 +28644,12 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/chapel/main)
+"npS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "npX" = (
 /obj/structure/chair,
 /obj/structure/cable,
@@ -30131,8 +28673,14 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"nqF" = (
+/turf/closed/wall,
+/area/security/execution/education)
 "nqS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30162,6 +28710,15 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"nrR" = (
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nrT" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -30188,6 +28745,12 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
+"nsA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "nsN" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -30222,14 +28785,22 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"nsY" = (
-/obj/structure/table,
-/obj/item/storage/box/hug,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+"nti" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/structure/closet/crate,
+/obj/item/shovel/spade,
+/obj/item/shovel/spade,
+/obj/item/cultivator,
+/obj/item/cultivator,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_official,
+/obj/effect/spawner/lootdrop/prison_contraband,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "ntr" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 10
@@ -30277,6 +28848,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"nuO" = (
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "nuR" = (
 /obj/machinery/computer/card{
 	dir = 8
@@ -30309,25 +28883,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"nvE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"nvN" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "nvW" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -30513,10 +29068,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"nCW" = (
-/obj/machinery/vending/security,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "nDv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -30650,6 +29201,10 @@
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"nGU" = (
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plating,
+/area/security/execution/education)
 "nHc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30713,17 +29268,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nJA" = (
+/obj/machinery/plate_press,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "nJO" = (
-/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/effect/landmark/event_spawn,
 /obj/effect/landmark/start/detective,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"nJW" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig Laundry";
+	dir = 1;
+	name = "Perma Camera";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "nKc" = (
 /obj/machinery/light{
 	dir = 4
@@ -30803,15 +29371,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"nNJ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "nNO" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
@@ -30882,6 +29441,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"nPs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "nPx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30924,6 +29489,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/hor)
+"nQs" = (
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nQQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -30939,17 +29512,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"nRC" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/processing)
 "nRK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -31002,19 +29564,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"nTk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "nTo" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/prison)
+/area/security/brig)
 "nTr" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -31070,15 +29625,15 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "nUR" = (
-/obj/structure/closet/secure_closet/injection,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/cable,
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	name = "Security RC";
+	pixel_y = 30
 	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nVl" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating{
@@ -31132,6 +29687,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"nWH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nWX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -31148,15 +29714,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"nXa" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
+"nXh" = (
+/obj/structure/closet/secure_closet/brig{
+	name = "Prisoner Locker"
 	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nXA" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -31175,9 +29741,17 @@
 /turf/open/floor/engine,
 /area/engine/atmos)
 "nXR" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/security/sec,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/table/reinforced,
+/obj/item/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/radio,
+/obj/item/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "nXT" = (
 /obj/machinery/camera{
@@ -31287,21 +29861,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/server)
-"oaz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "oaO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -31340,6 +29899,18 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/genetics)
+"ocj" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Cell 5"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "ocl" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod C";
@@ -31384,6 +29955,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"ocz" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "ocJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -31643,6 +30221,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"olZ" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	name = "hos sorting disposal pipe";
+	sortType = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"omc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "ome" = (
 /obj/structure/window{
 	dir = 1
@@ -31704,33 +30300,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"omY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "onb" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"onc" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "onR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
-"oon" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
 "ooH" = (
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -31780,6 +30361,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"opY" = (
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "oqd" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/item/gun/energy/e_gun/mini,
@@ -31826,6 +30410,15 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/tcommsat/computer)
+"oqT" = (
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oqU" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -31853,17 +30446,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "orB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "osb" = (
@@ -31947,6 +30540,35 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/hop)
+"owt" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "owD" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -32180,11 +30802,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "oDV" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/library)
 "oEH" = (
@@ -32200,6 +30822,12 @@
 /obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
+"oFo" = (
+/obj/machinery/door/poddoor{
+	id = "executionspaceblast"
+	},
+/turf/open/floor/plating,
+/area/security/execution/education)
 "oFv" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/grass,
@@ -32209,6 +30837,44 @@
 /obj/machinery/door/window/eastleft,
 /turf/open/floor/grass,
 /area/hydroponics)
+"oFz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen/red{
+	pixel_x = 3
+	},
+/obj/item/tank/internals/anesthetic{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/machinery/button/door{
+	id = "executionfireblast";
+	name = "Transfer Area Lockdown";
+	pixel_x = -25;
+	pixel_y = -5;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/flasher{
+	id = "executionflash";
+	pixel_x = -24;
+	pixel_y = 5
+	},
+/obj/machinery/button/door{
+	id = "executionspaceblast";
+	name = "Vent to Space";
+	pixel_x = 5;
+	pixel_y = 25;
+	req_access_txt = "7"
+	},
+/obj/machinery/button/ignition{
+	id = "executionburn";
+	pixel_x = -5;
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "oFA" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plasteel/showroomfloor,
@@ -32241,6 +30907,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/hydroponics)
+"oGZ" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "oHg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -32293,6 +30963,10 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/hydroponics)
+"oHK" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "oHS" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
@@ -32313,6 +30987,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"oJl" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "oJn" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light{
@@ -32376,6 +31054,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"oLM" = (
+/obj/machinery/door/airlock/security{
+	id_tag = "laborexit";
+	name = "Labor Shuttle";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "oMm" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -32432,18 +31119,6 @@
 /obj/machinery/flasher/portable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"oOq" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "oOA" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
@@ -32555,6 +31230,16 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"oSt" = (
+/obj/machinery/door/airlock/external{
+	name = "Security External Airlock";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "oSJ" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -32673,6 +31358,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"oWZ" = (
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = -8
+	},
+/obj/machinery/door/window/southleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Execution Gas";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plating,
+/area/security/execution/education)
 "oXl" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -32735,7 +31433,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
+"oZu" = (
+/obj/machinery/vending/security,
+/turf/open/floor/plasteel,
+/area/security/main)
 "oZS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /obj/machinery/door/window/northright{
 	dir = 4;
 	name = "Library Desk Door";
@@ -32747,12 +31455,6 @@
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -32904,18 +31606,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/engineering)
-"pgr" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Cell 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "pgv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -33087,6 +31777,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"pls" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "plX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -33324,10 +32023,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/genetics)
-"ptm" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "pto" = (
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/regular,
@@ -33493,6 +32188,15 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"pwV" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/box/deputy,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/main)
 "pxc" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -33564,11 +32268,6 @@
 "pyP" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"pzb" = (
-/mob/living/simple_animal/hostile/carp/cayenne/lia,
-/obj/structure/bed/dogbed/lia,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
 "pzd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -33601,12 +32300,6 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"pAv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
 "pAx" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -33664,14 +32357,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"pCi" = (
-/obj/structure/closet/secure_closet/hos,
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = -30
-	},
-/obj/item/gun/energy/e_gun/mini,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hos)
 "pCN" = (
 /obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
 /obj/machinery/meter,
@@ -33745,15 +32430,19 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "pGp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
 /area/security/brig)
-"pGy" = (
-/obj/item/paint/paint_remover,
-/turf/open/floor/plating,
-/area/security/prison)
 "pGW" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -33870,17 +32559,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "pKh" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "pKk" = (
@@ -33922,15 +32611,22 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
+"pLG" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/electropack,
+/obj/item/assembly/signaler,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "pLL" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"pMc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/docking,
-/turf/open/floor/plating,
-/area/security/processing)
 "pMf" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -33997,6 +32693,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/teleporter)
+"pOl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "pOS" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 1
@@ -34237,6 +32942,19 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"pWR" = (
+/obj/structure/closet/secure_closet/brig{
+	id = "Cell 1";
+	name = "Cell 1 Locker"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "pXA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -34482,6 +33200,40 @@
 "qeW" = (
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"qfi" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "qfu" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -34509,6 +33261,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"qgg" = (
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Shooting Range"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "qgk" = (
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 5
@@ -34517,11 +33281,11 @@
 /turf/open/floor/plasteel,
 /area/science/server)
 "qgB" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
 /turf/open/floor/carpet/orange,
 /area/lawoffice)
@@ -34574,16 +33338,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"qip" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "qis" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -34667,6 +33421,13 @@
 "qks" = (
 /turf/closed/wall,
 /area/janitor)
+"qlb" = (
+/obj/machinery/computer/prisoner/gulag_teleporter_computer,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "qlt" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -34701,6 +33462,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"qmm" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "qmp" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -34730,19 +33500,6 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"qnl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qnO" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
@@ -34801,6 +33558,10 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"qpl" = (
+/obj/machinery/gulag_teleporter,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "qpm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -34947,14 +33708,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"qsT" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 2";
-	name = "Cell 2"
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "qtc" = (
 /obj/structure/displaycase/captain,
 /obj/effect/turf_decal/stripes/line{
@@ -35010,7 +33763,7 @@
 	location = "Security"
 	},
 /turf/open/floor/plating,
-/area/security/brig)
+/area/maintenance/port)
 "qvK" = (
 /obj/machinery/computer/operating{
 	dir = 1;
@@ -35038,6 +33791,15 @@
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"qwZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "qxj" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -35183,6 +33945,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"qDw" = (
+/turf/closed/wall,
+/area/security/prison/safe)
 "qDG" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/effect/decal/cleanable/confetti,
@@ -35252,11 +34017,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"qFz" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "qFM" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -35267,18 +34027,6 @@
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"qGg" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Cell 6"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "qGQ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -35545,6 +34293,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"qPY" = (
+/obj/machinery/photocopier,
+/obj/item/radio/intercom{
+	pixel_x = 29;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "qQc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -35610,6 +34366,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
+"qRb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/sparker{
+	id = "executionburn";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "qRo" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -35711,6 +34477,18 @@
 	name = "black plastitanium floor"
 	},
 /area/crew_quarters/bar)
+"qWD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/bed,
+/obj/item/clothing/suit/straight_jacket,
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "qXp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -35821,13 +34599,13 @@
 /turf/open/floor/plating,
 /area/bridge)
 "qZN" = (
-/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/lawoffice)
 "rac" = (
@@ -35976,6 +34754,18 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
+"rcx" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rcF" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -36277,6 +35067,9 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"rmy" = (
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "rmP" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -36511,10 +35304,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"rta" = (
-/obj/machinery/suit_storage_unit/security,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "rtd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36535,12 +35324,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"ruf" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ruP" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/airalarm/mixingchamber{
@@ -36611,11 +35394,6 @@
 "rxU" = (
 /turf/closed/wall,
 /area/quartermaster/office)
-"rxV" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/secequipment,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "rxZ" = (
 /obj/item/grown/bananapeel,
 /turf/open/floor/plating,
@@ -36641,14 +35419,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/medbay/central)
-"ryw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ryI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -36731,6 +35501,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"rBp" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel,
+/area/security/main)
 "rBt" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -36931,37 +35707,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "rHI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "rabbitcontainment";
+	name = "privacy shutter"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "rIH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"rIZ" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Cell 5"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
 "rJM" = (
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -37399,6 +36155,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"rWX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison)
 "rXk" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
@@ -37480,6 +36244,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"rYZ" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/secequipment,
+/turf/open/floor/plasteel,
+/area/security/main)
 "rZd" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -37517,6 +36286,15 @@
 "rZW" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing)
+"saa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "saq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
@@ -37535,10 +36313,6 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
-"saL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
 "sbx" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -37576,15 +36350,12 @@
 "scP" = (
 /turf/open/space/basic,
 /area/engine/atmos)
-"scS" = (
-/obj/structure/toilet{
-	dir = 8
+"sdf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "sdl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -37682,11 +36453,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "sfI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/machinery/rnd/production/techfab/department/security,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel,
 /area/security/main)
 "sfL" = (
 /obj/structure/cable/layer1,
@@ -37763,13 +36532,13 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "shs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "shF" = (
@@ -38205,8 +36974,8 @@
 	},
 /area/maintenance/starboard/aft)
 "suV" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
+/obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/space/basic,
 /area/maintenance/solars/port/fore)
@@ -38433,6 +37202,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sBH" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Visiting Room"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "sCb" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
@@ -38593,13 +37369,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "sHP" = (
@@ -38638,18 +37414,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"sIk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"sIv" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Perma Brig Processing";
+	req_access_txt = "2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/security/prison)
 "sIx" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -38731,6 +37508,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
+"sJJ" = (
+/obj/structure/guillotine,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "sJR" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_y = -30
@@ -38755,6 +37536,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"sKJ" = (
+/obj/machinery/gulag_item_reclaimer{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "sKU" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -38884,6 +37674,23 @@
 /obj/item/paicard,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"sOt" = (
+/obj/machinery/camera{
+	c_tag = "HoS' Room";
+	network = list("ss13","prison")
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/machinery/button/door{
+	id = "hosspace";
+	name = "Space Shutters Control";
+	pixel_x = -8;
+	pixel_y = 24
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "sOv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -39077,6 +37884,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"sTT" = (
+/obj/docking_port/stationary/random{
+	id = "pod_2_lavaland";
+	name = "lavaland"
+	},
+/turf/open/space,
+/area/space)
 "sTU" = (
 /obj/structure/chair{
 	dir = 4
@@ -39210,6 +38024,10 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/pharmacy)
+"sWN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "sXm" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -39286,6 +38104,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"tba" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Cell 4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "tbB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -39540,6 +38370,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"tia" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/plasteel,
+/area/security/main)
 "tif" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
@@ -39595,11 +38430,32 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/bridge)
+"tjH" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/plasteel,
+/area/security/main)
 "tjP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/atmos)
+"tjX" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Head of Security";
+	req_access_txt = "58"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "rabbitcontainment";
+	name = "privacy shutter"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "tke" = (
 /obj/machinery/requests_console{
 	department = "AI";
@@ -39666,6 +38522,10 @@
 "tll" = (
 /turf/open/floor/grass,
 /area/security/prison)
+"tlF" = (
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/open/floor/plating,
+/area/security/execution/education)
 "tlJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -39766,12 +38626,12 @@
 /turf/open/floor/wood,
 /area/library)
 "top" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -39799,20 +38659,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "tqr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/table/glass,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/paper_bin,
-/obj/item/folder/red,
-/turf/open/floor/plasteel/white,
-/area/security/brig)
+/obj/structure/closet/secure_closet/warden,
+/obj/item/clothing/under/rank/security/warden/grey,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "tqB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -40630,6 +39480,21 @@
 	},
 /turf/open/floor/carpet/black,
 /area/maintenance/starboard/aft)
+"tLS" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 2;
+	icon_state = "right";
+	name = "Brig Infirmary"
+	},
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "tMD" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -40770,6 +39635,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"tRl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/main)
 "tRr" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -41020,11 +39892,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ubb" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -41058,6 +39930,12 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"uce" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/landmark/start/prisoner,
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "ucg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -41133,18 +40011,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"udS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "udV" = (
 /obj/structure/table/glass,
 /obj/structure/window{
@@ -41158,13 +40024,13 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "uea" = (
-/obj/structure/toilet{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/plasteel/white,
 /area/security/prison)
 "uei" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -41341,11 +40207,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"ukt" = (
-/obj/structure/table,
-/obj/item/clothing/suit/straight_jacket,
-/turf/open/floor/plasteel,
-/area/security/prison)
 "ukz" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/extinguisher_cabinet{
@@ -41381,8 +40242,8 @@
 	},
 /area/maintenance/department/electrical)
 "ult" = (
-/turf/closed/wall,
-/area/security/processing)
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "ulu" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -41434,19 +40295,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"umM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/ai_monitored/security/armory)
 "unh" = (
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -41583,6 +40431,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"uqd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "uqI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41733,6 +40594,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"uwj" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin/carbon,
+/obj/item/pen/fountain,
+/turf/open/floor/plasteel,
+/area/security/main)
 "uwy" = (
 /obj/machinery/atmospherics/pipe/simple/supply{
 	dir = 6
@@ -41829,8 +40696,9 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "uzz" = (
-/turf/closed/wall,
-/area/security/execution)
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/plasteel/dark,
+/area/security/main)
 "uzG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -41897,6 +40765,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"uBy" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "uBK" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "stationawaygate";
@@ -42118,16 +40995,6 @@
 	name = "black plastitanium floor"
 	},
 /area/maintenance/central)
-"uGT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "uHu" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -42305,6 +41172,11 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"uMa" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel,
+/area/security/main)
 "uMd" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -42500,6 +41372,12 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/starboard/aft)
+"uRu" = (
+/obj/structure/closet/secure_closet/brig{
+	name = "Prisoner Locker"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uRw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -42585,6 +41463,18 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"uUA" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Cell 6"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "uUX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/chem_master/condimaster{
@@ -42674,6 +41564,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "uWy" = (
@@ -42711,6 +41602,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"uXU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uYh" = (
 /obj/machinery/computer/card/minor/ce,
 /obj/machinery/button/door{
@@ -42756,6 +41659,15 @@
 "uZb" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"uZi" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "uZo" = (
 /obj/effect/mapping_helpers/dead_body_placer,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -42804,9 +41716,9 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "vaF" = (
-/obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/library)
 "vaN" = (
@@ -42890,6 +41802,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"veT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "veU" = (
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
@@ -43062,8 +41980,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "vla" = (
-/turf/closed/wall/r_wall,
-/area/security/processing)
+/obj/structure/bed/dogbed/lia,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "vlz" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -43179,7 +42098,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "vnK" = (
-/turf/closed/wall,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
 /area/security/main)
 "vnX" = (
 /obj/structure/disposalpipe/segment{
@@ -43313,17 +42233,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/tcommsat/computer)
-"vqE" = (
-/obj/machinery/door/airlock/external{
-	name = "Labor Camp Shuttle Airlock";
-	req_access_txt = "2";
-	shuttledocked = 1
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/processing)
 "vqK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -43356,6 +42265,18 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"vrs" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "vrL" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -43608,6 +42529,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"vvX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "vwh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43659,6 +42588,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"vyj" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security{
+	aiControlDisabled = 1;
+	name = "Prisoner Transfer Centre";
+	req_access_txt = "2"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "vyo" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -43920,6 +42859,20 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"vEs" = (
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/heads/hos";
+	dir = 8;
+	name = "Head of Security's Office APC";
+	pixel_y = -23
+	},
+/obj/machinery/light_switch{
+	pixel_x = -10;
+	pixel_y = -22
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "vEt" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/cyan,
@@ -43954,6 +42907,11 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel/showroomfloor,
 /area/hydroponics)
+"vET" = (
+/obj/structure/cable,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/maintenance/solars/port/fore)
 "vEU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -44012,6 +42970,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"vGN" = (
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "vHe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44038,6 +42999,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vHv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "vHE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -44116,6 +43082,13 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"vJy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vJI" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -44213,13 +43186,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "vMh" = (
+/obj/structure/cable,
 /obj/machinery/power/apc{
 	areastring = "/area/security/detectives_office";
 	dir = 8;
 	name = "Detective's Office APC";
 	pixel_x = -25
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "vMk" = (
@@ -44492,12 +43465,28 @@
 "vUW" = (
 /turf/open/floor/carpet/red,
 /area/chapel/main)
+"vVe" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "vVk" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"vVw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vWc" = (
 /obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom{
@@ -44563,6 +43552,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"vXt" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vXD" = (
 /obj/structure/cable,
 /turf/open/floor/plating{
@@ -44615,6 +43616,16 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"vYY" = (
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_x = -8
+	},
+/obj/machinery/recharger{
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "vZg" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -44639,11 +43650,14 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/cmo)
 "way" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Workshop"
+/obj/structure/table,
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/item/paper_bin,
+/obj/item/folder/red,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "waO" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
@@ -44746,14 +43760,6 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/chapel/main)
-"wej" = (
-/obj/machinery/door/window/brigdoor/security/holding{
-	dir = 1;
-	id = "Holding Cell";
-	name = "Holding Cell"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wey" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/security/telescreen/cmo,
@@ -44810,6 +43816,12 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"wgJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "whm" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/stripes/box,
@@ -44857,24 +43869,6 @@
 	icon_state = "wood-broken2"
 	},
 /area/maintenance/starboard/aft)
-"wia" = (
-/obj/machinery/door/window/southleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Armory";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/ai_monitored/security/armory)
 "wio" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -45049,6 +44043,14 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
+"woq" = (
+/obj/structure/table,
+/obj/item/folder/red{
+	pixel_x = 3
+	},
+/obj/item/storage/box/bodybags,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "woz" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -45113,12 +44115,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "wqa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /obj/effect/landmark/start/librarian,
 /obj/structure/disposalpipe/segment{
 	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/library)
@@ -45345,6 +44347,10 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/chapel/main)
+"wwo" = (
+/obj/machinery/computer/security/labor,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/transfer)
 "wwz" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/toolcloset,
@@ -45433,32 +44439,36 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"wzD" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "wzM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing/chamber)
-"wzT" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Brig Control";
-	req_access_txt = "3"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/warden)
 "wzY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wAs" = (
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/item/paper_bin,
+/obj/item/folder/red,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "wAv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -45486,6 +44496,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"wBx" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Perma Brig Processing";
+	req_access_txt = "2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "wBI" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing/chamber)
@@ -45580,6 +44601,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"wDc" = (
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "wDi" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -45604,6 +44628,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"wDK" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "wEC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45636,10 +44664,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/bridge)
-"wFb" = (
-/obj/structure/guillotine,
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "wFs" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -45649,8 +44673,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "wFG" = (
-/turf/open/floor/plating,
-/area/security/prison)
+/obj/machinery/door/airlock/security{
+	name = "Labor Shuttle";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "wGg" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/break_room)
@@ -45658,6 +44687,15 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wGq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "wGX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -45694,12 +44732,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
-"wIK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "wIT" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral,
@@ -45795,6 +44827,16 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"wLc" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Security's Desk";
+	departmentType = 5;
+	name = "Head of Security RC";
+	pixel_y = 30
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "wLd" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/indestructible{
@@ -45981,6 +45023,18 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/xenobiology)
+"wPQ" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "wPU" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
 /turf/open/floor/engine/vacuum,
@@ -46148,6 +45202,12 @@
 "wTN" = (
 /turf/closed/wall,
 /area/science/server)
+"wUf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "wUo" = (
 /obj/structure/window{
 	dir = 1
@@ -46204,14 +45264,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
+"wVI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/prison/safe)
 "wVR" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "wWd" = (
-/obj/structure/bed,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/effect/landmark/start/warden,
+/obj/structure/chair/office,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "wWn" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -46326,6 +45396,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wYE" = (
+/obj/item/paint/paint_remover,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "wYX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -46694,9 +45768,11 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "xky" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/processing)
+/obj/machinery/computer/security/hos{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "xkH" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -46811,16 +45887,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"xof" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xok" = (
 /turf/closed/wall,
 /area/hallway/primary/port)
@@ -47000,6 +46066,26 @@
 "xsd" = (
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
+"xsg" = (
+/obj/structure/rack,
+/obj/item/grenade/barrier{
+	pixel_x = -3;
+	pixel_y = 1
+	},
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "xsj" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -47192,6 +46278,11 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/security/courtroom)
+"xut" = (
+/obj/effect/turf_decal/box,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "xuz" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -47313,9 +46404,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -47447,11 +46535,9 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "xCg" = (
-/obj/machinery/door/poddoor{
-	id = "executionspaceblast"
-	},
-/turf/open/floor/plating,
-/area/security/execution)
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "xCC" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -47607,9 +46693,11 @@
 /area/hallway/secondary/exit)
 "xFu" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/door/airlock/security{
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xFM" = (
@@ -47700,6 +46788,9 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"xIr" = (
+/turf/closed/wall/r_wall,
+/area/security/main)
 "xII" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -47779,6 +46870,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
+"xLR" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Workshop"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison/safe)
 "xMg" = (
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -47853,14 +46950,11 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "xPV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -47875,6 +46969,13 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/science/test_area)
+"xQs" = (
+/obj/structure/rack,
+/obj/item/restraints/handcuffs,
+/obj/item/assembly/flash/handheld,
+/obj/item/reagent_containers/spray/pepper,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "xQv" = (
 /obj/effect/decal/cleanable/glitter,
 /turf/open/floor/plating,
@@ -47892,19 +46993,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "xRa" = (
-/obj/machinery/door/airlock/security{
-	id_tag = "laborexit";
-	name = "Labor Shuttle";
-	req_access_txt = "63"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/processing)
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "xRi" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/security,
@@ -47934,15 +47026,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"xRX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/execution)
 "xSt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -48053,6 +47136,9 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"xVV" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/security/brig)
 "xWk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -48115,18 +47201,15 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/starboard/aft)
-"xXy" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "xXF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/carpet/orange,
 /area/security/detectives_office)
+"xXQ" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/plasteel,
+/area/security/main)
 "xYt" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv{
@@ -48237,6 +47320,25 @@
 	name = "black plastitanium floor"
 	},
 /area/crew_quarters/bar)
+"yaY" = (
+/obj/item/restraints/handcuffs{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/security/main)
 "ybc" = (
 /obj/machinery/rnd/bepis,
 /turf/open/floor/plasteel/dark,
@@ -48752,6 +47854,10 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/cmo)
+"ymh" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/brig)
 
 (1,1,1) = {"
 gfQ
@@ -57050,7 +56156,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -57849,7 +56955,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -58086,7 +57192,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -58338,16 +57444,16 @@ gfQ
 gfQ
 gfQ
 gfQ
+fsz
 gfQ
 gfQ
 gfQ
 gfQ
+fsz
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -58592,21 +57698,21 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-xAV
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
 gfQ
 gfQ
 gfQ
@@ -58848,6 +57954,22 @@ gfQ
 gfQ
 gfQ
 gfQ
+fsz
+fsz
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
+fsz
+gfQ
+fsz
+aeX
+gfQ
+gfQ
+fsz
+gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -58860,22 +57982,6 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-xAV
 gfQ
 gfQ
 gfQ
@@ -59105,23 +58211,23 @@ gfQ
 gfQ
 gfQ
 gfQ
+fsz
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+yin
+yin
+yin
+yin
+yin
+yin
+yin
+uRW
+yhG
+yhG
+yhG
+fsz
+fsz
+fsz
 gfQ
 gfQ
 gfQ
@@ -59362,23 +58468,23 @@ gfQ
 gfQ
 gfQ
 gfQ
+fsz
 gfQ
 gfQ
+yin
+alw
+alQ
+xlD
+ygB
+anq
+apI
+apT
+uDr
+pMF
+yhG
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -59614,31 +58720,31 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+yin
+thl
+oRu
+bRe
+ygB
+anC
+apJ
+apU
+asI
+pMF
+uRW
 gfQ
 gfQ
 fsz
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -59871,35 +58977,35 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
 gfQ
 gfQ
 fsz
 gfQ
 gfQ
-gfQ
-gfQ
+fsz
+yfx
+yin
+lnP
+guT
+amj
+ygB
+krw
+qPW
+asT
+xlD
+pMF
+yin
+fsz
+fsz
 fsz
 gfQ
 gfQ
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -60123,42 +59229,42 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
 gfQ
 fsz
+gfQ
+yhG
+yhG
+yhG
+yhG
+yhG
+yhG
+yin
+ajp
+uzG
+amk
+ygB
+anT
+uCB
+xlD
+xlD
+vBc
+yin
+gfQ
+gfQ
 fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -60385,39 +59491,39 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
 fsz
 gfQ
-gfQ
-fsz
-gfQ
-gfQ
-fsz
-gfQ
-fsz
-aeX
-gfQ
-gfQ
-fsz
-gfQ
+yhG
+aiZ
+dUI
+wOt
+aiu
+qJP
+ygB
+ygB
+alR
+ygB
+ygB
+ygB
+apA
+arl
+ygB
+ygB
+yin
+yin
+yin
 fsz
 gfQ
 gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+ato
 gfQ
 gfQ
 gfQ
@@ -60642,40 +59748,40 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-gfQ
-gfQ
-yin
-yin
-yin
-yin
-yin
-yin
-yin
-uRW
+fsz
 yhG
-yhG
-yhG
-fsz
-fsz
+fdq
+dUI
+agS
+aix
+ajv
+akP
+pwd
+alS
+ihj
+amy
+xyS
+ctV
+arm
+dnN
+ygB
+nJA
+jMR
+yin
 fsz
 gfQ
 gfQ
+gfQ
+gfQ
+gfQ
+jes
+iLM
+jes
+gfQ
+jes
+iLM
+jes
 gfQ
 gfQ
 gfQ
@@ -60899,40 +60005,40 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
 gfQ
-gfQ
-yin
-alw
-alQ
-xlD
-ygB
-anq
-apI
-apT
-uDr
-pMF
 yhG
-gfQ
-gfQ
+wOt
+wOt
+agZ
+wOt
+wOt
+akR
+xlD
+xlD
+apc
+xlD
+xlD
+arz
+uCB
+xlD
+xLR
+rmy
+lVC
+yin
 fsz
 gfQ
 gfQ
+gfQ
+gfQ
+gfQ
+jes
+vGN
+jes
+gfQ
+jes
+vGN
+jes
 gfQ
 gfQ
 gfQ
@@ -61156,42 +60262,40 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-yin
-thl
-oRu
-bRe
-ygB
-anC
-apJ
-apU
-asI
-pMF
+iwb
 uRW
-gfQ
-gfQ
+aga
+qzX
+ahe
+qzX
+qzX
+ygB
+srQ
+srQ
+xaQ
+srQ
+srQ
+mSU
+uCB
+xlD
+ygB
+rmy
+rmy
+yin
 fsz
 gfQ
 gfQ
 gfQ
 gfQ
+jhu
+ioL
+eqD
+jes
+jhu
+jes
+eqD
+ioL
 gfQ
 gfQ
 gfQ
@@ -61201,7 +60305,9 @@ gfQ
 gfQ
 gfQ
 gfQ
-ato
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -61413,53 +60519,53 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
 gfQ
-gfQ
-fsz
-gfQ
-gfQ
-fsz
-yfx
 yin
-lnP
-guT
-amj
+qzX
+qzX
+ahk
+qzX
+ajA
 ygB
-krw
-qPW
-asT
+aoL
+rFn
+amm
+amz
+iDu
+ygB
+uCB
 xlD
-pMF
+ygB
+nJA
+jMR
 yin
 fsz
-fsz
-fsz
-gfQ
-gfQ
-gfQ
-xAV
 gfQ
 gfQ
 gfQ
 gfQ
-xky
-nRC
-xky
+jhu
+agA
+nhD
+miZ
+jhu
+sKJ
+fXO
+mWf
+ihX
+aYO
+aYO
+aYO
+hFs
 gfQ
-xky
-nRC
-xky
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -61670,53 +60776,53 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-xAV
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
 gfQ
-yhG
-yhG
-yhG
-yhG
-yhG
-yhG
 yin
-ajp
-uzG
-amk
+aga
+nKc
+ahs
+kMo
+apq
 ygB
-anT
-uCB
-xlD
-xlD
-vBc
+tll
+tll
+euO
+tll
+anU
+ygB
+fuQ
+asN
+ygB
+ygB
+ygB
 yin
+yin
+yin
+oFo
+oFo
+oFo
+jhu
+qpl
+ftA
+mLq
+jes
+uZi
+opY
+jYK
+ihX
+nsA
+lWs
+cOf
+hFs
 gfQ
 gfQ
-fsz
 gfQ
 gfQ
 gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-xky
-bcr
-xky
-gfQ
-xky
-bcr
-xky
 gfQ
 gfQ
 gfQ
@@ -61925,56 +61031,56 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-gfQ
-yhG
-aiZ
-dUI
-wOt
-aiu
-qJP
-ygB
-ygB
-alR
-ygB
-ygB
-ygB
-apA
-arl
-ygB
-ygB
-yin
-yin
-yin
 fsz
+fsz
+fsz
+uRW
+ygB
+ygB
+ygB
+ygB
+ygB
+ygB
+tll
+euO
+amn
+amA
+anV
+ygB
+gPL
+asK
+ygB
+aCz
+xlD
+avI
+nJW
+yin
+mYo
+iKe
+dWM
+jhu
+qlb
+ftA
+vvX
+jes
+uZi
+opY
+wDK
+ihX
+lEY
+ezc
+kqr
+hFs
 gfQ
 gfQ
 gfQ
 gfQ
 gfQ
 gfQ
-ult
-ult
-pMc
-vqE
-xky
-ult
-xky
-vqE
-pMc
-ult
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -62182,56 +61288,56 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-fsz
+gfQ
+gfQ
+gfQ
 yhG
-fdq
-dUI
-agS
-aix
-ajv
-akP
-pwd
-alS
-aml
-amy
-xyS
-kiu
-arm
-dnN
+agc
+ghC
+buj
+ags
+ajB
 ygB
-cqe
-ard
+aow
+tll
+tll
+amC
+anX
+ygB
+qLq
+xlD
+ygB
+arZ
+xlD
+xlD
+awL
 yin
-fsz
+qRb
+fnb
+kTf
+jhu
+wwo
+ftA
+mLq
+bzC
+uZi
+opY
+opY
+ihX
+lEY
+bQF
+kqr
+hFs
 gfQ
 gfQ
 gfQ
 gfQ
 gfQ
-fsz
-ult
-fuR
-aZz
-egQ
-beS
-ult
-bPo
-aSc
-cRf
-ult
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -62439,56 +61545,56 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
+gfQ
+gfQ
 gfQ
 yhG
-wOt
-wOt
-agZ
-wOt
-wOt
-akR
+agc
+ags
 xlD
-xlD
-apc
-xlD
-xlD
-xlD
-uCB
-xlD
-way
-wFG
-bQE
+aUK
+anf
+ygB
+aeK
+euO
+dOY
+tll
+nei
+ygB
+pua
+jbw
+imL
+avd
+asN
+lPE
+axb
 yin
-fsz
-uzz
+wGq
+irD
+wgJ
+jhu
+way
+sdf
+bQE
+jes
+uZi
+cwX
 xCg
-xCg
-xCg
-uzz
-fsz
-ult
-aro
-aZB
-egQ
-beY
-xky
-bPT
-egQ
-cUn
-ult
+ihX
+lEY
+bQF
+kqr
+hFs
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -62696,56 +61802,56 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-iwb
-uRW
-aga
-qzX
-ahe
-qzX
-qzX
+fsz
+fsz
+yhG
+yhG
+xlD
+xlD
+xlD
+xlD
+xlD
 ygB
 srQ
 srQ
-xaQ
+uiV
 srQ
 srQ
 mSU
 uCB
 xlD
 ygB
-wFG
-wFG
+avf
+awE
+awE
 yin
-fsz
-uzz
-aCw
-aHs
+yin
+fhr
+ngN
+ngN
+jhu
+jhu
+ihX
+wFG
+ihX
+oLM
+ihX
+ihX
+ihX
 aOh
-uzz
-fsz
-ult
-cIB
-aZB
-baD
-bfh
-xky
-bQk
-kjK
-aTE
-ult
+qgg
+qwZ
+hFs
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -62753,7 +61859,7 @@ gfQ
 gfQ
 xAV
 gfQ
-fsz
+gfQ
 gfQ
 gfQ
 gfQ
@@ -62953,64 +62059,64 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
 gfQ
-yin
-qzX
-qzX
-ahk
-qzX
-ajA
-ygB
-aoL
-rFn
-amm
-amz
-iDu
-ygB
-uCB
+gfQ
+yhG
+xlD
+xlD
+mRJ
+ahv
+aeI
+pwd
+ndS
+pwd
+pwd
+apf
+pwd
+pwd
+eUB
+arp
 xlD
 ygB
-cqe
-ard
+ygB
+ygB
+ygB
 yin
-fsz
-uzz
-aJo
-aHZ
+oFz
+saa
+iKe
+wAs
+lYY
+woq
+nqF
+bez
+bez
+bez
+bez
+bez
+hFs
 aOi
-uzz
-fsz
 ult
+ccc
+hFs
 aYO
-aZB
+xrN
+cUC
+cUC
+xrN
 egQ
-bfi
-bvv
-bSp
 egQ
-egQ
-ult
-gfQ
-gfQ
-fsz
+xrN
 gfQ
 gfQ
 gfQ
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -63210,64 +62316,64 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
 gfQ
-yin
-aga
-nKc
-ahs
-kMo
-apq
-ygB
-tll
-tll
-euO
-tll
-anU
-ygB
+gfQ
+yhG
+uDr
+npX
+adV
+xlD
+xlD
+xlD
+oXQ
+xlD
+xlD
+gjB
+xlD
+xlD
+nrR
 uCB
 xlD
-ygB
-ygB
-ygB
+ewP
+rmy
+nti
+iBp
 yin
-aPn
-uzz
-aDt
+pLG
+ktR
+oGZ
+cDu
+mgf
+mgf
+vyj
+ymh
+ymh
+ymh
+ymh
+ymh
 aIM
 aLT
-uzz
-fsz
+xut
 ult
+klr
 aYP
-aZC
-baE
+xrN
+cVW
 bfj
 xky
 bSs
 baE
 cUC
-ult
 gfQ
 gfQ
-fsz
-gfQ
-fsz
 gfQ
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -63467,66 +62573,66 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-fsz
-fsz
-fsz
-uRW
+gfQ
+gfQ
+yhG
+xlD
+agc
+agx
+ahz
+xlD
+ajE
 ygB
+qDw
+qDw
+qDw
+qDw
+qDw
+qDw
+uCB
+xlD
 ygB
-ygB
-ygB
-ygB
-ygB
-tll
-euO
-amn
-amA
-anV
-ygB
-gPL
-asK
-ygB
-aCz
-avI
-awE
-uzz
-uzz
-aJB
+rmy
+rmy
+wYE
+yin
+lQn
+qmm
+wDc
+mgf
+wDc
+flS
+nqF
+nqF
+nXh
+bez
+ymh
+bez
+hFs
 aOk
-aOk
-uzz
-uzz
+hao
 ult
 ult
 ult
-vla
-bfk
-vla
+xrN
+sOt
+lYM
+nhE
 xRa
 vla
-vla
-vla
-vla
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
+xrN
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -63724,66 +62830,66 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-gfQ
-gfQ
-gfQ
+fsz
+fsz
 yhG
-agc
-ghC
-buj
-ags
-ajB
+yhG
+agd
+lBX
+ahC
+lBX
+lBX
 ygB
-aow
-tll
-tll
-amC
-anX
-ygB
-qLq
+dge
+kNf
+qDw
+mNi
+kNf
+qDw
+uCB
 xlD
 ygB
-arZ
-xlD
-awL
-uzz
-azr
-xRX
-aHs
-jVU
-aUD
-aTo
-asJ
-uzz
-gfQ
+mgQ
+gqX
+dxP
 yin
-bfl
-bcR
-bSy
-xky
-aSc
-fIz
-vla
+sJJ
+fVD
+wDc
+cdG
+nqF
+oWZ
+nGU
+nqF
+uRu
+bez
+ymh
+bez
+hFs
+hFs
+hFs
+hFs
+asJ
+bcZ
+xrN
+qYG
+lZk
+rbU
+bSs
+pAx
+xrN
 gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
 gfQ
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -63981,66 +63087,66 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
 gfQ
 gfQ
 gfQ
 yhG
-agc
-ags
-xlD
-aUK
-anf
+agk
+agN
+agN
+agN
+anh
 ygB
-aeK
-euO
-dOY
-tll
-nei
+pOl
+gjH
+qDw
+pOl
+gbL
+qDw
+arq
+asL
 ygB
-pua
-jbw
-imL
-avd
-avJ
-axb
-uzz
-azs
-aDz
+ygB
+ygB
+ygB
+yin
+yin
+yin
+yin
+yin
+yin
+tlF
+lFh
+nqF
+uRu
+bez
+ymh
+bez
 aIO
 aPU
 aUG
 aTz
 aXs
 aYQ
-gfQ
-yin
-rHI
-xlD
-bSK
-cjC
-aSc
-dkG
-vla
+xrN
+baN
+mdd
+dFp
+bSs
+pBJ
+xrN
 gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
 gfQ
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -64238,66 +63344,66 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-fsz
-fsz
+gfQ
+gfQ
+gfQ
 yhG
-yhG
-xlD
-xlD
-xlD
-xlD
-xlD
+dcp
+diO
+ahD
+aiU
+sTh
 ygB
-srQ
-srQ
-uiV
-srQ
-srQ
-mSU
+ocj
+qDw
+qDw
+tba
+qDw
+qDw
 uCB
 xlD
-ygB
-avf
 xlD
-mit
-uzz
+xlD
+xlD
+wUf
+xlD
+xlD
+xlD
+yin
+yin
+yin
+yin
+xke
+xke
+xke
+xke
 nUR
-nNJ
-gCC
+bez
+bcd
 lND
 aPd
 aTG
-afk
+aXs
 uzz
-gfQ
-yin
-bfm
-wIK
-bTh
-vla
-vla
-vla
-vla
-gfQ
-fsz
-gfQ
-gyd
-fsz
+xrN
+kNU
+meM
+nhE
+bSs
+pBK
+xrN
 gfQ
 gfQ
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -64495,66 +63601,66 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-gfQ
-gfQ
-yhG
-xlD
-xlD
-mRJ
-ahv
-aeI
-pwd
-ndS
-pwd
-pwd
-apf
-pwd
-pwd
-pwd
-arp
-xlD
-ygB
-ygB
-ygB
-ygB
-uzz
-wFb
-hGp
-aJq
-aQh
-uzz
-uzz
-uzz
-uzz
-ygB
+fsz
+fsz
+rWm
+uRW
 yin
-fGs
-xlD
-aQi
+yin
+ygB
+ygB
+ygB
+ygB
+aoC
+alU
+rSS
+amL
+rSS
+adY
+aoH
+rSS
+rSS
+rSS
+jbw
+dRj
+jbw
+jbw
+jbw
+ayG
+kDY
+nPs
+oHK
+mRd
+hmb
+ciu
+xke
+ymh
+bez
+aJq
+bAi
+bAi
+tLS
+aXs
+bUD
+xrN
+wLc
+bSs
+bSs
+bSs
 cln
-cVk
-wlQ
-wlQ
-wlQ
-wlQ
-wlQ
-wlQ
-wlQ
-wlQ
-wlQ
+xrN
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -64754,64 +63860,64 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-gfQ
+fsz
+fsz
 gfQ
 yhG
-uDr
-npX
-adV
+blo
+aja
+jxE
+ygB
+alD
+asl
+asf
+amM
 xlD
 xlD
-xlD
-oXQ
-xlD
-xlD
-gjB
-xlD
-xlD
-apE
 uCB
 xlD
-atR
-wFG
-mZO
-axF
-ygB
-ygB
-ygB
-aJw
-ygB
-aPn
-gfQ
-gfQ
-ygB
-eaW
+xlD
+xlD
 yin
+yin
+yin
+yin
+yin
+yin
+bbP
+aJk
+oHK
+eHF
+hmb
+ciu
+sBH
+ymh
+bez
+bcf
+bku
+aPn
+qWD
+aXs
+uzz
+xrN
+bCa
 bfT
-asN
-xlD
-xlD
-bSK
-wlQ
-hnt
+ckf
+jtM
+vEs
+xrN
+gfQ
+gfQ
 eiS
-eIT
-fBq
-gye
-hOd
-iEc
-wlQ
-wlQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 gfQ
 gfQ
 gfQ
@@ -65013,68 +64119,68 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-gfQ
 gfQ
 yhG
+ahR
+aje
+kBX
+ygB
+qDw
+uUA
+qDw
+qDw
+qDw
+qDw
+arw
+asN
 xlD
-agc
-agx
-ahz
 xlD
-ajE
-ygB
-ygB
-ygB
-ygB
-ygB
-ygB
-ygB
-uCB
-xlD
-ygB
-wFG
-wFG
-pGy
-ygB
-azu
-ahN
-aed
-aee
-aPs
 yin
+caT
+aOm
+aOm
+aOm
 yin
-yin
-yin
-yin
+aye
+aye
+oHK
+eHF
+hmb
+ciu
+xke
+ymh
+bez
+xIr
+xIr
+xIr
+xIr
+lYV
+xIr
+xrN
 rHI
-xlD
-xlD
-xlD
-ryw
-wlQ
-oOk
-nTk
-fCj
-hrM
-fCj
-fCj
-iEd
-bfp
-wlQ
-fsz
+rHI
+tjX
+iNJ
+iNJ
+xrN
+xIr
 gfQ
 gfQ
 gfQ
-waV
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+aEk
 ocl
-waV
+aEk
 wth
 uOT
 bbx
@@ -65270,66 +64376,66 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-fsz
-fsz
-yhG
-yhG
-agd
-lBX
-ahC
-lBX
-lBX
+gfQ
+uRW
+fQN
+aje
+rkL
 ygB
-qFz
-uea
-ygB
-kvd
-uea
-ygB
-uCB
+vrs
+jJJ
+qDw
+jMr
+uce
+qDw
+qLq
 xlD
-ygB
-abg
-avK
-aPE
-ygB
+xlD
+xlD
+yin
+uea
+sWN
+kvd
+aOm
+yin
+jhS
+aye
+oHK
+eHF
+hmb
+ciu
+xke
 azA
-aDI
-iHj
+bez
+bcZ
 aQi
 gpV
-asA
-gpV
-gpV
+cXi
+cXi
+cXi
 aZD
-gpV
-bfU
-xlD
-xlD
-xlD
+cXi
+cXi
+tRl
+cXi
+cXi
 bSK
+xIr
+gfQ
 wlQ
-aFo
-ekN
-eJk
-lFR
-gyP
-hOU
-iED
-bfq
 wlQ
-fsz
+wlQ
+wlQ
+wlQ
 gfQ
 gfQ
 gfQ
-waV
+gfQ
+gfQ
+gfQ
+gfQ
+aEk
 wFw
 sOT
 wth
@@ -65527,66 +64633,66 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-gfQ
-gfQ
-gfQ
-yhG
-agk
-agN
-agN
-agN
-anh
+fsz
+yin
+fQN
+ajg
+rkL
 ygB
-dkE
+uBy
+uce
+qDw
+mTz
+wVI
+qDw
+uCB
+xlD
+xlD
+asZ
+yin
 iYi
-ygB
-dkE
-aop
-ygB
-arq
-asL
-ygB
-ygB
-ygB
-ygB
-ygB
-omY
-aDN
+yin
+yin
+yin
+yin
+yin
+yin
+yin
+xke
+xke
+xke
+xke
+azA
+bez
 kiu
-xyS
-xyS
-xyS
-xyS
-abn
-xyS
-baJ
+cXi
+cXi
+cXi
+cXi
+cXi
+bcN
+cXi
 bht
-xyS
-xyS
-clP
-bSK
+dMx
+qPY
+cXi
+xXQ
+xIr
 wlQ
-oOk
-udS
+wlQ
 eJX
 auk
 gzl
-hPL
-iEN
-bfr
 wlQ
-fsz
+wlQ
 gfQ
 gfQ
 gfQ
-waV
+gfQ
+gfQ
+gfQ
+aEk
 oCT
 lYf
 wth
@@ -65779,71 +64885,71 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
 gfQ
 fsz
 gfQ
-gfQ
-gfQ
-yhG
-dcp
-diO
-ahD
-aiU
-sTh
+yin
+aic
+ajo
+rkL
 ygB
-rIZ
-ygB
-ygB
-amD
-ygB
-ygB
+qDw
+qDw
+qDw
+qDw
+mDZ
+qDw
 uCB
 xlD
-ygB
+xlD
+xlD
+yhG
+asl
+buj
+xlD
+yhG
+xlD
+xlD
+hPS
+xlD
 aCA
 aFk
-aye
-ygB
+gQW
+eDb
 azD
-uCB
-aLP
-xlD
-aQz
-vnK
-vnK
-vnK
-vnK
-vnK
-vnK
-vnK
-vnK
-coi
+bez
+bcZ
+tia
 cXi
-wlQ
-wlQ
+cXi
+cXi
+cXi
+bcN
+cXi
+uwj
+pwV
+vnK
+cXi
+cXi
+xIr
+qfi
 dMW
-rta
-umM
-gAq
+nuO
+nuO
+nuO
 hRi
-iFv
 wlQ
-wlQ
-fsz
 gfQ
 gfQ
 gfQ
-waV
+gfQ
+gfQ
+gfQ
+aEk
 rlI
 waV
 wth
@@ -66041,66 +65147,66 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-fsz
-fsz
-rWm
-uRW
+gfQ
 yin
-yin
-ygB
-ygB
-ygB
-ygB
-aoC
-alU
-rSS
-amL
-rSS
-adY
+jxE
+ajt
+vNQ
+alN
+alG
+alY
+gKM
+pwd
 aoH
-rSS
-iXY
-aqX
+pwd
+arx
+xyS
+xyS
+xyS
+sIv
+bpR
+xyS
+uDr
+wBx
+uDr
+uDr
+uDr
+uDr
+vHv
 mpE
 aym
-ygB
-omY
-uCB
-xlD
-xlD
-ptm
-vnK
+vHv
+azA
+bez
+bcZ
+tia
+cXi
+yaY
 nXR
-abr
-aZE
-baO
-bhB
-nXR
-vnK
-coF
-cXj
-wlQ
-wlQ
-wlQ
-eKb
-wia
+cXi
+bcN
+cXi
+cXi
+tRl
+cXi
+cXi
+cXi
+xIr
+owt
+nuO
+gGI
+nuO
 gBo
-eKb
+nuO
 wlQ
-wlQ
-xrN
-xrN
-xrN
-aDU
-aDU
-xrN
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+aEk
 oCT
 csI
 wVb
@@ -66298,66 +65404,66 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
 fsz
-fsz
-gfQ
-yhG
-blo
-aja
-jxE
-ygB
-alD
+yin
+yin
+yin
+yin
+yin
+xlD
 asl
-asf
-amM
+oqT
+xlD
+asl
+asP
+arz
 xlD
 xlD
-uCB
 xlD
-ygB
-abi
+rWX
+xlD
+uDr
+xlD
+yhG
+xlD
+uDr
+xlD
+xlD
+aCA
+aFk
 avN
-avN
-ygB
+eDb
 azA
-uCB
-xlD
-xlD
-lAG
+bez
+bcZ
+tia
+cXi
 vnK
-nXR
-abs
+uMa
+cXi
 aZG
 bbj
-sfI
-rxV
-bcZ
+cXi
+tRl
+cXi
 eEi
-fDa
-jdC
+vVe
+xIr
 dKC
-acR
+nuO
 eLO
-fBS
-uIx
-uIx
-iGP
-xrN
-lgS
-avt
-nfM
-dAQ
-pzb
-xrN
+nuO
+xsg
+nuO
+wlQ
+fsz
+fsz
+fsz
+fsz
+fsz
+btp
+aEk
 rmY
 lxT
 tPY
@@ -66561,60 +65667,60 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
-gfQ
-yhG
-ahR
-aje
-kBX
+yin
+qDw
+cDF
+qDw
+qDw
+dSh
 ygB
-ygB
-qGg
-ygB
-ygB
-ygB
-ygB
-arw
-asN
-ygB
-abj
-avO
-avO
-ygB
+aUK
+auR
+auR
+aUK
+yin
+auR
+iOp
+lMI
+yin
+cKG
+jAq
+hZQ
+xQs
+xke
+xke
+xke
+xke
 azF
-uCB
-xlD
-xlD
-ptm
-vnK
-aIA
-jbL
-bll
+jFn
+xIr
+tia
+cXi
+kVM
+uMa
+cXi
+aZG
 bcs
 jbL
-rxV
-bcZ
+tRl
+rBp
 cqA
-fDa
-jdC
+vVe
+bcZ
 dLK
-amW
-uIx
-fCq
+nuO
+ibE
+nuO
 gBJ
-hTd
-iHc
-xrN
-kIQ
-lYM
-nhE
-nXa
-pAv
-xrN
+nuO
+wlQ
+fsz
+cLn
+cLn
+cLn
+fsz
+fsz
+aEk
 rqj
 aEk
 wVb
@@ -66817,61 +65923,61 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-gfQ
+yin
+pls
+jJJ
+qDw
+pls
+wPQ
+yin
+yin
+yin
+yin
+yin
 uRW
-fQN
-aje
-rkL
-ygB
-alF
-alX
-ygB
-amN
-qFz
-ygB
-qLq
-asZ
-ygB
-jfI
-qip
-qip
-ygB
+yhG
+yhG
+yhG
+yin
+yhG
+yhG
+yhG
+yin
+xke
+gfQ
+gfQ
+xke
 azJ
-uCB
-fCm
-nsY
-ukt
-vnK
-xXy
-sfI
-bll
-bcs
-sfI
-bxy
+bez
 bcZ
-eEi
-fDa
-jdC
+tia
+cXi
+cXi
+cXi
+cXi
+bcN
+buV
+buV
+tRl
+buV
+buV
+cXi
+bcZ
 dMY
-uIx
+nuO
 eLR
-fCB
-uIx
-uIx
-iHL
-xrN
-qYG
-lZk
-rbU
-oon
-pAx
-xrN
+nuO
+bcA
+nuO
+wlQ
+fsz
+cLn
+cLn
+cLn
+fsz
+fsz
+aEk
 rqE
 aEk
 ayb
@@ -67075,60 +66181,60 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
-fsz
 yin
-fQN
-ajg
-rkL
-ygB
-scS
-ajc
-ygB
-amO
-aoG
-ygB
-uCB
-xlD
-ygB
-nvN
-avP
-ayn
-ayG
+kYl
+cgp
+qDw
+uBy
+uce
+yin
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+xke
 azM
-arp
-ygB
-ygB
-ygB
-vnK
-nXR
-jbL
-bll
-bcs
-jbL
-rxV
+bez
 bcZ
-eEi
-fDa
+tia
+cXi
+cXi
+cXi
+cXi
+bll
+jbF
+npS
+tRl
+cXi
+cXi
+cXi
 dmp
-dNN
-emn
+nuO
+nuO
 eLX
-fDV
-uIx
-uIx
-iIH
-xrN
-baN
-mdd
-dFp
-oon
-pBJ
-xrN
+nuO
+oJl
+nuO
+wlQ
+xke
+xke
+oSt
+xke
+xke
+fsz
+aEk
 rqj
 aEk
 ayb
@@ -67331,61 +66437,61 @@ gfQ
 gfQ
 gfQ
 gfQ
-xAV
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
 gfQ
 yin
-aic
-ajo
-rkL
-ygB
-ygB
-ygB
-ygB
-ygB
-apB
-ygB
-uCB
-xlD
-ygB
-ygB
-ygB
-ygB
-ygB
-aJj
-uCB
-aKa
-aOm
-aOm
-vnK
-nCW
-sfI
-aZH
-bbA
-bcN
-bxW
+yin
+yin
+yin
+yin
+yin
+yin
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+aUP
+pVH
+aUP
+xVV
+xke
+xke
+xke
+xke
+azA
+bez
 bcZ
-eEi
-fDa
-gbh
-dOr
-uIx
-bdS
-fFH
-bex
+gyC
+cXi
+oZu
+cXi
+sfI
+rYZ
+rYZ
+bcN
+tRl
+rYZ
+rYZ
+tjH
+bcZ
+oOk
+oOk
+nuO
+nuO
+oOk
 hUo
-iJf
-xrN
-kNU
-meM
-nhE
-oon
-pBK
-xrN
+wlQ
+hGX
+xke
+omc
+fRl
+xke
+fsz
+aEk
 rqL
 aEk
 ayb
@@ -67593,56 +66699,56 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
-yin
-jxE
-ajt
-vNQ
-alN
-alG
-alY
-pwd
-pwd
-aoH
-pwd
-arx
-xyS
-afE
-xyS
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+aUP
+gfQ
+gfQ
+gfQ
+gfQ
 avT
-xyS
-ayH
-aMl
-aDV
-ygB
-aQo
-aOm
-vnK
-aXt
-aTt
-aZH
-bbC
+fRl
+xke
+azA
+bez
+xIr
+bcZ
+bcZ
+bcZ
+bcZ
+bcZ
+bcZ
+bcZ
 bhG
 bzj
-vnK
-cqC
-fDa
-gbh
-wzT
-gbh
-gbh
-fGp
-gbh
-gbh
-gbh
-xrN
-kOo
+bcZ
+bcZ
+bcZ
+xIr
+eKb
+eKb
+hOO
+eKb
+eKb
+wlQ
+wlQ
+xke
+xke
 mhV
 niD
-jbs
-pCi
-xrN
+xke
+fsz
+aEk
 rqj
 aEk
 ayb
@@ -67835,7 +66941,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
+mfS
 gfQ
 gfQ
 gfQ
@@ -67850,56 +66956,56 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-fsz
-yin
-yin
-yin
-yin
-yin
-xlD
-asl
-asf
-xlD
-asl
-asP
-arz
-xlD
-yhG
-uDr
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+aUP
+sTT
+gfQ
+gfQ
+gfQ
 avV
-uDr
-yhG
-oaz
-avV
-xke
-xke
-xke
-vnK
-vnK
-vnK
-aZI
-bbO
-vnK
-vnK
-bTF
-crc
+veT
+gny
+azA
+bez
+bez
+bez
+bez
+bez
+bez
+bez
+bez
+bez
+tPP
+vJy
+bez
+bez
 cXp
 bfv
-dOP
+bfv
 bfv
 bfv
 bfv
 bfv
 bfv
 pPg
-xrN
-kPg
+xke
+xke
 avw
-aTd
-aTd
-xrN
-xrN
+xke
+xke
+xke
+aEk
 rqL
 aEk
 ayb
@@ -68113,50 +67219,50 @@ gfQ
 gfQ
 gfQ
 gfQ
-yin
-ygB
-amc
-ygB
-ygB
-pgr
-ygB
-aUK
-auR
-ygB
-gQU
-aUK
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+aUP
+gfQ
+gfQ
+gfQ
+gfQ
+avT
 ayo
-yin
-azN
-xlD
 xke
-aRc
-aRc
-saL
-jzL
-jzL
-jzL
-bca
-biB
-jzL
-jzL
-eEi
+azD
+bez
+bez
+bez
+bez
+bez
+bez
+bez
+bez
+bez
+tPP
+vJy
+bez
+bez
 bpv
 bez
-xof
 bez
 bez
 bez
 bez
 bez
-tPP
 bez
 tPP
-xof
+nQs
+bez
+bez
 bez
 bez
 xke
-vQo
+waV
 rqj
 aEk
 wVb
@@ -68369,46 +67475,46 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-yin
-ajw
-alX
-ygB
-ajw
-aan
-yin
-yin
-yin
-uRW
-yhG
-yhG
-yhG
-yin
-oaz
-ruf
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+aUP
+aUP
+aUP
+xVV
 xke
-ahL
-ciu
-wej
-bez
+xke
+xke
+xke
+azA
+ymh
+ymh
+ymh
+ymh
+ymh
+ymh
 aYR
-xFu
 deM
-xFu
-xFu
-xFu
 deM
-bdW
-xFu
-boP
+ihf
+olZ
+mik
+mik
+mik
+mik
+mik
 emM
-bdW
-xFu
-xFu
-xFu
+mik
+mik
+mik
+mik
 dPY
 xFu
-kPs
+mik
 mik
 niR
 oqE
@@ -68627,38 +67733,38 @@ gfQ
 fsz
 gfQ
 gfQ
-yin
-alK
-aHY
-ygB
-scS
-ajc
-yin
-gfQ
-fsz
 gfQ
 gfQ
-fsz
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 yfx
-yin
-oaz
-xlD
 xke
-aRK
-aUH
-saL
+bbR
+xke
+xke
+xke
+xke
+xke
 bez
 sHE
 aZJ
-iMd
-iMd
-iMd
-iMd
+jdC
+gbh
+gbh
+gbh
 ctz
-ant
-dnd
-uGT
-enS
+gbh
+gbh
+jdC
+jdC
 bdX
 iMd
 iMd
@@ -68670,7 +67776,7 @@ iMd
 nkv
 osb
 xke
-vQo
+waV
 rrb
 lxT
 cGO
@@ -68884,38 +67990,38 @@ fsz
 fsz
 gfQ
 gfQ
-yin
-yin
-yin
-yin
-yin
-yin
-yin
-gfQ
-fsz
 gfQ
 gfQ
-fsz
 gfQ
-yin
-azX
-yin
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 xke
-xke
-xke
+ciu
+ciu
+ocz
+ciu
+ciu
 vQo
-aXE
+bez
 sHE
 kcR
-bcb
+gbh
 tqr
-bzo
-bTT
-xke
-bAe
-dom
+uIx
+uIx
+uIx
+uIx
+uIx
 akz
-xke
+jdC
 xke
 xke
 xke
@@ -68928,7 +68034,7 @@ nmm
 xke
 xke
 aEZ
-waV
+wFw
 sRp
 tQd
 wFw
@@ -69142,37 +68248,37 @@ fsz
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
 gfQ
 gfQ
-fsz
 gfQ
 gfQ
-fsz
-fsz
-fsz
-fsz
 gfQ
-yin
-bbH
-aEz
-aKn
-bbN
-ygB
-aVZ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+xke
+ciu
+ciu
+ciu
+ciu
+ciu
+vQo
 bez
 sHE
 kcR
-bcd
+gbh
 biP
-bzZ
-bVy
-xke
-aDn
-xMu
+uIx
+uIx
+uIx
+uIx
+uIx
 fxF
-xke
+jdC
 bdZ
 fMK
 waV
@@ -69386,50 +68492,50 @@ xZv
 tFc
 xZv
 gfQ
-xZv
-tFc
-xZv
+eTS
+vET
+eTS
 gfQ
-xZv
-tFc
-xZv
-gfQ
-fsz
-gfQ
-gfQ
-gfQ
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-gfQ
+eTS
+vET
+eTS
 gfQ
 fsz
 gfQ
-yin
-aJk
-aLR
-aLR
-aOn
-ygB
-aTI
-bez
-bbF
-msM
-bce
-biU
-bAi
-aRE
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 xke
-wWd
-xMu
 ciu
-xke
+aRc
+aRc
+ciu
+ciu
+vQo
+bez
+sHE
+kcR
+ctz
+uIx
+uIx
+aRE
+bdS
+wWd
+uIx
+bqY
+jdC
 bea
 fRw
 beE
@@ -69643,13 +68749,13 @@ xZv
 tFc
 xZv
 gfQ
-xZv
-tFc
-xZv
+eTS
+vET
+eTS
 gfQ
-xZv
-tFc
-xZv
+eTS
+vET
+eTS
 rpu
 fsz
 fsz
@@ -69668,25 +68774,25 @@ gfQ
 gfQ
 gfQ
 gfQ
-yin
+xke
 nTo
 bbK
 jYP
-bbP
+ciu
+ciu
 bbR
-aVZ
 bez
-bbI
-lrX
-bcf
-bku
-bBs
-bku
-xke
-rPv
-rPv
-rPv
-vQo
+sHE
+kcR
+gbh
+uIx
+uIx
+jdC
+bRx
+ibb
+bRx
+jdC
+jdC
 beb
 kKw
 kKw
@@ -69925,20 +69031,20 @@ gfQ
 gfQ
 gfQ
 gfQ
-yin
-aye
-jfI
-jfI
-aye
-ygB
-aWo
+xke
+ciu
+aRK
+aRK
+ciu
+ciu
+vQo
 bez
 sHE
 aZK
-xke
-xke
-xke
-xke
+gbh
+uIx
+uIx
+bRx
 cwE
 axU
 dpX
@@ -70182,20 +69288,20 @@ gfQ
 gfQ
 gfQ
 gfQ
-yin
-aye
-aye
-aye
+xke
+ciu
+ciu
+ciu
 aRL
-ygB
-aVZ
+ciu
+vQo
 bez
-bbI
-nqn
-pGp
-bkx
-wWd
-rPv
+sHE
+kcR
+jdC
+iJf
+vYY
+bRx
 lVS
 vYu
 vYu
@@ -70439,8 +69545,8 @@ xyp
 xyp
 xyp
 xyp
-yin
-yin
+xke
+xke
 xke
 xke
 xke
@@ -70448,11 +69554,11 @@ xke
 xke
 aXK
 sHE
-lNN
-qsT
-xMu
-xMu
-rPv
+kcR
+jdC
+gbh
+gbh
+jdC
 cyQ
 vYu
 vYu
@@ -70704,12 +69810,12 @@ aSR
 kIP
 xke
 aXM
-xPV
-mnh
+sHE
+kcR
 huR
-bky
-ciu
-rPv
+fDa
+fDa
+rcx
 lVS
 vYu
 tVR
@@ -70962,11 +70068,11 @@ aUJ
 aWp
 aXR
 aYS
-aZL
-xke
-xke
-xke
-xke
+kcR
+vHv
+uXU
+gQW
+vHv
 cAB
 vYu
 ofq
@@ -71217,16 +70323,16 @@ lVd
 aTn
 aUL
 xke
-bez
+sBt
 bbI
 nqn
 pGp
-bkH
-ciu
-rPv
-lVS
-vYu
-vtk
+nWH
+nWH
+hej
+fKk
+dpz
+wzD
 tIA
 rEE
 vJh
@@ -71475,15 +70581,15 @@ xke
 xke
 xke
 aYc
-sHE
-lNN
-bcg
-xMu
-xMu
-rPv
+asr
+kcR
+xke
+vHv
+vHv
+xke
 cyQ
 vYu
-vtk
+uqd
 tIA
 mmn
 vJh
@@ -71734,13 +70840,13 @@ xke
 sBt
 xPV
 mnh
-huR
+ecm
 bkL
-wWd
-rPv
-lVS
+xMu
+eCf
+hWW
 vYu
-vtk
+uqd
 tIA
 iVw
 ePA
@@ -71989,15 +71095,15 @@ uJa
 foq
 xke
 aYn
-xPV
+asr
 bAP
-vQo
 xke
-xke
-xke
-vQo
-cXv
-vtk
+pWR
+hLe
+eCf
+cBP
+vYu
+uqd
 dPE
 kKw
 kKw
@@ -72246,14 +71352,14 @@ uJa
 xyp
 xke
 baz
-qnl
-fyi
-oOq
-sIk
-nvE
-bVH
-cAF
-dla
+asr
+kcR
+xke
+rPv
+rPv
+xke
+cBP
+vYu
 dqN
 bwn
 euy
@@ -72503,31 +71609,31 @@ uJa
 aUV
 xke
 aYB
-tPP
-kcR
-saL
-lnx
-bCo
-saL
+xPV
+mnh
+ecm
+bkL
+xMu
+eCf
 cBP
 vYu
 drd
 xyI
 kEt
-xyI
-xyI
-xyI
+dcN
+dcN
+dcN
 orB
-xyI
-xyI
-xyI
-xyI
-xyI
-xyI
+dcN
+dcN
+dcN
+dcN
+dcN
+dcN
 pKh
-xyI
-xyI
-xyI
+dcN
+dcN
+dcN
 orB
 kEt
 xyI
@@ -72760,14 +71866,14 @@ lDb
 nrT
 xke
 xke
-aYT
+asr
 aZM
-bch
+xke
+pWR
 ble
-ble
-bWO
-cDi
-pLL
+eCf
+cBP
+vYu
 drZ
 vYu
 xct
@@ -73017,12 +72123,12 @@ uJa
 uJa
 lSd
 xke
-bez
+asr
 kcR
-vQo
-aaz
-aaB
-bYw
+xke
+rPv
+rPv
+xke
 cBP
 vYu
 aaG
@@ -73274,12 +72380,12 @@ sVb
 sVb
 sVb
 xke
-bez
-kcR
-saL
-blN
-bCu
-ilC
+vVw
+mnh
+ecm
+bkL
+xMu
+eCf
 cBP
 vYu
 aaH
@@ -73532,14 +72638,14 @@ cTO
 aWq
 xke
 wrw
-kcR
-acZ
-blW
+vXt
+xke
+pWR
 bES
-caY
+eCf
 cDU
 cYt
-aby
+fjv
 vYu
 xok
 ePQ
@@ -91094,7 +90200,7 @@ gfQ
 idc
 rUF
 uhX
-uhX
+onc
 uhX
 ljV
 idc

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -60,6 +60,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aaH" = (
@@ -77,6 +83,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aaL" = (
@@ -586,7 +598,7 @@
 /area/chapel/main)
 "adJ" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals North - West";
+	c_tag = "Arrivals North - East";
 	dir = 8
 	},
 /obj/structure/sign/warning/pods{
@@ -679,11 +691,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aeo" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/landmark/carpspawn,
-/turf/open/floor/plasteel/airless,
-/area/space/nearstation)
 "aep" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden,
@@ -1946,7 +1953,7 @@
 /area/maintenance/fore)
 "amK" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals North - East";
+	c_tag = "Arrivals North - West";
 	dir = 4
 	},
 /obj/structure/sign/warning/pods{
@@ -1972,6 +1979,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"amO" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Evidence Storage";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "amP" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
@@ -3392,8 +3408,8 @@
 	pixel_y = 24
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "awW" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -3729,10 +3745,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Brig Prison Hallway North";
-	network = list("ss13","prison")
-	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
 	req_access_txt = "2"
@@ -3763,6 +3775,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Prison Hallway North East";
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -3813,19 +3829,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aAb" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
 "aAc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aAi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aAm" = (
@@ -4110,11 +4127,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"aCo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aCs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -4894,22 +4906,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/hydroponics)
-"aKq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aKu" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -4987,13 +4983,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
-"aLf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aLi" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -5032,16 +5021,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/fore)
-"aLI" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aLJ" = (
 /obj/structure/table/wood/fancy/red,
 /turf/open/floor/carpet/red,
@@ -5103,6 +5082,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/fitness)
+"aMA" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/brig)
 "aMJ" = (
 /obj/machinery/door/airlock{
 	id_tag = "FitnessShower";
@@ -5752,10 +5737,7 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "aRc" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/grimy,
 /area/security/brig)
 "aRd" = (
 /obj/structure/table,
@@ -5847,19 +5829,25 @@
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "aRK" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/requests_console{
+	department = "Detective's office";
+	name = "Detective Office RC";
+	pixel_x = -32
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "aRL" = (
-/obj/machinery/camera{
-	c_tag = "Brig Interrogation";
-	dir = 8;
-	network = list("interrogation")
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
 	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
+/obj/structure/cable,
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "aRW" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -6272,17 +6260,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aUJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aUK" = (
 /obj/structure/table,
 /turf/open/floor/plasteel,
@@ -6509,15 +6486,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"aWp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/security/glass{
-	name = "Evidence Storage";
-	req_access_txt = "63"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aWq" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plasteel/sepia,
@@ -6679,13 +6647,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/sepia,
 /area/chapel/office)
-"aXK" = (
-/obj/machinery/camera{
-	c_tag = "Security Hallway North";
-	network = list("ss13","prison")
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aXM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -6711,11 +6672,6 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/chapel/main)
-"aXR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aXT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -6738,9 +6694,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aYc" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aYe" = (
@@ -6902,15 +6857,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aYS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aYU" = (
@@ -7224,6 +7170,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "baA" = (
@@ -7340,11 +7289,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"bbK" = (
-/obj/structure/table/reinforced,
-/obj/item/flashlight/lamp,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bbP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -7367,9 +7311,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "bbY" = (
@@ -8135,10 +8076,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bhF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
+/obj/effect/loot_site_spawner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bhG" = (
@@ -8263,13 +8205,6 @@
 "biF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"biG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -9331,6 +9266,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
+"bwh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Prison Hallway North West";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bwn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -9924,6 +9873,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"bTw" = (
+/obj/machinery/camera{
+	c_tag = "Security Cells West";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bUm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
@@ -10488,6 +10444,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
+"cly" = (
+/turf/closed/wall/r_wall,
+/area/security/detectives_office)
 "clA" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -10701,6 +10660,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "Hydrophonics Backroom";
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "cuz" = (
@@ -10877,6 +10840,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "cAJ" = (
@@ -10979,18 +10945,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cDU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "cEi" = (
 /obj/structure/window{
 	dir = 4
@@ -11222,6 +11176,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"cPT" = (
+/obj/structure/closet/secure_closet/detective,
+/obj/machinery/camera{
+	c_tag = "Detective Office"
+	},
+/obj/item/book/manual/wiki/detective,
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "cQk" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
@@ -11463,8 +11425,11 @@
 /area/ai_monitored/storage/eva)
 "cWP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
 /turf/open/floor/carpet/orange,
-/area/security/detectives_office)
+/area/vacant_room/office)
 "cWV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -11532,15 +11497,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/quartermaster/office)
-"cYt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "cYy" = (
 /obj/machinery/light{
 	dir = 1
@@ -11803,6 +11759,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/camera{
+	c_tag = "Security Central";
+	dir = 8;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dfj" = (
@@ -12130,6 +12091,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "dqR" = (
@@ -12176,6 +12143,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "drj" = (
@@ -12198,6 +12171,12 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12354,6 +12333,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"dwf" = (
+/obj/structure/table/wood,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/orange,
+/area/security/detectives_office)
 "dwt" = (
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
@@ -13261,6 +13251,10 @@
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
+/obj/machinery/camera{
+	c_tag = "Arrivals Middle - West";
+	dir = 8
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -13308,6 +13302,9 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"dPi" = (
+/turf/open/floor/carpet/orange,
+/area/security/detectives_office)
 "dPn" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating{
@@ -13953,10 +13950,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"eiS" = (
-/obj/machinery/flasher/portable,
-/turf/open/space/basic,
-/area/space)
 "ejv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -14010,6 +14003,10 @@
 /obj/item/pen/red,
 /turf/open/floor/carpet/orange,
 /area/lawoffice)
+"elI" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel/grimy,
+/area/security/brig)
 "elJ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -14134,6 +14131,10 @@
 "eqU" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
+	},
+/obj/machinery/camera{
+	c_tag = "Arrivals Middle East";
+	dir = 4
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 8
@@ -15218,6 +15219,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"eYe" = (
+/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/light_switch{
+	pixel_x = -20;
+	pixel_y = 11
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "eYG" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -15521,6 +15531,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"ffN" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet/orange,
+/area/vacant_room/office)
 "ffT" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -15981,6 +15996,15 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fri" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "frl" = (
 /obj/structure/closet/l3closet,
 /turf/open/floor/plasteel/white,
@@ -17162,17 +17186,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "fZM" = (
-/obj/structure/closet/secure_closet/detective,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/camera{
-	c_tag = "Detective Office"
-	},
-/obj/item/book/manual/wiki/detective,
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "fZN" = (
 /obj/item/banner/cargo/mundane,
 /turf/open/floor/plating,
@@ -17514,14 +17534,6 @@
 	dir = 9
 	},
 /area/hallway/secondary/entry)
-"gjd" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	name = "detective sorting disposal pipe";
-	sortType = 30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "gjj" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -17623,11 +17635,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/obj/structure/chair{
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/floor/carpet/orange,
-/area/security/detectives_office)
+/area/vacant_room/office)
 "gnl" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -17734,6 +17746,11 @@
 "gpV" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/l3closet/security,
+/obj/machinery/camera{
+	c_tag = "Security Briefing Room North";
+	dir = 4;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "gqf" = (
@@ -17758,6 +17775,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"gqW" = (
+/obj/machinery/door/airlock/security{
+	name = "Detective's Office";
+	req_access_txt = "4"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "gqX" = (
 /obj/item/paint/anycolor,
 /turf/open/floor/plating,
@@ -18302,6 +18331,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"gGM" = (
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
+/area/security/detectives_office)
 "gGT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -19791,6 +19826,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/captain)
+"hBf" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	name = "det sorting disposal pipe";
+	sortType = 30
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "hBg" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -20308,6 +20354,10 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
+/obj/machinery/camera{
+	c_tag = "Aux Base Construction";
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "hUo" = (
@@ -20696,6 +20746,14 @@
 /obj/machinery/griddle,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"igv" = (
+/obj/machinery/camera{
+	c_tag = "Brig Interrogation";
+	dir = 8;
+	network = list("interrogation")
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/brig)
 "ihf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
@@ -20942,6 +21000,20 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psychology)
+"ipo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Medbay South Hallway";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "ips" = (
 /obj/machinery/meter{
 	name = "External Ports Gas Meter"
@@ -20971,6 +21043,20 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"iqq" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/evidence,
+/obj/item/hand_labeler{
+	pixel_x = 5
+	},
+/obj/item/camera/detective,
+/obj/machinery/requests_console{
+	department = "Detective's office";
+	name = "Detective Office RC";
+	pixel_y = 30
+	},
+/turf/open/floor/carpet/orange,
+/area/security/detectives_office)
 "irD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21923,6 +22009,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/medical/pharmacy)
+"iYx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iYB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -21944,8 +22040,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "iZm" = (
 /obj/machinery/turretid{
 	icon_state = "control_stun";
@@ -22100,10 +22196,13 @@
 /area/crew_quarters/heads/captain)
 "jdA" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/whiskey,
-/obj/item/lighter,
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/folder/blue,
 /turf/open/floor/carpet/orange,
-/area/security/detectives_office)
+/area/vacant_room/office)
 "jdB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -22194,6 +22293,11 @@
 /obj/structure/sign/poster/official/obey{
 	pixel_x = 30
 	},
+/obj/machinery/camera{
+	c_tag = "Permabrig Garden";
+	name = "Perma Camera";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "jig" = (
@@ -22230,6 +22334,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"jjA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/camera{
+	c_tag = "Security Armory Exterior";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jjB" = (
 /obj/structure/window{
 	dir = 1
@@ -22343,6 +22459,20 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"jna" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Security Cells East";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jnm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -23081,11 +23211,10 @@
 /turf/open/floor/plasteel,
 /area/storage/tech)
 "jLJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Detective Maintenance";
-	req_access_txt = "4"
-	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "jLN" = (
@@ -23499,6 +23628,13 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/bridge)
+"jYu" = (
+/obj/machinery/camera/motion{
+	c_tag = "Armory External";
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "jYJ" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Treatment Center";
@@ -23518,10 +23654,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"jYP" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "jYX" = (
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Control"
@@ -23566,6 +23698,29 @@
 "kbB" = (
 /turf/open/floor/carpet/black,
 /area/maintenance/starboard/aft)
+"kbG" = (
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/machinery/button/door{
+	id = "kanyewest";
+	name = "Privacy Shutters";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/turf/open/floor/carpet/orange,
+/area/security/detectives_office)
+"kce" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/item/storage/secure/safe{
+	pixel_x = -23;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "kcB" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -23824,6 +23979,10 @@
 	},
 /obj/item/radio/intercom{
 	pixel_y = 25
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay North Hallway";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -24197,6 +24356,9 @@
 /area/science/robotics/mechbay)
 "kuM" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Cargo Warehouse"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "kva" = (
@@ -24221,13 +24383,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/airlock/security{
-	name = "Detective's Office";
-	req_access_txt = "4"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/grunge{
+	name = "Vacant Office"
+	},
 /turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/area/vacant_room/office)
 "kvM" = (
 /obj/structure/closet/emcloset,
 /obj/structure/extinguisher_cabinet{
@@ -24347,6 +24508,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"kyx" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/orange,
+/area/vacant_room/office)
 "kyH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24476,6 +24641,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"kDO" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kDS" = (
 /obj/machinery/light{
 	dir = 1
@@ -25211,6 +25387,10 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"lcn" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/grimy,
+/area/security/brig)
 "lcu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -25248,6 +25428,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"ldw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "leo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -25393,6 +25579,12 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"lie" = (
+/obj/machinery/computer/med_data{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
+/area/security/detectives_office)
 "liK" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -25863,7 +26055,7 @@
 	network = list("mine","auxbase","vault","qm")
 	},
 /obj/machinery/camera{
-	c_tag = "Quartermaster's Office";
+	c_tag = "Cargo Quartermaster's Office";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26283,6 +26475,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"lKO" = (
+/obj/machinery/camera{
+	c_tag = "Security Visitation";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "lLh" = (
 /obj/machinery/light{
 	dir = 8
@@ -26555,6 +26755,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"lRx" = (
+/obj/machinery/camera{
+	c_tag = "Mining Dock East";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
 "lRA" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/light{
@@ -27422,6 +27629,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"mqm" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/camera{
+	c_tag = "Security Hall South";
+	dir = 8;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mqn" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "misclab";
@@ -27606,6 +27825,17 @@
 "mwJ" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/engineering)
+"mwO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "mwP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -27990,6 +28220,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/button/door{
+	id = "kanyeeast";
+	name = "Privacy Shutters";
+	pixel_x = -24;
+	pixel_y = 24
+	},
 /turf/open/floor/carpet/orange,
 /area/lawoffice)
 "mKA" = (
@@ -28005,6 +28241,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mKN" = (
+/obj/structure/chair/comfy/brown,
+/obj/effect/landmark/start/detective,
+/turf/open/floor/carpet/orange,
+/area/security/detectives_office)
 "mKV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
@@ -29191,11 +29432,8 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "nuz" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
@@ -29580,6 +29818,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"nGv" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/detective,
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "nGL" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
@@ -29663,9 +29908,8 @@
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/landmark/start/detective,
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "nJW" = (
 /obj/machinery/camera{
 	c_tag = "Permabrig Laundry";
@@ -29946,12 +30190,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"nTo" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "nTr" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -30147,7 +30385,7 @@
 /area/security/main)
 "nXT" = (
 /obj/machinery/camera{
-	c_tag = "Mining Dock";
+	c_tag = "Mining Dock West";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30349,11 +30587,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ocz" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/reinforced,
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/grimy,
 /area/security/brig)
 "ocJ" = (
 /obj/structure/disposalpipe/segment{
@@ -30420,6 +30656,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -30605,6 +30847,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"olN" = (
+/obj/machinery/camera{
+	c_tag = "Warden's Office";
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "olU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -30661,6 +30910,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"omx" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "omI" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
@@ -30729,6 +30984,11 @@
 /area/engine/engineering)
 "ooP" = (
 /obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior Access West";
+	dir = 1;
+	network = list("minisat")
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/bridge)
 "ooZ" = (
@@ -32299,6 +32559,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"pnf" = (
+/obj/machinery/newscaster{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "png" = (
 /obj/machinery/button/door{
 	id = "rnd2";
@@ -33358,19 +33624,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "pWg" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
-/obj/effect/landmark/start/detective,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
 	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/carpet/orange,
-/area/security/detectives_office)
+/area/vacant_room/office)
 "pWw" = (
 /obj/structure/cable/layer1,
 /turf/open/floor/plasteel/dark/telecomms,
@@ -34160,17 +34424,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "qvd" = (
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
 /obj/item/storage/secure/safe{
 	pixel_x = -23
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/obj/machinery/photocopier,
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "qve" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -36175,9 +36434,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"rJM" = (
+"rJa" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/structure/chair,
 /turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/area/security/brig)
 "rKi" = (
 /obj/machinery/door/airlock/external{
 	name = "Tcoms External Access";
@@ -36298,6 +36562,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"rNk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "rNp" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/door/window/eastleft{
@@ -36466,6 +36737,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rSZ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "rTM" = (
 /obj/machinery/door/airlock/research/glass{
 	req_access_txt = "29"
@@ -36559,15 +36846,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
-"rWm" = (
-/obj/machinery/camera{
-	c_tag = "Permabrig Exterior Kitchen";
-	dir = 1;
-	name = "Perma Camera";
-	network = list("ss13","prison")
-	},
-/turf/open/space/basic,
-/area/space)
 "rWs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36985,16 +37263,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/bridge)
-"shs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "shF" = (
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -38519,6 +38787,14 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"sXu" = (
+/obj/machinery/camera{
+	c_tag = "Security Armory";
+	dir = 4;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "sXv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel/white,
@@ -39119,11 +39395,8 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "toN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -39163,13 +39436,8 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/detectives_office)
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "tqP" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -40452,7 +40720,11 @@
 	},
 /area/maintenance/central)
 "udk" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kanyeeast";
+	name = "privacy shutters"
+	},
 /turf/open/floor/plating,
 /area/lawoffice)
 "udr" = (
@@ -40939,6 +41211,12 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42529,11 +42807,11 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "vlz" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
+/obj/item/radio/intercom{
+	pixel_x = 29
 	},
 /turf/open/floor/carpet/orange,
-/area/security/detectives_office)
+/area/vacant_room/office)
 "vlD" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
@@ -42764,7 +43042,7 @@
 /area/medical/chemistry)
 "vqs" = (
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior Access";
+	c_tag = "MiniSat Exterior Access - East";
 	dir = 1;
 	network = list("minisat")
 	},
@@ -43068,6 +43346,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
+"vwg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "vwh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43299,11 +43583,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "vBY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/closed/wall,
-/area/security/detectives_office)
+/area/vacant_room/office)
 "vCn" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
@@ -43420,6 +43701,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"vEB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "vEG" = (
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/plasteel/showroomfloor,
@@ -44994,6 +45282,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "wzM" = (
@@ -45277,6 +45571,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"wHJ" = (
+/obj/machinery/camera{
+	c_tag = "Security Briefing Room South";
+	dir = 1;
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "wHS" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -45857,20 +46159,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"wWY" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/evidence,
-/obj/item/hand_labeler{
-	pixel_x = 5
-	},
-/obj/item/camera/detective,
-/obj/machinery/requests_console{
-	department = "Detective's office";
-	name = "Detective Office RC";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
 "wXl" = (
 /turf/closed/wall,
 /area/library)
@@ -45982,8 +46270,8 @@
 /area/bridge)
 "xaC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "xaE" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -46055,6 +46343,14 @@
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"xbX" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
 "xch" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -47763,7 +48059,7 @@
 "xXF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/carpet/orange,
-/area/security/detectives_office)
+/area/vacant_room/office)
 "xXQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -47805,10 +48101,12 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/maintenance/solars/port/fore)
 "xZz" = (
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen,
 /turf/open/floor/carpet/orange,
-/area/security/detectives_office)
+/area/vacant_room/office)
 "yaj" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Foyer";
@@ -48259,14 +48557,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "yiA" = (
-/obj/machinery/computer/med_data{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
+/turf/open/floor/wood,
+/area/vacant_room/office)
 "yiI" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -57768,14 +58060,14 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
-gfQ
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
 gfQ
 gfQ
 gfQ
@@ -58531,11 +58823,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+sHc
+sHc
+sHc
+sHc
+sHc
 fsz
 fsz
 gfQ
@@ -58788,9 +59080,9 @@ gfQ
 gfQ
 gfQ
 gfQ
+sHc
 gfQ
-gfQ
-gfQ
+fsz
 gfQ
 gfQ
 fsz
@@ -59047,7 +59339,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 fsz
@@ -59557,7 +59849,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 gfQ
@@ -59814,8 +60106,8 @@ gfQ
 xAV
 gfQ
 gfQ
-gfQ
-gfQ
+sHc
+fsz
 fsz
 gfQ
 yhG
@@ -60071,7 +60363,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 gfQ
@@ -60328,7 +60620,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 fsz
@@ -60585,7 +60877,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 gfQ
@@ -60842,8 +61134,8 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+sHc
+fsz
 fsz
 iwb
 uRW
@@ -61099,7 +61391,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 gfQ
@@ -62125,7 +62417,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 gfQ
@@ -62382,8 +62674,8 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+sHc
+fsz
 fsz
 fsz
 fsz
@@ -62639,7 +62931,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 gfQ
@@ -62896,7 +63188,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 gfQ
@@ -63153,7 +63445,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 gfQ
@@ -63410,8 +63702,8 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+sHc
+fsz
 fsz
 fsz
 fsz
@@ -63667,7 +63959,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 gfQ
@@ -64186,7 +64478,7 @@ gfQ
 fsz
 fsz
 fsz
-rWm
+fsz
 uRW
 yin
 yin
@@ -64215,9 +64507,9 @@ nPs
 oHK
 mRd
 hmb
-ciu
+lKO
 xke
-dux
+bwh
 ugW
 aJq
 nCq
@@ -64442,8 +64734,8 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-fsz
+sHc
+gfQ
 fsz
 gfQ
 yhG
@@ -64491,7 +64783,7 @@ vEs
 xrN
 gfQ
 gfQ
-eiS
+gfQ
 gfQ
 gfQ
 gfQ
@@ -64699,7 +64991,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 gfQ
@@ -64749,7 +65041,7 @@ xrN
 xIr
 gfQ
 gfQ
-gfQ
+jYu
 gfQ
 gfQ
 gfQ
@@ -64956,8 +65248,8 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+sHc
+fsz
 fsz
 gfQ
 uRW
@@ -65213,7 +65505,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 fsz
@@ -65470,8 +65762,8 @@ gfQ
 xAV
 gfQ
 gfQ
-gfQ
-gfQ
+sHc
+fsz
 fsz
 gfQ
 yin
@@ -65516,10 +65808,10 @@ uwj
 pwV
 vnK
 cXi
-cXi
+wHJ
 xIr
 nuO
-nuO
+sXu
 nuO
 nuO
 nuO
@@ -65727,7 +66019,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 gfQ
@@ -65984,7 +66276,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+sHc
 gfQ
 fsz
 fsz
@@ -66244,7 +66536,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -66500,11 +66792,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+sHc
+sHc
+sHc
+sHc
+sHc
 fsz
 yin
 pls
@@ -68088,7 +68380,7 @@ ndz
 bxg
 ndz
 dcP
-ndz
+jjA
 emM
 feI
 jhM
@@ -68354,7 +68646,7 @@ iMd
 klF
 enS
 xxu
-iMd
+mqm
 nkv
 osb
 xke
@@ -68587,17 +68879,17 @@ gfQ
 gfQ
 xke
 ciu
-ciu
+rJa
 ocz
+aMA
 ciu
-ciu
-vQo
+bbR
 bez
 sHE
 kcR
 gbh
 tqr
-uIx
+olN
 uIx
 iVV
 uIx
@@ -68844,9 +69136,9 @@ gfQ
 gfQ
 xke
 ciu
-ciu
-ciu
-ciu
+elI
+lcn
+aMA
 ciu
 vQo
 aYB
@@ -69101,8 +69393,8 @@ gfQ
 gfQ
 xke
 ciu
-ciu
 aRc
+igv
 aRc
 ciu
 vQo
@@ -69356,13 +69648,13 @@ gfQ
 gfQ
 gfQ
 gfQ
-xke
-nTo
-ciu
-bbK
-jYP
-ciu
-bbR
+cly
+xvP
+xvP
+xvP
+xvP
+xvP
+xvP
 bez
 sHE
 kcR
@@ -69613,13 +69905,13 @@ gfQ
 gfQ
 gfQ
 gfQ
-xke
-ciu
-ciu
+cly
+cPT
+kce
+eYe
 aRK
-aRK
-ciu
-vQo
+pnf
+gZr
 bez
 cUY
 aZK
@@ -69870,15 +70162,15 @@ gfQ
 gfQ
 gfQ
 gfQ
-xke
-ciu
-ciu
-ciu
+cly
+iqq
+dPi
+xYt
 aRL
-ciu
-vQo
-bez
-sHE
+fri
+gqW
+vEB
+hBf
 kcR
 jdC
 iJf
@@ -70127,14 +70419,14 @@ xyp
 xyp
 xyp
 xyp
-xke
-xke
-xke
-xke
-xke
-xke
-xke
-aXK
+cly
+kbG
+mKN
+bSQ
+nGv
+vwg
+gZr
+bez
 sHE
 kcR
 jdC
@@ -70384,14 +70676,14 @@ rIH
 rIH
 uJa
 adu
-uJa
-aAa
-xke
-kIP
-aSR
-kIP
-xke
-aXM
+cly
+lie
+gGM
+dwf
+omx
+xbX
+xvP
+bTw
 sHE
 kcR
 huR
@@ -70644,19 +70936,19 @@ xyp
 uJa
 aAb
 xke
-aKq
-shs
-aUJ
-aWp
-aXR
-aYS
+xke
+xke
+xke
+xke
+aXM
+sHE
 kcR
 vHv
 uXU
 gQW
 vHv
 cAB
-vYu
+axU
 ofq
 olI
 lJW
@@ -70899,13 +71191,13 @@ ouv
 avZ
 xyp
 uJa
-bxZ
+aAa
 xke
-lVd
-aTn
-aUL
+kIP
+aSR
+kIP
 xke
-sBt
+bez
 bbI
 nqn
 pGp
@@ -71158,12 +71450,12 @@ xyp
 uJa
 aAc
 xke
-xke
-xke
-xke
-xke
+rSZ
+iYx
+kDO
+amO
 aYc
-asr
+ldw
 kcR
 xke
 vHv
@@ -71412,12 +71704,12 @@ xUQ
 avg
 nrT
 qiz
-lDb
+uJa
 aAi
-uJa
-uJa
-aTp
-aUQ
+xke
+lVd
+aTn
+aUL
 xke
 sBt
 xPV
@@ -71670,11 +71962,11 @@ ehq
 ehq
 xUQ
 xUQ
-aAm
-aCo
-aLf
-uJa
-foq
+aty
+xke
+xke
+xke
+xke
 xke
 aYn
 ngZ
@@ -71927,11 +72219,11 @@ sVb
 sVb
 sVb
 sVb
-xyp
-xyp
-aLI
-uJa
-xyp
+aAm
+rNk
+aYX
+aTp
+aUQ
 xke
 baz
 asr
@@ -71966,7 +72258,7 @@ awT
 raM
 pLL
 bgK
-gjd
+pLL
 raM
 aFQ
 oAn
@@ -72186,9 +72478,9 @@ aBP
 sVb
 lSd
 bhF
-biG
 uJa
-aUV
+uJa
+foq
 xke
 aYB
 xPV
@@ -72223,7 +72515,7 @@ xyI
 xyI
 bgz
 bgL
-aFv
+mwO
 xyI
 aFv
 xyI
@@ -72444,8 +72736,8 @@ sVb
 bhr
 biF
 uJa
-lDb
-nrT
+uJa
+aUV
 xke
 xke
 asr
@@ -72480,7 +72772,7 @@ vYu
 vYu
 vtk
 hXc
-alH
+vYu
 vYu
 alH
 vYu
@@ -72705,7 +72997,7 @@ uJa
 uJa
 lSd
 xke
-asr
+jna
 kcR
 xke
 rPv
@@ -72989,11 +73281,11 @@ wXl
 fhP
 mZF
 xGY
-xvP
-xvP
-gZr
+vBY
+vBY
+vBY
 kvt
-gZr
+vBY
 vBY
 vKj
 wwP
@@ -73225,8 +73517,8 @@ xke
 pWR
 bES
 eCf
-cDU
-cYt
+cBP
+vYu
 fjv
 vYu
 xok
@@ -73246,11 +73538,11 @@ wXl
 xtO
 ucy
 xGY
-xvP
+vBY
 fZM
-rJM
+yiA
 iZa
-rJM
+yiA
 qvd
 vKj
 mas
@@ -73503,11 +73795,11 @@ wXl
 sSZ
 mZF
 peX
-xvP
-wWY
-rJM
+vBY
+yiA
+yiA
 nJO
-rJM
+yiA
 yiA
 vKj
 hRJ
@@ -73760,7 +74052,7 @@ wXl
 xGY
 mZF
 xGY
-gZr
+vBY
 xaC
 xXF
 gnk
@@ -74017,10 +74309,10 @@ wXl
 xGY
 ucy
 xsR
-gZr
-rJM
-xYt
-bSQ
+vBY
+yiA
+ffN
+kyx
 jdA
 nuk
 vKj
@@ -74274,7 +74566,7 @@ wXl
 xtO
 mZF
 xtO
-xvP
+vBY
 awV
 xZz
 pWg
@@ -74531,12 +74823,12 @@ wXl
 xtO
 ucE
 uSb
-xvP
+vBY
 jLJ
-xvP
-xvP
-xvP
-xvP
+vBY
+vBY
+vBY
+vBY
 vKj
 vKj
 vKj
@@ -80218,7 +80510,7 @@ rEK
 iLc
 xbn
 wXv
-pSt
+lRx
 riG
 tuj
 dAn
@@ -84558,7 +84850,7 @@ vXY
 xqj
 ydT
 ygp
-jIV
+ipo
 mjV
 uAo
 shF
@@ -94508,7 +94800,7 @@ aaL
 aaw
 abw
 aaw
-aeo
+aaw
 aaw
 aaw
 aaw

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -201,29 +201,7 @@
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
-"abF" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "abK" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/central";
-	name = "Central Hall APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "abL" = (
@@ -375,20 +353,6 @@
 	},
 /turf/closed/wall,
 /area/quartermaster/sorting)
-"acq" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "packageSort2";
-	name = "mail belt"
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
 "act" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance";
@@ -461,6 +425,10 @@
 /turf/closed/wall,
 /area/quartermaster/miningdock)
 "acG" = (
+/mob/living/simple_animal/bot/mulebot{
+	home_destination = "QM #2";
+	suffix = "#2"
+	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
@@ -470,10 +438,6 @@
 	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
-	},
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #2";
-	suffix = "#2"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -576,18 +540,13 @@
 /turf/open/space/basic,
 /area/engine/atmos)
 "adA" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 4;
-	name = "Service Hall APC";
-	pixel_x = 26
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "adD" = (
@@ -1213,6 +1172,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"ahL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "ahP" = (
 /obj/structure/closet/athletic_mixed,
 /obj/machinery/camera{
@@ -1585,6 +1550,9 @@
 /obj/machinery/computer/prisoner/management{
 	dir = 1
 	},
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "akD" = (
@@ -1673,12 +1641,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "alm" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/entry";
-	name = "Entry Hall APC";
-	pixel_y = -23
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "alp" = (
@@ -2104,6 +2068,7 @@
 /area/security/prison)
 "ank" = (
 /obj/effect/landmark/start/quartermaster,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "anq" = (
@@ -2250,13 +2215,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/aft)
-"aod" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "aof" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -2348,16 +2306,12 @@
 /obj/item/radio/off{
 	pixel_y = 6
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/auxiliary";
-	name = "Security Checkpoint APC";
-	pixel_y = -23
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = -22
 	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
 "apa" = (
@@ -2634,17 +2588,9 @@
 	name = "Crematorium Maintenance";
 	req_access_txt = "27"
 	},
-/turf/open/floor/plating,
-/area/chapel/office)
-"arK" = (
-/obj/machinery/power/apc{
-	areastring = "/area/chapel/office";
-	name = "Chapel Office APC";
-	pixel_y = -23
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/maintenance/port/fore)
+/area/chapel/office)
 "arN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -2739,6 +2685,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "asi" = (
@@ -2868,12 +2815,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "asU" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/port/fore";
-	dir = 8;
-	name = "Port Bow Solar APC";
-	pixel_x = -25
-	},
 /obj/machinery/camera{
 	c_tag = "Fore Port Solar Control";
 	dir = 1
@@ -2883,6 +2824,7 @@
 	pixel_x = -20;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "asV" = (
@@ -2890,6 +2832,7 @@
 	id = "chapelgun";
 	name = "Chapel Launcher Door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/main)
 "asY" = (
@@ -3084,6 +3027,7 @@
 	name = "Law Office Maintenance";
 	req_access_txt = "38"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "auk" = (
@@ -3099,6 +3043,7 @@
 /area/ai_monitored/security/armory)
 "aul" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aum" = (
@@ -3110,12 +3055,14 @@
 	pixel_x = -11;
 	pixel_y = -20
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "aun" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/sepia,
 /area/chapel/office)
 "aup" = (
@@ -3136,15 +3083,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
-"auD" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/dorms";
-	name = "Dormitory APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "auH" = (
 /obj/structure/cable,
 /obj/machinery/light/small{
@@ -3154,12 +3092,6 @@
 /area/maintenance/fore)
 "auJ" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/fore";
-	dir = 1;
-	name = "Fore Maintenance APC";
-	pixel_y = 23
-	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -3255,6 +3187,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/plasteel/sepia,
 /area/chapel/office)
 "avy" = (
@@ -3436,6 +3370,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "awR" = (
@@ -3456,6 +3391,7 @@
 	name = "Privacy Shutters";
 	pixel_y = 24
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "awW" = (
@@ -3561,6 +3497,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "axO" = (
@@ -3623,6 +3560,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ayo" = (
@@ -3748,11 +3687,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"azk" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "azA" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -3761,6 +3695,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azD" = (
@@ -3774,6 +3714,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azF" = (
@@ -3793,6 +3739,12 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azJ" = (
@@ -3806,6 +3758,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azM" = (
@@ -3822,6 +3780,12 @@
 	pixel_y = 30
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "azS" = (
@@ -4358,6 +4322,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aFh" = (
@@ -4740,6 +4705,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "aIN" = (
@@ -4821,6 +4788,7 @@
 	icon_state = "right";
 	name = "Brig Infirmary"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aJt" = (
@@ -4873,6 +4841,7 @@
 	name = "Kitchen Maintenance";
 	req_access_txt = "28"
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/central)
 "aJZ" = (
@@ -4898,7 +4867,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"aKh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aKk" = (
+/obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "aKl" = (
@@ -4969,16 +4944,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
-"aKB" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/central";
-	dir = 1;
-	name = "Central Maintenance APC";
-	pixel_y = 23
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aKF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -5001,6 +4966,8 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aKR" = (
@@ -5085,6 +5052,10 @@
 /area/crew_quarters/dorms)
 "aLT" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "aLU" = (
@@ -5191,15 +5162,10 @@
 	},
 /area/holodeck/rec_center)
 "aNj" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/fitness";
-	dir = 8;
-	name = "Fitness Room APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "aNm" = (
@@ -5324,15 +5290,18 @@
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "aOk" = (
-/obj/machinery/power/apc/auto_name/north,
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "aOm" = (
@@ -5577,6 +5546,9 @@
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /obj/item/folder/red,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "aQa" = (
@@ -5614,6 +5586,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "aQm" = (
@@ -5933,6 +5906,11 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"aSD" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "aSE" = (
 /obj/machinery/light{
 	dir = 1
@@ -5978,7 +5956,6 @@
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/obj/item/kitchen/knife,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aTc" = (
@@ -6022,7 +5999,6 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aTv" = (
@@ -6607,17 +6583,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/hydroponics/garden";
-	dir = 4;
-	name = "Garden APC";
-	pixel_x = 26
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aWP" = (
@@ -6784,6 +6755,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aYp" = (
@@ -6910,7 +6882,6 @@
 /obj/item/clothing/ears/earmuffs{
 	pixel_y = 7
 	},
-/obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "aYQ" = (
@@ -6921,11 +6892,16 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "aYR" = (
-/obj/effect/landmark/start/security_officer,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aYS" = (
@@ -6963,13 +6939,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aYY" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/fore";
-	dir = 8;
-	name = "Fore Primary Hallway APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aZb" = (
@@ -6989,6 +6960,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aZe" = (
@@ -7002,11 +6974,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aZf" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aZh" = (
@@ -7016,6 +6990,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aZi" = (
@@ -7115,6 +7090,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aZJ" = (
@@ -7126,6 +7102,9 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -7162,16 +7141,6 @@
 	},
 /turf/open/floor/grass,
 /area/chapel/main)
-"aZP" = (
-/obj/machinery/power/apc{
-	areastring = "/area/storage/art";
-	name = "Art Storage";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "aZR" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
@@ -7188,6 +7157,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aZV" = (
@@ -7319,6 +7289,14 @@
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
+/turf/open/floor/plasteel,
+/area/security/main)
+"bbq" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/secequipment,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "bbt" = (
@@ -7483,8 +7461,9 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -7595,6 +7574,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "bdJ" = (
@@ -7609,6 +7589,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "bdM" = (
@@ -7760,17 +7741,12 @@
 "beO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/psychology";
-	dir = 8;
-	name = "Psychology APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "beP" = (
@@ -7905,12 +7881,6 @@
 /obj/machinery/vending/autodrobe,
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/theatre";
-	dir = 1;
-	name = "Theatre Backstage APC";
-	pixel_y = 23
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -8198,17 +8168,12 @@
 /area/crew_quarters/bar)
 "bhS" = (
 /obj/machinery/rnd/production/circuit_imprinter,
-/obj/machinery/power/apc{
-	areastring = "/area/engine/break_room";
-	dir = 8;
-	name = "Engineering Foyer APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/break_room)
 "bhT" = (
@@ -8335,16 +8300,6 @@
 /obj/structure/bed/dogbed/mcgriff,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"biQ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/chapel/main";
-	dir = 4;
-	name = "Chapel APC";
-	pixel_x = 26
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "biS" = (
 /obj/structure/displaycase/trophy{
 	pixel_y = 5
@@ -8431,11 +8386,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "bjz" = (
-/obj/machinery/power/apc{
-	areastring = "/area/storage/primary";
-	name = "Primary Tool Storage APC";
-	pixel_y = -23
-	},
 /obj/structure/table,
 /obj/item/analyzer,
 /obj/structure/cable,
@@ -8446,6 +8396,7 @@
 /obj/item/analyzer,
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bjA" = (
@@ -8492,12 +8443,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/pharmacy";
-	dir = 1;
-	name = "Pharmacy APC";
-	pixel_y = 23
-	},
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
 	pixel_y = 5
@@ -8507,6 +8452,7 @@
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/pharmacy)
 "bjT" = (
@@ -8896,6 +8842,8 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bmR" = (
@@ -9012,6 +8960,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bqm" = (
@@ -9030,6 +8979,8 @@
 "bqU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "bqY" = (
@@ -9119,6 +9070,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "brH" = (
@@ -9210,6 +9162,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "bsI" = (
@@ -9365,6 +9318,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "bvu" = (
@@ -9391,6 +9345,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"bxg" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "bxj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -9441,6 +9406,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "bzt" = (
@@ -9483,6 +9454,9 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -9628,17 +9602,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/chapel/main)
-"bHq" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
 "bHK" = (
 /obj/machinery/camera{
 	c_tag = "Escape North";
@@ -9702,11 +9665,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bJr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/aft";
-	name = "Aft Maintenance APC";
-	pixel_y = -23
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
@@ -9714,6 +9672,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bJu" = (
@@ -9877,6 +9836,13 @@
 	dir = 1;
 	network = list("ss13","prison")
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "bQF" = (
@@ -9945,6 +9911,13 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"bTh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/security/brig)
 "bTm" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
@@ -9961,7 +9934,7 @@
 /area/maintenance/port/aft)
 "bUD" = (
 /obj/structure/tank_dispenser/oxygen,
-/obj/machinery/light/small,
+/obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bUR" = (
@@ -10094,6 +10067,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "cbj" = (
@@ -10151,6 +10127,12 @@
 "ccc" = (
 /obj/machinery/camera{
 	c_tag = "Firing Range";
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -10227,11 +10209,6 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "cdG" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/execution";
-	name = "Prisoner Transfer Centre";
-	pixel_y = -23
-	},
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
@@ -10240,6 +10217,7 @@
 	pixel_y = -22
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "cdQ" = (
@@ -10396,6 +10374,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/gateway)
 "chl" = (
@@ -10459,6 +10438,12 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "cki" = (
@@ -10476,17 +10461,12 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/miningdock";
-	dir = 1;
-	name = "Mining Dock APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "cln" = (
@@ -10530,6 +10510,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"cme" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/main)
 "cmf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
@@ -10586,6 +10573,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/bridge)
 "coG" = (
@@ -10673,6 +10661,12 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ctG" = (
@@ -10779,15 +10773,15 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"cwL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cwX" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
@@ -10936,6 +10930,7 @@
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "cCs" = (
@@ -10960,6 +10955,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "cDF" = (
@@ -11074,11 +11071,7 @@
 "cJh" = (
 /obj/machinery/light,
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/bar";
-	name = "Bar APC";
-	pixel_y = -23
-	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
@@ -11113,11 +11106,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"cLn" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "cLV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/machinery/meter,
@@ -11131,13 +11119,6 @@
 /obj/structure/flora/junglebush,
 /turf/open/floor/grass,
 /area/chapel/main)
-"cMo" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "cMq" = (
 /turf/open/floor/plasteel/white/side,
 /area/hallway/secondary/entry)
@@ -11147,6 +11128,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "cMM" = (
@@ -11244,12 +11226,6 @@
 /turf/closed/wall,
 /area/hallway/primary/starboard)
 "cQt" = (
-/obj/machinery/power/apc/highcap/fifteen_k{
-	areastring = "/area/engine/engineering";
-	dir = 1;
-	name = "Engineering APC";
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -11270,6 +11246,7 @@
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cQB" = (
@@ -11440,6 +11417,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"cUY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cVt" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -11577,8 +11567,15 @@
 "cZu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"cZR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "daf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
@@ -11735,6 +11732,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"dcP" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ddh" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -11792,6 +11798,11 @@
 "deM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dfj" = (
@@ -11801,6 +11812,15 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"dfr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "dfs" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office";
@@ -11977,6 +11997,7 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "dmt" = (
@@ -12164,16 +12185,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"drV" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/lawoffice";
-	dir = 1;
-	name = "Law Office APC";
-	pixel_y = 23
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "drZ" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -12275,6 +12286,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"dux" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "duS" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
@@ -12386,6 +12407,10 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"dxa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "dxe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12415,7 +12440,6 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
 "dxv" = (
-/obj/structure/cable,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/rack,
 /turf/open/floor/plating,
@@ -12827,12 +12851,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"dFh" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "dFp" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
 	on = 0;
 	pixel_x = -3;
 	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
@@ -12879,17 +12911,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "dGn" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/lab";
-	dir = 1;
-	name = "Research Lab APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/lab)
 "dGI" = (
@@ -12986,27 +13013,34 @@
 /area/hallway/primary/central)
 "dKC" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/vest{
+/obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/suit/armor/vest{
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/clothing/head/helmet{
+/obj/item/clothing/head/helmet/alt{
 	layer = 3.00001;
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/head/helmet{
+/obj/item/clothing/head/helmet/alt{
 	layer = 3.00001
 	},
-/obj/item/clothing/head/helmet{
+/obj/item/clothing/head/helmet/alt{
 	layer = 3.00001;
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 25
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -13076,16 +13110,29 @@
 /area/hallway/primary/central)
 "dLK" = (
 /obj/structure/rack,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/teargas{
+/obj/item/clothing/suit/armor/vest{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/key/security,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/clothing/suit/armor/vest{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -13122,6 +13169,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "dME" = (
@@ -13141,14 +13194,19 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dMW" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -29
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/security/armory)
 "dMY" = (
-/obj/vehicle/ridden/secway,
+/obj/structure/rack,
+/obj/item/storage/box/flashbangs{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/teargas{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/key/security,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -13199,6 +13257,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"dOM" = (
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "dOO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -13283,6 +13349,8 @@
 	name = "security sorting disposal pipe";
 	sortType = 7
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dQJ" = (
@@ -13439,7 +13507,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/xenobiology)
 "dVp" = (
@@ -13789,6 +13856,11 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/hop)
+"egL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel,
+/area/security/main)
 "egQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -13810,6 +13882,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"ehE" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ehQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
@@ -13950,6 +14034,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "enk" = (
@@ -13982,14 +14069,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "63"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "enY" = (
@@ -14050,6 +14131,14 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
+"eqU" = (
+/obj/item/radio/intercom{
+	pixel_x = -29
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/hallway/secondary/entry)
 "eqX" = (
 /obj/structure/table/wood/poker,
 /obj/item/clothing/glasses/monocle,
@@ -14558,11 +14647,6 @@
 /area/science/nanite)
 "eGB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal/incinerator";
-	name = "Incinerator APC";
-	pixel_y = -23
-	},
 /obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -14638,6 +14722,7 @@
 /area/quartermaster/storage)
 "eKb" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
 "eKl" = (
@@ -14682,20 +14767,22 @@
 /area/quartermaster/miningdock)
 "eLO" = (
 /obj/structure/rack,
-/obj/item/gun/energy/e_gun{
+/obj/item/gun/energy/laser{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -14703,25 +14790,34 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "eLR" = (
-/obj/structure/closet/secure_closet{
-	name = "contraband locker";
-	req_access_txt = "3"
+/obj/structure/rack,
+/obj/item/gun/ballistic/shotgun/riot,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = 6
 	},
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/effect/spawner/lootdrop/armory_contraband/metastation,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+	dir = 1
 	},
-/obj/item/circuitboard/computer/advanced_camera,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "eLX" = (
 /obj/effect/turf_decal/bot,
 /mob/living/simple_animal/bot/secbot/beepsky{
 	name = "Sergent Armsky"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -15024,19 +15120,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "eUz" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/mixing/chamber";
-	dir = 8;
-	name = "Toxins Chamber APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/showroomfloor,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "eUB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -15195,6 +15286,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"eZB" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "eZL" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -15415,6 +15510,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/pharmacy)
+"feI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ffT" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -15628,6 +15734,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "fjN" = (
@@ -15779,6 +15888,8 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "foc" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "foq" = (
@@ -15889,6 +16000,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "frP" = (
@@ -16105,6 +16218,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/box,
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "fxo" = (
@@ -16126,6 +16240,11 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "fxU" = (
@@ -16352,6 +16471,10 @@
 /obj/structure/chair/sofa/left{
 	dir = 8
 	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/break_room)
 "fFk" = (
@@ -16403,6 +16526,10 @@
 	},
 /turf/closed/wall,
 /area/science/xenobiology)
+"fHW" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "fIb" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
@@ -16416,14 +16543,13 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "fIO" = (
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
 /obj/machinery/computer/gateway_control,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/gateway)
 "fJr" = (
@@ -16606,6 +16732,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/sepia,
 /area/chapel/main)
 "fPC" = (
@@ -16626,12 +16753,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "fPI" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/tcommsat/server";
-	dir = 1;
-	name = "Telecomms Server APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -16651,6 +16772,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "fPN" = (
@@ -16734,15 +16856,11 @@
 /area/security/courtroom)
 "fSL" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engine/gravity_generator";
-	name = "Gravity Generator APC";
-	pixel_y = -23
-	},
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = -22
 	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/showroomfloor,
 /area/engine/gravity_generator)
 "fSP" = (
@@ -16926,6 +17044,15 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"fWR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/hos)
 "fWV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -16989,6 +17116,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "fXO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "fYi" = (
@@ -17695,7 +17825,7 @@
 /obj/item/stack/spacecash/c200,
 /obj/item/stack/spacecash/c200,
 /obj/item/stack/spacecash/c20,
-/obj/item/toy/minimeteor,
+/obj/machinery/light,
 /turf/open/floor/vault,
 /area/security/nuke_storage)
 "gts" = (
@@ -17883,24 +18013,13 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "gxw" = (
-/obj/machinery/power/apc{
-	areastring = "/area/gateway";
-	dir = 4;
-	name = "Gateway APC";
-	pixel_x = 26
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "gxD" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/starboard/fore";
-	dir = 1;
-	name = "Starboard Bow Maintenance APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "gxF" = (
@@ -18029,8 +18148,9 @@
 	pixel_y = -2
 	},
 /obj/item/gun/grenadelauncher,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -18044,8 +18164,9 @@
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -18164,21 +18285,20 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "gGI" = (
-/obj/structure/rack,
-/obj/item/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/structure/closet/secure_closet{
+	name = "contraband locker";
+	req_access_txt = "3"
 	},
-/obj/item/gun/energy/laser,
-/obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/spawner/lootdrop/armory_contraband/metastation,
+/obj/item/circuitboard/computer/advanced_camera,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -18212,6 +18332,12 @@
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"gHW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "gIl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18293,6 +18419,8 @@
 	pixel_x = 22;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "gLp" = (
@@ -18302,6 +18430,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
 "gLq" = (
@@ -18310,6 +18440,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
+"gLx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "gLT" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -18366,6 +18504,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/dark/visible{
 	dir = 4
+	},
+/obj/machinery/airalarm/server{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -18439,13 +18581,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
-"gQq" = (
-/obj/machinery/power/apc{
-	areastring = "/area/library";
-	dir = 8;
-	name = "Library APC";
-	pixel_x = -25
+"gQk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
+"gQq" = (
 /obj/structure/cable,
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -18624,17 +18773,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing)
-"gTU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "gUp" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -18684,7 +18822,19 @@
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/pharmacy)
+"gVE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/main)
 "gVQ" = (
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "gWb" = (
@@ -18914,6 +19064,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge)
+"hdJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "hee" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -19559,6 +19718,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"hym" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/main)
 "hyo" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/open/floor/plasteel,
@@ -19608,6 +19774,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hAX" = (
@@ -19784,15 +19951,6 @@
 "hFs" = (
 /turf/closed/wall/r_wall,
 /area/security/range)
-"hFQ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/construction/mining/aux_base";
-	name = "Auxillary Base Construction APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "hFT" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 4
@@ -19837,6 +19995,10 @@
 /obj/structure/flora/bush,
 /turf/open/floor/grass,
 /area/bridge)
+"hHv" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/library)
 "hHw" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -19916,7 +20078,6 @@
 /obj/structure/sign/poster/contraband/lusty_xenomorph{
 	pixel_x = -32
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "hKE" = (
@@ -20022,6 +20183,13 @@
 	name = "Armory";
 	req_access_txt = "3"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "hOS" = (
@@ -20052,13 +20220,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "hPS" = (
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/security/prison";
-	dir = 4;
-	name = "Prison Wing APC";
-	pixel_x = -26
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hQc" = (
@@ -20148,17 +20311,13 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "hUo" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/security/armory";
-	dir = 4;
-	name = "Armory APC";
-	pixel_x = 24
-	},
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
 	},
 /obj/machinery/flasher/portable,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "hUH" = (
@@ -20188,6 +20347,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"hWd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/range)
 "hWE" = (
 /obj/structure/window{
 	dir = 1
@@ -20357,18 +20525,22 @@
 /area/crew_quarters/bar)
 "ibE" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_y = 6
-	},
-/obj/item/gun/ballistic/shotgun/riot{
+/obj/item/gun/energy/e_gun{
+	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -20390,6 +20562,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"ick" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "icF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
@@ -20451,6 +20633,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/bridge)
 "ifc" = (
@@ -20518,6 +20701,8 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ihj" = (
@@ -20662,6 +20847,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"imN" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "imS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 10
@@ -20706,6 +20900,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"iof" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ioj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20806,6 +21006,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/break_room)
+"isl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "isG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -20896,6 +21102,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"iuN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "iuU" = (
 /obj/machinery/camera{
 	c_tag = "South Hallway - East";
@@ -20931,17 +21143,12 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/science/nanite";
-	dir = 4;
-	name = "Nanite Lab APC";
-	pixel_x = 26
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
 "iwn" = (
@@ -21049,6 +21256,7 @@
 /obj/item/book/manual/wiki/experimentor,
 /obj/item/relic,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/explab)
 "iys" = (
@@ -21197,13 +21405,8 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "iIf" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/starboard";
-	dir = 4;
-	name = "Starboard Maintenance APC";
-	pixel_x = 26
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "iIJ" = (
@@ -21258,11 +21461,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "iKA" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/bridge";
-	name = "Bridge APC";
-	pixel_y = -23
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -21271,6 +21469,7 @@
 /obj/machinery/computer/med_data{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel,
 /area/bridge)
 "iKS" = (
@@ -21633,6 +21832,15 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/grass,
 /area/security/courtroom)
+"iVV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "iWs" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -21699,13 +21907,8 @@
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "iYj" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/mixing";
-	dir = 4;
-	name = "Toxins Lab APC";
-	pixel_x = 26
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "iYk" = (
@@ -21761,7 +21964,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/east,
 /obj/machinery/door/window{
 	base_state = "leftsecure";
 	dir = 1;
@@ -21770,6 +21972,7 @@
 	obj_integrity = 300;
 	req_access_txt = "16"
 	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "iZs" = (
@@ -21853,15 +22056,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"jcA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/bridge)
 "jcB" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 4;
@@ -21891,6 +22085,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jdu" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jdx" = (
 /obj/structure/sign/poster/ripped,
 /turf/closed/wall/r_wall,
@@ -21929,6 +22132,11 @@
 "jey" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"jeG" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "jfV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -21975,6 +22183,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"jhM" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jhS" = (
 /obj/structure/sign/poster/official/obey{
 	pixel_x = 30
@@ -22058,17 +22273,12 @@
 /area/storage/tech)
 "jkt" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	areastring = "/area/science/storage";
-	dir = 8;
-	name = "Toxins Storage APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "jku" = (
@@ -22228,10 +22438,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"jqK" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "jrJ" = (
 /obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom{
@@ -22282,6 +22488,9 @@
 "jtc" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/brute,
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "jtk" = (
@@ -22327,6 +22536,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/xenobiology)
 "jtM" = (
@@ -22592,6 +22803,8 @@
 /obj/structure/window{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "jBo" = (
@@ -22633,6 +22846,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"jCe" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "jCj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -22861,6 +23085,7 @@
 	name = "Detective Maintenance";
 	req_access_txt = "4"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "jLN" = (
@@ -23069,6 +23294,12 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
+"jTo" = (
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/morgue)
 "jTv" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Server Room";
@@ -23188,6 +23419,15 @@
 /obj/item/toy/cards/deck/syndicate,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
+"jVL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel,
+/area/security/main)
+"jVV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "jVW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23552,6 +23792,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"kji" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kjj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -23643,6 +23888,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/range)
+"klu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "klF" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -23650,6 +23901,9 @@
 /obj/effect/turf_decal/tile/red,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -23679,6 +23933,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "kmZ" = (
@@ -23940,15 +24195,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"kup" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/central/secondary";
-	name = "Starboard Central Maintenance APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "kuM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
@@ -23964,6 +24210,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/bed,
+/obj/item/bedsheet,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "kvt" = (
@@ -24174,6 +24422,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"kBM" = (
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "kBX" = (
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_y = -32
@@ -24262,6 +24517,7 @@
 "kEB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "kEW" = (
@@ -24310,6 +24566,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
+"kGh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kGn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -24415,6 +24677,11 @@
 /obj/machinery/teleport/station,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
+"kJH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kJU" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -24472,12 +24739,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/virology)
 "kKK" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/chemistry";
-	dir = 8;
-	name = "Chemistry APC";
-	pixel_x = -25
-	},
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
@@ -24489,6 +24750,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "kKP" = (
@@ -24669,6 +24931,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "kPn" = (
@@ -24810,8 +25073,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_access_txt = "31"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "kVx" = (
 /obj/machinery/light{
@@ -25061,16 +25329,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/virology)
-"lgr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/kitchen";
-	dir = 4;
-	name = "Kitchen APC";
-	pixel_x = 26
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "lgv" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -25089,6 +25347,22 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"lgV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lgW" = (
 /obj/machinery/shower{
 	dir = 1
@@ -25181,7 +25455,6 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "ljV" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -25189,6 +25462,7 @@
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 35
 	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "lko" = (
@@ -25213,6 +25487,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/bridge)
+"lkK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/main)
 "lkO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -25279,6 +25557,7 @@
 	name = "qm sorting disposal pipe";
 	sortType = 3
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "lmy" = (
@@ -25301,6 +25580,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/storage/art)
 "lmA" = (
@@ -25368,7 +25649,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -25434,10 +25714,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningdock)
-"lpz" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
 "lqd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
@@ -25515,14 +25791,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "lrT" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office";
-	req_access_txt = "31"
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/spawner/structure/window,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "lsb" = (
@@ -25540,6 +25812,22 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lsr" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lsN" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
@@ -25640,11 +25928,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lwr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/aft";
-	name = "Aft Hall APC";
-	pixel_y = -23
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -25656,6 +25939,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "lws" = (
@@ -25897,17 +26181,12 @@
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/science/genetics";
-	dir = 1;
-	name = "Genetics APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/genetics)
 "lGE" = (
@@ -26227,6 +26506,25 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
+"lQx" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lQG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light{
@@ -26409,6 +26707,17 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/science/genetics)
+"lWv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/main)
 "lWC" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway - South";
@@ -26423,6 +26732,13 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lWI" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "lWT" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -26527,6 +26843,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"mbP" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/lawoffice)
 "mbX" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -26618,6 +26938,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/gateway)
 "meM" = (
@@ -26636,12 +26957,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "mff" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/toilet";
-	dir = 8;
-	name = "Dormitory Bathrooms APC";
-	pixel_x = -25
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/light{
@@ -26762,6 +27077,9 @@
 /area/security/brig)
 "mik" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mio" = (
@@ -26787,6 +27105,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "miZ" = (
@@ -26809,6 +27128,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "mjw" = (
@@ -26885,6 +27205,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mkQ" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig Control";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "mli" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/frame/machine,
@@ -26924,6 +27253,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "mne" = (
@@ -26975,6 +27305,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mnE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "mnR" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -26985,6 +27321,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "mnV" = (
@@ -26994,6 +27331,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
+"mnZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel,
+/area/security/main)
 "moj" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable/layer1,
@@ -27009,6 +27351,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "moX" = (
@@ -27053,6 +27396,8 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "mpM" = (
@@ -27178,7 +27523,6 @@
 /area/engine/engineering)
 "muZ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -27195,13 +27539,8 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/quartermaster/office)
 "mvp" = (
+/mob/living/simple_animal/pet/fox/renault,
 /obj/structure/bed/dogbed/renault,
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/captain";
-	dir = 1;
-	name = "Captain's Office APC";
-	pixel_y = 23
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -27210,7 +27549,7 @@
 	pixel_x = -10;
 	pixel_y = 22
 	},
-/mob/living/simple_animal/pet/fox/renault,
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "mvr" = (
@@ -27364,12 +27703,6 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "mzT" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/port";
-	dir = 1;
-	name = "Port Hall APC";
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
@@ -27387,6 +27720,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "mAb" = (
@@ -27455,10 +27789,12 @@
 	name = "Library Maintenance";
 	req_access_txt = "12"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "mDX" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -27540,7 +27876,6 @@
 	name = "Closet";
 	req_access_txt = "55"
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "mGs" = (
@@ -27678,11 +28013,20 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"mLm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/range)
 "mLq" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "mLC" = (
@@ -27766,6 +28110,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mPj" = (
@@ -27788,6 +28133,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"mPW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "mQs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
@@ -27877,6 +28231,10 @@
 /obj/structure/sign/poster/official/obey,
 /turf/closed/wall,
 /area/security/prison)
+"mTd" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "mTe" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white/side{
@@ -27950,6 +28308,7 @@
 	name = "cargo sorting disposal pipe";
 	sortType = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "mTW" = (
@@ -28247,12 +28606,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/genetics)
 "naM" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hop";
-	name = "Head of Personnel APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
@@ -28307,6 +28660,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"ndz" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ndN" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
@@ -28415,6 +28775,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "ngD" = (
@@ -28450,6 +28811,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"ngZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nhm" = (
 /obj/effect/turf_decal,
 /obj/effect/landmark/start/atmospheric_technician,
@@ -28465,6 +28834,9 @@
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "nhE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
 "nhU" = (
@@ -28518,13 +28890,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "njM" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/xenobiology";
-	dir = 8;
-	name = "Xenobiology APC";
-	pixel_x = -25
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "njN" = (
@@ -28595,6 +28960,8 @@
 /area/bridge)
 "noH" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "noK" = (
@@ -28607,12 +28974,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "noX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "npf" = (
@@ -28828,12 +29197,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "nuz" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/fore";
-	name = "Port Bow Maintenance APC";
-	pixel_y = -23
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "nuC" = (
@@ -29037,6 +29402,14 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"nCk" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel,
+/area/security/main)
 "nCm" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/shower{
@@ -29053,6 +29426,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"nCq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/white,
+/area/security/brig)
 "nCs" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/white,
@@ -29490,11 +29873,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/hor)
 "nQs" = (
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "63"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Brig"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "nQQ" = (
@@ -29584,6 +29966,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"nTC" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/main)
 "nTJ" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -29631,6 +30017,12 @@
 	departmentType = 5;
 	name = "Security RC";
 	pixel_y = 30
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -29845,12 +30237,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/science/server";
-	dir = 4;
-	name = "Server Room APC";
-	pixel_x = 26
-	},
 /obj/machinery/atmospherics/pipe/simple{
 	dir = 9
 	},
@@ -29859,6 +30245,7 @@
 	pixel_x = 22;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/science/server)
 "oaO" = (
@@ -29899,6 +30286,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/genetics)
+"obY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ocj" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Cell 5"
@@ -30073,6 +30466,15 @@
 /obj/item/multitool,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
+"ogY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/security/execution/transfer)
 "ohu" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -30095,19 +30497,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "oiD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/teleporter";
-	dir = 4;
-	name = "Teleporter APC";
-	pixel_x = 26
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/teleporter)
 "oiJ" = (
@@ -30228,6 +30626,12 @@
 	sortType = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "omc" = (
@@ -30328,14 +30732,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/bridge)
 "ooZ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port/aft";
-	dir = 8;
-	name = "Port Quarter Maintenance APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "opa" = (
@@ -30484,6 +30883,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "osV" = (
@@ -30496,6 +30896,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/office)
+"osZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "otG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -30542,28 +30948,34 @@
 /area/crew_quarters/heads/hop)
 "owt" = (
 /obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
+/obj/item/clothing/suit/armor/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot{
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
+/obj/item/clothing/head/helmet/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot{
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
@@ -30879,16 +31291,6 @@
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plasteel/showroomfloor,
 /area/bridge)
-"oGh" = (
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/qm";
-	dir = 1;
-	name = "Quartermaster APC";
-	pixel_y = 23
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "oGk" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8;
@@ -30909,8 +31311,30 @@
 /area/hydroponics)
 "oGZ" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
+"oHf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "oHg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -30989,6 +31413,7 @@
 /area/maintenance/starboard)
 "oJl" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "oJn" = (
@@ -31005,6 +31430,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"oJO" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"oKE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "oKW" = (
 /obj/structure/window{
 	dir = 8
@@ -31240,6 +31682,11 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"oSx" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/main)
 "oSJ" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -31261,13 +31708,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/showroomfloor,
 /area/quartermaster/office)
-"oTQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/port/aft)
 "oUB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -31411,6 +31851,10 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"oYl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "oYo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 1;
@@ -31472,11 +31916,6 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "paT" = (
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/office";
-	name = "Cargo Office APC";
-	pixel_y = -23
-	},
 /obj/machinery/photocopier,
 /obj/structure/cable,
 /obj/machinery/light_switch{
@@ -31539,6 +31978,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "pdg" = (
@@ -31570,6 +32010,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"pex" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "peJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -31644,12 +32100,6 @@
 	},
 /area/maintenance/starboard)
 "pia" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hor";
-	dir = 8;
-	name = "RD Office APC";
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -31658,6 +32108,7 @@
 	pixel_x = -20;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "pib" = (
@@ -31935,13 +32386,6 @@
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/hop)
-"ppu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/showroomfloor,
-/area/science/xenobiology)
 "ppA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
@@ -32001,13 +32445,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "prU" = (
+/mob/living/simple_animal/bot/secbot/pingsky,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/mob/living/simple_animal/bot/secbot/pingsky,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "psZ" = (
@@ -32039,6 +32483,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "ptI" = (
@@ -32106,6 +32551,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
 "puT" = (
@@ -32195,6 +32641,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "pxc" = (
@@ -32231,15 +32683,11 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "pyp" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai_upload";
-	name = "Upload APC";
-	pixel_y = -23
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "pys" = (
@@ -32252,6 +32700,7 @@
 "pyL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -32426,6 +32875,10 @@
 /obj/item/stock_parts/cell/high/plus,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
@@ -32955,6 +33408,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"pXa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/execution/education)
 "pXA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -32994,16 +33453,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"qam" = (
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/sorting";
-	dir = 4;
-	name = "Delivery Office APC";
-	pixel_x = 26
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "qav" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 5
@@ -33036,6 +33485,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
+"qaJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qaK" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -33053,6 +33508,11 @@
 /obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qaS" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/library)
 "qaV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
@@ -33200,40 +33660,6 @@
 "qeW" = (
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"qfi" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "qfu" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -33364,6 +33790,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "qiF" = (
@@ -33632,6 +34059,7 @@
 	dir = 5
 	},
 /obj/item/beacon,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "qrt" = (
@@ -33676,17 +34104,6 @@
 /obj/item/gun/energy/e_gun/mini,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
-"qsv" = (
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/warehouse";
-	dir = 4;
-	name = "Cargo Warehouse APC";
-	pixel_x = 26
-	},
-/obj/structure/cable,
-/obj/effect/loot_site_spawner,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "qsA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33785,6 +34202,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "qwB" = (
@@ -33842,6 +34260,7 @@
 /area/maintenance/central)
 "qyp" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -33859,16 +34278,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/bridge)
-"qAh" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/courtroom";
-	dir = 4;
-	name = "Courtroom APC";
-	pixel_x = 26
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "qAC" = (
 /obj/structure/chair/office,
 /turf/open/floor/plasteel,
@@ -33954,14 +34363,9 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "qDX" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/storage/eva";
-	dir = 1;
-	name = "EVA Storage APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /obj/machinery/camera,
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "qEB" = (
@@ -33986,6 +34390,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
 "qEP" = (
@@ -34159,6 +34564,18 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/bridge)
+"qLe" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "qLq" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -34206,17 +34623,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "qMx" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/heads/chief";
-	dir = 4;
-	name = "CE Office APC";
-	pixel_x = 24
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "qMQ" = (
@@ -34608,6 +35020,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/lawoffice)
+"qZR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "rac" = (
 /obj/machinery/camera{
 	c_tag = "Telecommunications Chamber";
@@ -34741,6 +35162,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "rbU" = (
@@ -34751,6 +35173,9 @@
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = 8;
 	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
@@ -34842,19 +35267,21 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
-"reN" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/starboard/aft";
-	dir = 8;
-	name = "Starboard Quarter Solar APC";
-	pixel_x = -25
+"reM" = (
+/obj/effect/turf_decal/bot,
+/obj/item/radio/intercom{
+	pixel_x = 29
 	},
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
+"reN" = (
 /obj/item/stack/cable_coil,
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "reS" = (
@@ -34950,6 +35377,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"rhI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/main)
 "rif" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -35033,6 +35465,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"rkY" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "rla" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -35188,6 +35627,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"rqA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "rqE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35324,6 +35769,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"rtK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "ruP" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/airalarm/mixingchamber{
@@ -35382,13 +35833,13 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "rxf" = (
+/mob/living/simple_animal/pet/dog/corgi/ian,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24
 	},
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/mob/living/simple_animal/pet/dog/corgi/ian,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/hop)
 "rxU" = (
@@ -35457,6 +35908,7 @@
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "rzJ" = (
@@ -35467,6 +35919,7 @@
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
 "rAm" = (
@@ -35487,7 +35940,6 @@
 	name = "atmospherics sorting disposal pipe";
 	sortType = 6
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 10
 	},
@@ -35573,6 +36025,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/gateway)
 "rEm" = (
@@ -35714,6 +36167,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"rIm" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "rIH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -36303,6 +36760,7 @@
 	name = "bar sorting disposal pipe";
 	sortType = 19
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "sat" = (
@@ -36354,6 +36812,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "sdl" = (
@@ -36468,12 +36928,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "sgE" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/research";
-	dir = 1;
-	name = "Research Division APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -36603,6 +37057,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/fore)
+"sjX" = (
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "skp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -36853,6 +37316,7 @@
 	name = "Disposal Access";
 	req_access_txt = "12"
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
 "srf" = (
@@ -36917,6 +37381,16 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
+"sst" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "ssG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
@@ -36952,19 +37426,15 @@
 "stt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "stu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/hydroponics";
-	dir = 1;
-	name = "Hydroponics APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "suU" = (
@@ -36996,6 +37466,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"svN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/security/range)
 "svO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -37056,6 +37531,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"sxe" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "sxg" = (
 /obj/effect/landmark/start/mime,
 /turf/open/floor/plasteel/cafeteria,
@@ -37209,6 +37689,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"sBT" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
 "sCb" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
@@ -37230,6 +37714,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/pharmacy)
 "sCR" = (
+/mob/living/simple_animal/bot/floorbot,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -37240,7 +37725,6 @@
 	c_tag = "MiniSat - Antechamber";
 	network = list("minisat")
 	},
-/mob/living/simple_animal/bot/floorbot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sCZ" = (
@@ -37433,18 +37917,13 @@
 /area/maintenance/starboard)
 "sIJ" = (
 /obj/structure/table,
-/obj/machinery/power/apc{
-	areastring = "/area/engine/engine_smes";
-	dir = 1;
-	name = "SMES room APC";
-	pixel_y = 23
-	},
 /obj/machinery/computer/security/telescreen/engine,
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "sIR" = (
@@ -37506,6 +37985,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "sJJ" = (
@@ -37602,15 +38082,6 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/science/test_area)
-"sMp" = (
-/obj/machinery/power/apc{
-	areastring = "/area/quartermaster/storage";
-	name = "Cargo Bay APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "sMq" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -37750,8 +38221,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"sPG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "sQO" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -37815,6 +38293,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"sSG" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "sSK" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -37903,16 +38387,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/medbay/lobby";
-	name = "Medbay Lobby APC";
-	pixel_y = -23
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = -22
 	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "sUA" = (
@@ -38028,6 +38508,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
+"sXk" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/security/courtroom)
 "sXm" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -38169,12 +38654,6 @@
 "tcM" = (
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/medbay/central";
-	dir = 4;
-	name = "Medbay Central APC";
-	pixel_x = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -38323,12 +38802,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "thn" = (
-/obj/machinery/power/apc{
-	areastring = "/area/tcommsat/computer";
-	dir = 8;
-	name = "Telecomms Monitoring APC";
-	pixel_x = -25
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
@@ -38338,15 +38811,11 @@
 	c_tag = "Bridge Entry East";
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/showroomfloor,
 /area/tcommsat/computer)
 "thA" = (
 /obj/machinery/light,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/exam_room";
-	name = "Treatment Center APC";
-	pixel_y = -23
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -38356,6 +38825,7 @@
 	pixel_x = -10;
 	pixel_y = -22
 	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/white,
 /area/medical/exam_room)
 "thC" = (
@@ -38363,6 +38833,11 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
+"thO" = (
+/obj/structure/cable,
+/obj/vehicle/ridden/secway,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "thQ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -38454,6 +38929,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
 "tke" = (
@@ -38625,6 +39106,14 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"tnU" = (
+/obj/machinery/door/airlock{
+	name = "Crematorium";
+	req_access_txt = "27"
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "top" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -38669,16 +39158,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"tqN" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/robotics/mechbay";
-	dir = 1;
-	name = "Mech Bay APC";
-	pixel_y = 23
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "tqO" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -38740,6 +39219,11 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"trn" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "trx" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -38803,11 +39287,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "tsz" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/cryo";
-	name = "Cryogenics APC";
-	pixel_y = -23
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -38841,6 +39320,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"ttL" = (
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tuj" = (
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -38868,13 +39353,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/janitor";
-	dir = 8;
-	name = "Custodial Closet APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "tve" = (
@@ -39367,6 +39847,14 @@
 "tHa" = (
 /turf/closed/wall,
 /area/hallway/primary/central)
+"tHd" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "tIA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39640,6 +40128,12 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "tRr" = (
@@ -39795,12 +40289,6 @@
 "tVT" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/storage";
-	dir = 1;
-	name = "Medbay Storage APC";
-	pixel_y = 23
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera{
 	c_tag = "Medbay Storage"
@@ -39810,6 +40298,7 @@
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "tWG" = (
@@ -39880,6 +40369,12 @@
 "tZG" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"tZP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "tZR" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/transit_tube/horizontal,
@@ -39908,13 +40403,8 @@
 	pixel_x = -20;
 	pixel_y = 11
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/medical/break_room";
-	dir = 8;
-	name = "Medical Breakroom APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/cafeteria,
 /area/medical/break_room)
 "ubG" = (
@@ -40116,6 +40606,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"ugW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uhD" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 4
@@ -40411,8 +40905,13 @@
 "uoG" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"uoI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/security/main)
 "upp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -40492,6 +40991,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/quartermaster,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "urj" = (
@@ -40519,6 +41019,8 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/lawoffice)
 "urR" = (
@@ -40558,6 +41060,16 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall,
 /area/science/mixing/chamber)
+"utH" = (
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/cable,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "utV" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -40594,6 +41106,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"uwe" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "uwj" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin/carbon,
@@ -40693,6 +41211,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/lawoffice)
 "uzz" = (
@@ -40976,6 +41495,15 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/grass,
 /area/hydroponics)
+"uGD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/crew_quarters/heads/hos)
 "uGE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
@@ -41112,6 +41640,7 @@
 /area/crew_quarters/fitness)
 "uJy" = (
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -41157,6 +41686,12 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/science/test_area)
+"uLg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "uLB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -41215,6 +41750,15 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/science/test_area)
+"uMK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/execution/transfer)
 "uNb" = (
 /obj/structure/sign/departments/science,
 /turf/closed/wall,
@@ -41226,6 +41770,10 @@
 	name = "hyper-reinforced wall"
 	},
 /area/science/test_area)
+"uOh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plasteel,
+/area/security/main)
 "uOm" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -41237,12 +41785,6 @@
 /area/engine/engineering)
 "uOy" = (
 /obj/structure/rack,
-/obj/machinery/power/apc{
-	areastring = "/area/storage/tech";
-	dir = 1;
-	name = "Tech Storage APC";
-	pixel_y = 23
-	},
 /obj/item/stock_parts/subspace/treatment,
 /obj/item/stock_parts/subspace/treatment,
 /obj/item/stock_parts/subspace/treatment,
@@ -41259,6 +41801,7 @@
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "uOK" = (
@@ -41331,14 +41874,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "uQW" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/port";
-	dir = 8;
-	name = "Port Maintenance APC";
-	pixel_x = -25
-	},
 /obj/structure/chair,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "uRj" = (
@@ -41453,6 +41991,16 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/hydroponics)
+"uUm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uUx" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -41586,12 +42134,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "uXS" = (
-/obj/machinery/power/apc{
-	areastring = "/area/medical/morgue";
-	dir = 1;
-	name = "Morgue APC";
-	pixel_y = 23
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -41600,6 +42142,7 @@
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "uXU" = (
@@ -41878,11 +42421,6 @@
 	pixel_x = -10;
 	pixel_y = -22
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/science/explab";
-	name = "Experimentation Lab APC";
-	pixel_y = -23
-	},
 /obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/explab)
@@ -41938,6 +42476,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"vkd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "vkf" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -41963,6 +42507,7 @@
 	dir = 8;
 	pixel_x = 30
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "vkH" = (
@@ -42011,17 +42556,12 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/cmo";
-	dir = 1;
-	name = "CMO Office APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/cmo)
 "vmb" = (
@@ -42155,6 +42695,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "vpr" = (
@@ -42194,12 +42736,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "vpQ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/robotics/lab";
-	dir = 4;
-	name = "Robotics Lab APC";
-	pixel_x = 26
-	},
 /obj/machinery/requests_console{
 	department = "Robotics";
 	departmentType = 2;
@@ -42213,6 +42749,7 @@
 	pixel_x = 22;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
 "vpT" = (
@@ -42240,15 +42777,6 @@
 "vqN" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
-"vqZ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/starboard/aft";
-	name = "Starboard Quarter Maintenance APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "vrd" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/window{
@@ -42319,17 +42847,12 @@
 	dir = 1
 	},
 /obj/structure/table,
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/medical/virology";
-	dir = 1;
-	name = "Virology APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/virology)
 "vsy" = (
@@ -42475,6 +42998,8 @@
 	dir = 8;
 	network = list("ss13","engine")
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
 "vvt" = (
@@ -42535,6 +43060,12 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "vwh" = (
@@ -42544,6 +43075,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vwz" = (
@@ -42554,18 +43086,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
-"vxS" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/exit";
-	dir = 8;
-	name = "Escape Hallway APC";
-	pixel_x = -25
-	},
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/aft)
 "vxV" = (
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/plasteel,
@@ -42596,6 +43116,8 @@
 	req_access_txt = "2"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "vyo" = (
@@ -42745,11 +43267,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"vAN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/bridge)
 "vAS" = (
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
@@ -42787,6 +43304,11 @@
 	},
 /turf/closed/wall,
 /area/security/detectives_office)
+"vCn" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/vault,
+/area/security/nuke_storage)
 "vCr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -42840,12 +43362,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "vDN" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "vEc" = (
@@ -42860,17 +43382,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "vEs" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hos";
-	dir = 8;
-	name = "Head of Security's Office APC";
-	pixel_y = -23
-	},
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = -22
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hos)
 "vEt" = (
@@ -42936,6 +43453,10 @@
 /obj/structure/grille,
 /turf/open/space,
 /area/space/nearstation)
+"vFy" = (
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
 "vFF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plasteel,
@@ -42968,6 +43489,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "vGN" = (
@@ -42999,6 +43521,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vHo" = (
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "vHv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -43036,6 +43563,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"vHY" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/security/prison)
 "vIg" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Foyer";
@@ -43082,13 +43615,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"vJy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vJI" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -43132,13 +43658,13 @@
 /turf/open/floor/engine,
 /area/engine/supermatter)
 "vKH" = (
-/obj/machinery/power/apc/auto_name/south,
+/mob/living/simple_animal/bot/cleanbot,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vKO" = (
@@ -43148,6 +43674,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "vKQ" = (
@@ -43187,12 +43714,7 @@
 /area/hallway/primary/port)
 "vMh" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/security/detectives_office";
-	dir = 8;
-	name = "Detective's Office APC";
-	pixel_x = -25
-	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "vMk" = (
@@ -43305,6 +43827,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"vPT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "vPZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
@@ -43312,6 +43841,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "vQo" = (
@@ -43469,6 +43999,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
 "vVk" = (
@@ -43561,6 +44092,9 @@
 	id = "Cell 3";
 	name = "Cell 3";
 	pixel_y = -32
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -43794,6 +44328,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wfm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/plasteel,
+/area/security/main)
 "wfT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -43978,6 +44517,13 @@
 "wlQ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
+"wlT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/plasteel/sepia,
+/area/chapel/main)
 "wma" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -44025,12 +44571,6 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "wnI" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/starboard";
-	dir = 8;
-	name = "Starboard Primary Hallway APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -44086,6 +44626,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
 "wpu" = (
@@ -44136,6 +44677,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
 "wqn" = (
@@ -44189,6 +44731,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
 "wrm" = (
@@ -44225,6 +44768,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
 "wrw" = (
@@ -44439,6 +44983,10 @@
 /obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
+"wyY" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
 "wzD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
@@ -44505,6 +45053,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "wBI" = (
@@ -44678,6 +45228,13 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
 "wGg" = (
@@ -44867,6 +45424,12 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/science/test_area)
+"wMh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "wMi" = (
 /obj/effect/spawner/structure/window/reinforced/indestructable,
 /turf/open/floor/plating,
@@ -44918,7 +45481,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wNB" = (
@@ -45458,6 +46020,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xbl" = (
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/maintenance/central)
 "xbn" = (
@@ -45529,6 +46092,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "xct" = (
@@ -45748,14 +46313,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xjX" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/electrical";
-	dir = 1;
-	name = "Electrical Maintenance APC";
-	pixel_y = 23
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "xkc" = (
@@ -46081,8 +46641,9 @@
 	pixel_x = 6;
 	pixel_y = -2
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
@@ -46174,12 +46735,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xtn" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engine/atmos";
-	dir = 8;
-	name = "Atmospherics APC";
-	pixel_x = -25
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -20;
@@ -46193,6 +46748,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xto" = (
@@ -46244,16 +46800,6 @@
 "xtO" = (
 /turf/closed/wall,
 /area/maintenance/central)
-"xtY" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/disposal";
-	dir = 8;
-	name = "Disposal APC";
-	pixel_x = -25
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "xuk" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -46281,6 +46827,7 @@
 "xut" = (
 /obj/effect/turf_decal/box,
 /obj/effect/landmark/start/security_officer,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/range)
 "xuz" = (
@@ -46343,6 +46890,7 @@
 "xvE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
 "xvK" = (
@@ -46562,6 +47110,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"xCW" = (
+/obj/structure/cable,
+/turf/open/floor/circuit/green,
+/area/science/robotics/mechbay)
 "xDh" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/closet/crate/coffin,
@@ -46693,11 +47245,10 @@
 /area/hallway/secondary/exit)
 "xFu" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/security{
-	name = "Brig";
-	req_access_txt = "63"
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xFM" = (
@@ -46860,6 +47411,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/lab)
+"xLx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/main)
 "xLM" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
@@ -46899,6 +47461,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "xNm" = (
@@ -46931,6 +47494,11 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/chapel/office)
+"xOz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
 "xOU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47083,12 +47651,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "xUo" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/nuke_storage";
-	dir = 1;
-	name = "Vault APC";
-	pixel_y = 23
-	},
 /obj/structure/filingcabinet/employment,
 /obj/structure/cable,
 /turf/open/floor/vault,
@@ -47122,6 +47684,10 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "xVA" = (
+/mob/living/simple_animal/bot/mulebot{
+	home_destination = "QM #1";
+	suffix = "#1"
+	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light,
 /obj/machinery/navbeacon{
@@ -47130,15 +47696,8 @@
 	freq = 1400;
 	location = "QM #1"
 	},
-/mob/living/simple_animal/bot/mulebot{
-	home_destination = "QM #1";
-	suffix = "#1"
-	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"xVV" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/security/brig)
 "xWk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -47208,8 +47767,14 @@
 "xXQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/donkpockets,
+/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/main)
+"xYa" = (
+/obj/machinery/flasher/portable,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/security/armory)
 "xYt" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv{
@@ -47240,6 +47805,8 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/maintenance/solars/port/fore)
 "xZz" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
 /turf/open/floor/carpet/orange,
 /area/security/detectives_office)
 "yaj" = (
@@ -47450,6 +48017,7 @@
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "ydD" = (
@@ -47499,11 +48067,6 @@
 /obj/item/reagent_containers/blood/a_plus,
 /obj/item/reagent_containers/blood/a_minus,
 /obj/machinery/light,
-/obj/machinery/power/apc{
-	areastring = "/area/medical/surgery";
-	name = "Surgery APC";
-	pixel_y = -23
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -47516,6 +48079,7 @@
 	pixel_x = -10;
 	pixel_y = -22
 	},
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "yen" = (
@@ -47551,6 +48115,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/gateway)
+"yeZ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "yfs" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
@@ -47789,6 +48369,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "ykm" = (
+/mob/living/simple_animal/pet/cat/runtime,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -47807,7 +48388,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/mob/living/simple_animal/pet/cat/runtime,
 /obj/structure/bed/dogbed/runtime,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/cmo)
@@ -47856,6 +48436,8 @@
 /area/crew_quarters/heads/cmo)
 "ymh" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/brig)
 
@@ -60804,11 +61386,11 @@ oFo
 oFo
 jhu
 qpl
-ftA
+hdJ
 mLq
 jes
 uZi
-opY
+uMK
 jYK
 ihX
 nsA
@@ -61061,16 +61643,16 @@ iKe
 dWM
 jhu
 qlb
-ftA
+mPW
 vvX
 jes
 uZi
-opY
+qZR
 wDK
 ihX
-lEY
+hWd
 ezc
-kqr
+svN
 hFs
 gfQ
 gfQ
@@ -61319,10 +61901,10 @@ kTf
 jhu
 wwo
 ftA
-mLq
+gQk
 bzC
 uZi
-opY
+qZR
 opY
 ihX
 lEY
@@ -61836,7 +62418,7 @@ ihX
 wFG
 ihX
 oLM
-ihX
+ogY
 ihX
 ihX
 aOh
@@ -61919,7 +62501,7 @@ bnA
 bnA
 gfQ
 gfQ
-azk
+fsz
 bnA
 odS
 eMT
@@ -62085,15 +62667,15 @@ ygB
 yin
 oFz
 saa
-iKe
+oKE
 wAs
 lYY
 woq
 nqF
+asr
 bez
 bez
-bez
-bez
+ehE
 bez
 hFs
 aOi
@@ -62344,18 +62926,18 @@ pLG
 ktR
 oGZ
 cDu
-mgf
-mgf
+klu
+klu
 vyj
+uUm
 ymh
 ymh
-ymh
-ymh
-ymh
+iof
+kGh
 aIM
 aLT
 xut
-ult
+isl
 klr
 aYP
 xrN
@@ -62599,7 +63181,7 @@ wYE
 yin
 lQn
 qmm
-wDc
+pXa
 mgf
 wDc
 flS
@@ -62607,12 +63189,12 @@ nqF
 nqF
 nXh
 bez
-ymh
+ick
 bez
 hFs
 aOk
 hao
-ult
+mLm
 ult
 ult
 xrN
@@ -62635,11 +63217,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
+fsz
+fsz
+fsz
+fsz
 gfQ
 gfQ
 gfQ
@@ -62864,8 +63446,8 @@ nGU
 nqF
 uRu
 bez
-ymh
-bez
+dux
+sjX
 hFs
 hFs
 hFs
@@ -62892,11 +63474,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+aUP
 gfQ
 avX
 gfQ
-gfQ
+aUP
 gfQ
 gfQ
 gfQ
@@ -63121,7 +63703,7 @@ lFh
 nqF
 uRu
 bez
-ymh
+ick
 bez
 aIO
 aPU
@@ -63149,12 +63731,12 @@ gfQ
 gfQ
 gfQ
 gfQ
+aUP
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
+aUP
+mfS
 gfQ
 gfQ
 gfQ
@@ -63389,7 +63971,7 @@ uzz
 xrN
 kNU
 meM
-nhE
+uGD
 bSs
 pBK
 xrN
@@ -63406,7 +63988,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+aUP
 gfQ
 gfQ
 gfQ
@@ -63635,10 +64217,10 @@ mRd
 hmb
 ciu
 xke
-ymh
-bez
+dux
+ugW
 aJq
-bAi
+nCq
 bAi
 tLS
 aXs
@@ -63646,7 +64228,7 @@ bUD
 xrN
 wLc
 bSs
-bSs
+fWR
 bSs
 cln
 xrN
@@ -63663,7 +64245,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+aUP
 gfQ
 gfQ
 gfQ
@@ -63892,7 +64474,7 @@ eHF
 hmb
 ciu
 sBH
-ymh
+ick
 bez
 bcf
 bku
@@ -63920,7 +64502,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+aEk
 gfQ
 kPn
 gfQ
@@ -64140,17 +64722,17 @@ yin
 caT
 aOm
 aOm
-aOm
+tHd
 yin
-aye
+sSG
 aye
 oHK
 eHF
 hmb
-ciu
+wyY
 xke
-ymh
-bez
+ick
+fHW
 xIr
 xIr
 xIr
@@ -64177,7 +64759,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+aEk
 aEk
 ocl
 aEk
@@ -64397,7 +64979,7 @@ yin
 uea
 sWN
 kvd
-aOm
+vHY
 yin
 jhS
 aye
@@ -64411,15 +64993,15 @@ bez
 bcZ
 aQi
 gpV
+uwe
 cXi
-cXi
-cXi
+rkY
 aZD
-cXi
+uwe
 cXi
 tRl
 cXi
-cXi
+uwe
 bSK
 xIr
 gfQ
@@ -64663,8 +65245,8 @@ xke
 xke
 xke
 xke
-azA
-bez
+oHf
+rtK
 kiu
 cXi
 cXi
@@ -64925,9 +65507,9 @@ bez
 bcZ
 tia
 cXi
-cXi
-cXi
-cXi
+jVL
+wfm
+vkd
 bcN
 cXi
 uwj
@@ -64936,8 +65518,8 @@ vnK
 cXi
 cXi
 xIr
-qfi
-dMW
+nuO
+nuO
 nuO
 nuO
 nuO
@@ -65167,38 +65749,38 @@ xyS
 sIv
 bpR
 xyS
-uDr
+osZ
 wBx
-uDr
-uDr
-uDr
-uDr
-vHv
+osZ
+osZ
+osZ
+osZ
+bTh
 mpE
 aym
-vHv
-azA
+bTh
+qLe
 bez
 bcZ
 tia
 cXi
 yaY
 nXR
-cXi
-bcN
-cXi
-cXi
-tRl
-cXi
-cXi
-cXi
+sPG
+hym
+uoI
+uoI
+xLx
+nTC
+nTC
+oSx
 xIr
 owt
-nuO
+uLg
 gGI
 nuO
 gBo
-nuO
+wMh
 wlQ
 gfQ
 gfQ
@@ -65434,7 +66016,7 @@ aCA
 aFk
 avN
 eDb
-azA
+pex
 bez
 bcZ
 tia
@@ -65444,25 +66026,25 @@ uMa
 cXi
 aZG
 bbj
-cXi
-tRl
-cXi
+uOh
+gVE
+ahL
 eEi
 vVe
 xIr
 dKC
-nuO
+mnE
 eLO
 nuO
 xsg
-nuO
+kBM
 wlQ
 fsz
 fsz
 fsz
 fsz
 fsz
-btp
+gfQ
 aEk
 rmY
 lxT
@@ -65694,7 +66276,7 @@ xke
 azF
 jFn
 xIr
-tia
+jCe
 cXi
 kVM
 uMa
@@ -65706,18 +66288,18 @@ tRl
 rBp
 cqA
 vVe
-bcZ
+rhI
 dLK
-nuO
+mnE
 ibE
 nuO
 gBJ
-nuO
+gHW
 wlQ
 fsz
-cLn
-cLn
-cLn
+aUP
+aUP
+aUP
 fsz
 fsz
 aEk
@@ -65953,28 +66535,28 @@ bez
 bcZ
 tia
 cXi
-cXi
-cXi
-cXi
-bcN
+egL
+mnZ
+lkK
+cme
+nCk
+nCk
+lWv
 buV
 buV
-tRl
-buV
-buV
 cXi
-bcZ
+rhI
 dMY
-nuO
+mnE
 eLR
 nuO
 bcA
-nuO
+gHW
 wlQ
 fsz
-cLn
-cLn
-cLn
+aUP
+aUP
+aUP
 fsz
 fsz
 aEk
@@ -66222,11 +66804,11 @@ cXi
 cXi
 dmp
 nuO
-nuO
+obY
 eLX
-nuO
+oYl
 oJl
-nuO
+iuN
 wlQ
 xke
 xke
@@ -66454,16 +67036,16 @@ gfQ
 gfQ
 gfQ
 gfQ
-aUP
+fsz
 pVH
 aUP
-xVV
+aUP
+aUP
 xke
 xke
 xke
-xke
-azA
-bez
+lsr
+tZP
 bcZ
 gyC
 cXi
@@ -66471,18 +67053,18 @@ oZu
 cXi
 sfI
 rYZ
-rYZ
+bbq
 bcN
 tRl
-rYZ
+bbq
 rYZ
 tjH
-bcZ
+rhI
+thO
 oOk
-oOk
-nuO
-nuO
-oOk
+sst
+eZB
+xYa
 hUo
 wlQ
 hGX
@@ -66711,7 +67293,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-aUP
+fsz
 gfQ
 gfQ
 gfQ
@@ -66719,8 +67301,8 @@ gfQ
 avT
 fRl
 xke
-azA
-bez
+pex
+ttL
 xIr
 bcZ
 bcZ
@@ -66968,7 +67550,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-aUP
+fsz
 sTT
 gfQ
 gfQ
@@ -66976,7 +67558,7 @@ gfQ
 avV
 veT
 gny
-azA
+pex
 bez
 bez
 bez
@@ -66987,14 +67569,14 @@ bez
 bez
 bez
 tPP
-vJy
+sHE
 bez
 bez
 cXp
 bfv
 bfv
 bfv
-bfv
+yeZ
 bfv
 bfv
 bfv
@@ -67225,7 +67807,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-aUP
+fsz
 gfQ
 gfQ
 gfQ
@@ -67233,25 +67815,25 @@ gfQ
 avT
 ayo
 xke
-azD
+lQx
 bez
 bez
 bez
-bez
+qaJ
 bez
 bez
 bez
 bez
 bez
 tPP
-vJy
+sHE
 bez
 bez
 bpv
+qaJ
 bez
 bez
-bez
-bez
+asr
 bez
 bez
 bez
@@ -67260,7 +67842,7 @@ nQs
 bez
 bez
 bez
-bez
+fHW
 xke
 waV
 rqj
@@ -67482,39 +68064,39 @@ gfQ
 gfQ
 gfQ
 gfQ
+fsz
 aUP
 aUP
 aUP
-xVV
+aUP
 xke
 xke
 xke
-xke
-azA
+lgV
+imN
 ymh
 ymh
-ymh
-ymh
+gLx
 ymh
 ymh
 aYR
-deM
+ndz
 deM
 ihf
 olZ
-mik
-mik
-mik
-mik
-mik
+ndz
+bxg
+ndz
+dcP
+ndz
 emM
-mik
-mik
-mik
-mik
+feI
+jhM
+jhM
+jdu
 dPY
 xFu
-mik
+kJH
 mik
 niR
 oqE
@@ -67748,12 +68330,12 @@ gfQ
 yfx
 xke
 bbR
-xke
-xke
-xke
-xke
-xke
-bez
+vQo
+vQo
+vQo
+vQo
+vQo
+kji
 sHE
 aZJ
 jdC
@@ -68017,7 +68599,7 @@ gbh
 tqr
 uIx
 uIx
-uIx
+iVV
 uIx
 uIx
 akz
@@ -68267,15 +68849,15 @@ ciu
 ciu
 ciu
 vQo
-bez
+aYB
 sHE
 kcR
 gbh
 biP
-uIx
-uIx
-uIx
-uIx
+jVV
+dxa
+dfr
+cZR
 uIx
 fxF
 jdC
@@ -68289,8 +68871,8 @@ aEk
 miB
 noK
 osN
-beE
-wFw
+lWI
+rIm
 oCT
 oCT
 ozE
@@ -68519,17 +69101,17 @@ gfQ
 gfQ
 xke
 ciu
-aRc
-aRc
 ciu
+aRc
+aRc
 ciu
 vQo
 bez
 sHE
-kcR
-ctz
-uIx
-uIx
+oJO
+mkQ
+sBT
+sBT
 aRE
 bdS
 wWd
@@ -68776,9 +69358,9 @@ gfQ
 gfQ
 xke
 nTo
+ciu
 bbK
 jYP
-ciu
 ciu
 bbR
 bez
@@ -68786,7 +69368,7 @@ sHE
 kcR
 gbh
 uIx
-uIx
+aSD
 jdC
 bRx
 ibb
@@ -69033,13 +69615,13 @@ gfQ
 gfQ
 xke
 ciu
-aRK
-aRK
 ciu
+aRK
+aRK
 ciu
 vQo
 bez
-sHE
+cUY
 aZK
 gbh
 uIx
@@ -69061,7 +69643,7 @@ mnR
 vAA
 ozB
 sov
-qAh
+rIm
 rwr
 sRw
 tSN
@@ -69316,7 +69898,7 @@ nWs
 nWs
 mor
 noX
-vJh
+sXk
 sov
 sov
 mpc
@@ -69325,7 +69907,7 @@ tUB
 waV
 gfQ
 xBz
-xsr
+vCn
 ust
 ust
 ust
@@ -70377,19 +70959,19 @@ pIn
 tkB
 vZs
 low
-oTQ
-oTQ
-qNv
-qNv
+wcH
+wcH
+fgQ
+fgQ
 rAG
 muZ
-fcJ
-fcJ
-fcJ
-fcJ
-fcJ
-fcJ
-fcJ
+sxe
+sxe
+sxe
+sxe
+sxe
+sxe
+sxe
 rYJ
 uzs
 tuj
@@ -70633,7 +71215,7 @@ iNF
 yfs
 vZs
 vZs
-cDT
+rDp
 aHw
 aHw
 aHw
@@ -70890,7 +71472,7 @@ biz
 mCN
 vZs
 tuj
-qsA
+vHe
 neN
 gfQ
 gfQ
@@ -71095,7 +71677,7 @@ uJa
 foq
 xke
 aYn
-asr
+ngZ
 bAP
 xke
 pWR
@@ -71147,7 +71729,7 @@ fxU
 mne
 vZs
 tuj
-qsA
+vHe
 neN
 gfQ
 gfQ
@@ -71400,11 +71982,11 @@ pLL
 pLL
 pLL
 pLL
-bHq
-raM
+bgK
+pLL
 aTu
-qNv
-jfV
+fgQ
+foP
 neN
 gfQ
 gfQ
@@ -71660,7 +72242,7 @@ dla
 fXf
 aDB
 vZs
-vGt
+tuj
 aof
 neN
 gfQ
@@ -71917,7 +72499,7 @@ vYu
 wAv
 dSR
 vZs
-vGt
+tuj
 qSY
 neN
 gfQ
@@ -72118,7 +72700,7 @@ npx
 sVb
 bhD
 biF
-biQ
+uJa
 uJa
 uJa
 lSd
@@ -72174,7 +72756,7 @@ vYu
 wAv
 gqQ
 vZs
-vGt
+tuj
 aof
 neN
 gfQ
@@ -72431,7 +73013,7 @@ vYu
 wAv
 vYu
 vZs
-vGt
+tuj
 tuj
 neN
 gfQ
@@ -72632,7 +73214,7 @@ sVb
 sVb
 sVb
 fPw
-qaV
+wlT
 aOT
 cTO
 aWq
@@ -72688,7 +73270,7 @@ vYu
 wAv
 vYu
 vZs
-roz
+aof
 aof
 aHw
 gfQ
@@ -72704,7 +73286,7 @@ gfQ
 gfQ
 gfQ
 aHw
-vGt
+tuj
 tuj
 uVD
 tYO
@@ -72945,7 +73527,7 @@ vYu
 wAv
 vYu
 vZs
-vGt
+tuj
 tuj
 aHw
 gfQ
@@ -72961,14 +73543,14 @@ gfQ
 gfQ
 gfQ
 aHw
-vGt
+tuj
 tuj
 tuj
 cmm
 jfV
-xtY
-tuj
-aof
+vGt
+vGt
+roz
 sqP
 puR
 vvc
@@ -73202,7 +73784,7 @@ bqm
 lsb
 bqm
 vZs
-vGt
+tuj
 tuj
 uuC
 aHw
@@ -73218,10 +73800,10 @@ bYN
 bYN
 bYN
 bYN
-qsv
+vQC
 dAn
 tuj
-mmM
+tYO
 rwH
 aof
 rhF
@@ -73459,7 +74041,7 @@ cfI
 hEB
 cfI
 vZs
-vGt
+tuj
 dAn
 naz
 vQC
@@ -73478,7 +74060,7 @@ bYN
 bYN
 bYN
 aof
-rDp
+cDT
 vZs
 vZs
 vQC
@@ -73701,7 +74283,7 @@ tqO
 vKj
 urs
 uzu
-lqj
+mbP
 alf
 wgu
 vKj
@@ -73716,11 +74298,11 @@ cfI
 hEB
 cfI
 vZs
-vGt
-vGt
-xRS
-vGt
-sMp
+tuj
+tuj
+hYd
+tuj
+tuj
 gpP
 csh
 hXX
@@ -73735,7 +74317,7 @@ voR
 mcr
 evw
 lmt
-foP
+jfV
 lzG
 vZs
 oXV
@@ -73962,7 +74544,7 @@ auj
 vKj
 vKj
 vKj
-drV
+uMp
 xGY
 xGY
 xGY
@@ -73973,7 +74555,7 @@ cfI
 hEB
 cfI
 vZs
-qam
+tuj
 tuj
 tuj
 hYd
@@ -73991,7 +74573,7 @@ wTe
 ash
 mpC
 bYN
-mmM
+tYO
 tuj
 naz
 vZs
@@ -74164,7 +74746,7 @@ gfQ
 gfQ
 xhd
 xUQ
-uJa
+xUQ
 arF
 axD
 aul
@@ -74215,7 +74797,7 @@ jXh
 fBW
 xsR
 pVM
-pVM
+aKh
 mRp
 xGY
 xGY
@@ -74248,7 +74830,7 @@ spy
 gVQ
 gnJ
 bYN
-mmM
+tYO
 jls
 aof
 dAn
@@ -74453,8 +75035,8 @@ tnP
 tnP
 tnP
 poo
-xRK
-xRK
+qaS
+hHv
 biS
 wXl
 dou
@@ -74502,7 +75084,7 @@ iXW
 bYN
 irX
 qQf
-kuM
+xOz
 lid
 bYN
 vwh
@@ -74681,7 +75263,7 @@ xUQ
 uJa
 rPO
 rPO
-auf
+tnU
 rPO
 awh
 hFk
@@ -74762,7 +75344,7 @@ rny
 gVQ
 wsN
 bYN
-mmM
+tYO
 tuj
 rfR
 fBs
@@ -74936,7 +75518,7 @@ fsz
 xyp
 aoW
 uJa
-arK
+xUQ
 rPO
 aun
 avx
@@ -74968,14 +75550,14 @@ xtO
 tJT
 xtO
 peX
+uMp
 xGY
-xGY
 xtO
 xtO
 xtO
 xtO
 xtO
-aKB
+uMp
 xGY
 wWn
 xcn
@@ -75015,11 +75597,11 @@ acD
 acG
 bYN
 reB
-wsN
-kuM
+reM
+xOz
 rCl
 bYN
-mmM
+tYO
 tuj
 veV
 fBs
@@ -75519,10 +76101,10 @@ mOJ
 mOJ
 aHt
 vSt
-acq
+rEM
 aHm
 jAT
-acD
+vFy
 ank
 jDr
 acD
@@ -75530,10 +76112,10 @@ eMX
 acQ
 syK
 ltt
-foc
+ldr
 sCZ
 jkP
-mmM
+tYO
 vZs
 hnF
 fBs
@@ -75722,12 +76304,12 @@ mfJ
 wyf
 sVb
 aYW
-ehq
-ehq
-ehq
-xUQ
-xUQ
-cMo
+rIH
+rIH
+rIH
+uJa
+uJa
+aAS
 bhe
 xHv
 bhe
@@ -75780,7 +76362,7 @@ oql
 aHm
 ybc
 acD
-acD
+vFy
 jDr
 acD
 hYH
@@ -75790,7 +76372,7 @@ ldr
 gFd
 oDB
 qNv
-foP
+jfV
 jls
 vQC
 fBs
@@ -75979,7 +76561,7 @@ sVb
 aCY
 sVb
 uJa
-xUQ
+uJa
 xyp
 lSd
 uJa
@@ -75995,7 +76577,7 @@ xvt
 xvt
 iUd
 xvt
-lgr
+uMp
 mDX
 ntJ
 tdq
@@ -76029,7 +76611,7 @@ qCa
 rLe
 exH
 aHm
-lpz
+aHm
 lrT
 kUl
 pRP
@@ -76236,7 +76818,7 @@ aVf
 aHG
 sVb
 aYX
-xUQ
+uJa
 uJa
 uJa
 fRC
@@ -76291,7 +76873,7 @@ acJ
 hEI
 jtX
 lMQ
-jtX
+vPT
 jtX
 iPX
 jtX
@@ -76303,7 +76885,7 @@ poL
 ldr
 jnC
 sCZ
-oGh
+vGt
 tuj
 vZs
 vZs
@@ -76493,7 +77075,7 @@ sVb
 sVb
 sVb
 uJa
-ehq
+rIH
 rSo
 rSo
 rSo
@@ -76510,7 +77092,7 @@ gLp
 ybR
 wyW
 xvt
-xGY
+uMp
 aXZ
 tdq
 oqm
@@ -76750,7 +77332,7 @@ dea
 uJa
 rIH
 rIH
-aZP
+rIH
 rSo
 aIr
 bIx
@@ -76767,7 +77349,7 @@ uoG
 bdI
 aKk
 aJU
-xGY
+uMp
 nvk
 vyu
 vyu
@@ -77053,7 +77635,7 @@ yfY
 yfY
 yfY
 yfY
-hid
+cfI
 mvt
 clA
 rxU
@@ -77591,7 +78173,7 @@ rEK
 fjP
 fZN
 qBL
-hFQ
+vGt
 fBs
 lQG
 imv
@@ -79030,7 +79612,7 @@ afp
 kfL
 afs
 afs
-kfL
+dOM
 kfL
 kfL
 kfL
@@ -79287,7 +79869,7 @@ wYX
 wYX
 wYX
 wYX
-wYX
+wmK
 wYX
 wYX
 wYX
@@ -79863,7 +80445,7 @@ uWy
 vTP
 uGs
 ycD
-abF
+pQP
 abK
 vyu
 vyu
@@ -80418,7 +81000,7 @@ gnu
 gnu
 sFT
 mSn
-cwL
+oMD
 pty
 stt
 qrr
@@ -81193,7 +81775,7 @@ eUg
 cxf
 yaC
 ulu
-ulu
+mTd
 gmz
 gmz
 gmz
@@ -81343,7 +81925,7 @@ wYX
 wYX
 wYX
 wYX
-wYX
+wmK
 wYX
 wYX
 wYX
@@ -81404,7 +81986,7 @@ sEy
 bgt
 bgt
 bgo
-bgt
+jTo
 xcl
 bgN
 bhk
@@ -81450,7 +82032,7 @@ sis
 cxf
 vAa
 ulu
-ulu
+mTd
 nbb
 leO
 pZr
@@ -81600,7 +82182,7 @@ afr
 aem
 aft
 aft
-aem
+eqU
 aem
 aem
 aem
@@ -81707,7 +82289,7 @@ vmQ
 cxf
 kvM
 ulu
-ulu
+mTd
 ewg
 pnk
 fig
@@ -81887,7 +82469,7 @@ bcV
 ivy
 ivy
 bsK
-ivy
+vHo
 ivy
 brG
 bdJ
@@ -81964,7 +82546,7 @@ xrb
 cxf
 lyY
 ulu
-ulu
+mTd
 vKo
 vKo
 vKo
@@ -82144,8 +82726,8 @@ aGy
 aGy
 agn
 qxD
-aGy
-aGy
+rqA
+rqA
 aZf
 ivy
 tGp
@@ -82221,7 +82803,7 @@ gUz
 cxf
 jzC
 ulu
-ulu
+dFh
 oyQ
 pWI
 lkO
@@ -82733,9 +83315,9 @@ qtc
 tJB
 ppA
 dnU
-jqK
-jqK
-vxS
+vmQ
+vmQ
+sis
 yam
 vmQ
 vmQ
@@ -82905,7 +83487,7 @@ gfQ
 gfQ
 ybK
 hyg
-auD
+vhx
 xNm
 xNm
 xNm
@@ -83223,11 +83805,11 @@ aKO
 pnn
 jJn
 rLe
-gTU
-aod
-mJQ
-mJQ
-mJQ
+uio
+tmT
+yal
+yal
+yal
 dxv
 tTH
 tTH
@@ -83933,7 +84515,7 @@ ybK
 ybK
 ybK
 ybK
-vhx
+trn
 xNm
 awD
 xNm
@@ -84504,7 +85086,7 @@ shF
 rZB
 bKt
 pjE
-kup
+lyG
 pnn
 rau
 ojV
@@ -86041,7 +86623,7 @@ pjE
 pjE
 pjE
 pjE
-lyG
+jeG
 pnn
 pnn
 pnn
@@ -86829,7 +87411,7 @@ lMX
 buL
 inj
 wZK
-jcA
+qAe
 cND
 cND
 iyG
@@ -87086,7 +87668,7 @@ prv
 eXs
 hhY
 wZK
-jcA
+qAe
 cND
 cND
 cND
@@ -87345,8 +87927,8 @@ gQg
 cKk
 cos
 ieQ
-vAN
-vAN
+hMM
+hMM
 tkl
 cND
 ezH
@@ -89631,10 +90213,10 @@ ljx
 muF
 fBg
 oib
-fBg
+xCW
 bmt
 tEA
-tqN
+vnF
 vNW
 tmj
 swp
@@ -90716,7 +91298,7 @@ mlW
 mnV
 rip
 mnV
-whm
+utH
 idc
 gfQ
 gfQ
@@ -92738,7 +93320,7 @@ cAP
 tZZ
 hvE
 thC
-vqZ
+mJQ
 xsd
 thC
 iTL
@@ -94525,8 +95107,8 @@ tWG
 njM
 hKA
 mGj
-ppu
-ppu
+nlX
+nlX
 nlX
 nlX
 wPG
@@ -95502,7 +96084,7 @@ fsz
 fsz
 fsz
 fsz
-azk
+fsz
 fsz
 fsz
 xxF
@@ -98885,11 +99467,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+qtO
 gfQ
 uir
 gfQ
-gfQ
+qtO
 gfQ
 fsz
 gfQ
@@ -99142,11 +99724,11 @@ gfQ
 gfQ
 gfQ
 gfQ
+aUP
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+aUP
 gfQ
 fsz
 gfQ
@@ -99399,11 +99981,11 @@ gfQ
 gfQ
 xAV
 gfQ
+aUP
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+aUP
 gfQ
 gfQ
 gfQ
@@ -99656,11 +100238,11 @@ gfQ
 gfQ
 gfQ
 gfQ
+aUP
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+aUP
 gfQ
 gfQ
 fsz
@@ -99913,11 +100495,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+aUP
 gfQ
 tAr
 gfQ
-gfQ
+aUP
 gfQ
 gfQ
 gfQ
@@ -100170,11 +100752,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
+fsz
+fsz
+fsz
+fsz
 gfQ
 gfQ
 gfQ


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lima Security 2.0 - 
- Warden's office moved up to the hallway.
- Detective office now in sec proper.
- Old det office now vacant office.
- Cells are flashy now.
- Proper briefing room that leads to HOS room (aligns with TG's normal design)
- Armory got shifted around a bit
- Sec EVA moved out of armory, woo.
- Exit to space within sec
- Speaking of space? Sec escape pod.
- Firing range added.
- McGriff still good pupper, Lia still good feesh.
- Perma mostly unchanged, just area fixes with the cells and 'maint' areas moved to /prison/safe areas.

Ton of decal cleanup
Area fixes.
APCs swapped to autoname.
## Why It's Good For The Game

Security was bad. Now is less bad. Can't wait to see what all you fucks find that I messed up/forgot again.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: limasec 2.0
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
