### PR TITLE
Messes with our CI again (maybe it'll work this time?)

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -98,7 +98,7 @@ jobs:
           bash tools/ci/install_byond.sh
           source $HOME/BYOND/byond/bin/byondsetup
           tgui/bin/tgui --build
-          bash tools/ci/dm.sh -DCIBUILDING tgstation.dme
+          bash tools/ci/dm.sh -DCIBUILDING jollystation.dme
           bash tools/ci/run_server.sh
 
   test_windows:

--- a/tools/ci/build.ps1
+++ b/tools/ci/build.ps1
@@ -7,5 +7,5 @@ if(!(Test-Path -Path "C:/byond")){
 bash tools/ci/install_node.sh
 bash tgui/bin/tgui --build
 
-&"C:/byond/bin/dm.exe" -max_errors 0 tgstation.dme
+&"C:/byond/bin/dm.exe" -max_errors 0 jollystation.dme
 exit $LASTEXITCODE

--- a/tools/ci/run_server.sh
+++ b/tools/ci/run_server.sh
@@ -8,6 +8,6 @@ mkdir ci_test/config
 cp tools/ci/ci_config.txt ci_test/config/config.txt
 
 cd ci_test
-DreamDaemon tgstation.dmb -close -trusted -verbose -params "log-directory=ci"
+DreamDaemon jollystation.dmb -close -trusted -verbose -params "log-directory=ci"
 cd ..
 cat ci_test/data/logs/ci/clean_run.lk

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -20,7 +20,7 @@ if [ -d ".git" ]; then
   cp -r .git/logs/* $1/.git/logs/
 fi
 
-cp tgstation.dmb tgstation.rsc $1/
+cp jollystation.dmb jollystation.rsc $1/
 cp -r _maps/* $1/_maps/
 cp -r icons/runtime/* $1/icons/runtime/
 cp -r sound/runtime/* $1/sound/runtime/


### PR DESCRIPTION
Tools are all hard-lined to compile with tgstation.dme, so... just swapping it over to work with out dme could work. Alternatively we could just go back to using tgstation.dme.