### PR TITLE
Pixelshifting

### DIFF
--- a/jollystation.dme
+++ b/jollystation.dme
@@ -3502,6 +3502,7 @@
 #include "jollystation_modules\code\modules\mob\logout.dm"
 #include "jollystation_modules\code\modules\mob\mob.dm"
 #include "jollystation_modules\code\modules\mob\mob_defines.dm"
+#include "jollystation_modules\code\modules\mob\pixel_shift.dm"
 #include "jollystation_modules\code\modules\mob\typing_indicator.dm"
 #include "jollystation_modules\code\modules\mob\dead\new_player\sprite_accessories.dm"
 #include "jollystation_modules\code\modules\mob\living\living.dm"

--- a/jollystation_modules/code/modules/mob/pixel_shift.dm
+++ b/jollystation_modules/code/modules/mob/pixel_shift.dm
@@ -1,12 +1,23 @@
+#define COMSIG_PIXELSHIFT_POSY "pixelshift_posy"
+#define COMSIG_PIXELSHIFT_POSX "pixelshift_posx"
+#define COMSIG_PIXELSHIFT_NEGY "pixelshift_negy"
+#define COMSIG_PIXELSHIFT_NEGX "pixelshift_negx"
+
+#define COMSIG_PIXELSHIFT_RESET "pixelshift_reset"
+#define COMSIG_PIXELSHIFT_STOP "pixelshift_stop"
+
+/datum/keybinding/mob/prevent_movement/can_use(client/user)
+	var/mob/living/our_mob = user.mob
+	if(istype(our_mob))
+		if(our_mob.pixel_shifted)
+			return FALSE
+	return ..()
 /mob/living
 	var/pixel_shifted = FALSE
 
 /mob/living/verb/open_pixel_shift_ui()
 	set name = "Pixel Shift"
 	set category = "IC"
-
-	if(pixel_shifted)
-		return
 
 	if(stat != CONSCIOUS)
 		to_chat(src, "<span class='danger'>You need to be conscious to use pixel shifting.</span>")
@@ -16,41 +27,33 @@
 		to_chat(src, "<span class='danger'>You aren't able to use pixel shifting right now.</span>")
 		return
 
-	if(combat_mode)
-		to_chat(src, "<span class='danger'>You can't use pixel shifting while in combat mode.</span>")
-		return
-
 	var/datum/pixel_shift_ui/tgui = new(src)
 	tgui.ui_interact(src)
 
 /datum/pixel_shift_ui
 	var/mob/living/ui_user
-	var/x_shift = 0
-	var/y_shift = 0
 
 /datum/pixel_shift_ui/New(mob/living/user)
 	ui_user = user
-	ui_user.pixel_shifted = TRUE
-	if(!istype(ui_user))
-		CRASH("pixel_shift_ui passed a non-living mob")
-
-	x_shift = user.pixel_x
-	y_shift = user.pixel_y
-	RegisterSignal(ui_user, COMSIG_MOVABLE_PRE_MOVE, .proc/reset_offsets)
+	ui_user.AddComponent(/datum/component/pixel_shift)
 
 /datum/pixel_shift_ui/ui_close(mob/user)
-	UnregisterSignal(ui_user, COMSIG_MOVABLE_PRE_MOVE)
-	reset_offsets()
-	ui_user.pixel_shifted = FALSE
+	SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_STOP)
 	qdel(src)
 
-/datum/pixel_shift_ui/ui_state(mob/user)
-	return GLOB.not_incapacitated_state
+/datum/pixel_shift_ui/ui_status(mob/user, datum/ui_state/state)
+	if(!ui_user.pixel_shifted)
+		return UI_CLOSE
+	if(ui_user.stat != CONSCIOUS)
+		return UI_CLOSE
+	if(HAS_TRAIT(src, TRAIT_UI_BLOCKED) || ui_user.incapacitated())
+		return UI_DISABLED
+	return UI_INTERACTIVE
 
 /datum/pixel_shift_ui/ui_data(mob/user)
 	var/list/data = list()
-	data["x_shift"] = x_shift
-	data["y_shift"] = y_shift
+	data["x_shift"] = ui_user.pixel_x
+	data["y_shift"] = ui_user.pixel_y
 
 	return data
 
@@ -66,22 +69,105 @@
 		return
 
 	switch(action)
-		if("shift_x")
-			x_shift = clamp(params["shift_amount"] + x_shift, -16, 16)
-			update_offsets()
-		if("shift_y")
-			y_shift = clamp(params["shift_amount"] + y_shift, -16, 16)
-			update_offsets()
+		if("shift_posx")
+			SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_POSX)
+		if("shift_negx")
+			SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_NEGX)
+		if("shift_posy")
+			SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_POSY)
+		if("shift_negy")
+			SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_NEGY)
 		if("reset_shift")
-			reset_offsets()
+			SEND_SIGNAL(ui_user, COMSIG_PIXELSHIFT_RESET)
 
 	return TRUE
 
-/datum/pixel_shift_ui/proc/update_offsets()
-	ui_user.pixel_x = x_shift
-	ui_user.pixel_y = y_shift
+/datum/component/pixel_shift
+	dupe_mode = COMPONENT_DUPE_UNIQUE
+	var/mob/living/living_parent
+	var/x_shift = 0
+	var/y_shift = 0
 
-/datum/pixel_shift_ui/proc/reset_offsets()
-	x_shift = ui_user.base_pixel_x + ui_user.body_position_pixel_x_offset
-	y_shift = ui_user.base_pixel_y + ui_user.body_position_pixel_y_offset
+/datum/component/pixel_shift/Initialize()
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+
+	living_parent = parent
+	living_parent.client.movement_locked = TRUE
+	living_parent.pixel_shifted = TRUE
+	x_shift = living_parent.pixel_x
+	y_shift = living_parent.pixel_y
+
+	RegisterSignal(parent, list(COMSIG_MOVABLE_PRE_MOVE, COMSIG_PIXELSHIFT_RESET), .proc/reset_offsets)
+	RegisterSignal(parent, list(COMSIG_KB_MOVEMENT_NORTH_DOWN, COMSIG_PIXELSHIFT_POSY), .proc/shift_pos_y)
+	RegisterSignal(parent, list(COMSIG_KB_MOVEMENT_EAST_DOWN, COMSIG_PIXELSHIFT_POSX), .proc/shift_pos_x)
+	RegisterSignal(parent, list(COMSIG_KB_MOVEMENT_SOUTH_DOWN, COMSIG_PIXELSHIFT_NEGY), .proc/shift_neg_y)
+	RegisterSignal(parent, list(COMSIG_KB_MOVEMENT_WEST_DOWN, COMSIG_PIXELSHIFT_NEGX), .proc/shift_neg_x)
+	RegisterSignal(parent, list(COMSIG_LIVING_RESIST, COMSIG_LIVING_GET_PULLED, COMSIG_PIXELSHIFT_STOP), .proc/stop_pixel_shift)
+
+	to_chat(parent, "<span class='notice'>You are now pixel shifting. Movement has been locked. <b>Resist</b> or close the UI to stop pixel shifting.</span>")
+
+/datum/component/pixel_shift/Destroy()
+	reset_offsets()
+	living_parent.client.movement_locked = FALSE
+	living_parent.pixel_shifted = FALSE
+	living_parent = null
+	UnregisterSignal(parent, list(
+		COMSIG_MOVABLE_PRE_MOVE,
+		COMSIG_PIXELSHIFT_RESET,
+		COMSIG_LIVING_RESIST,
+		COMSIG_LIVING_GET_PULLED,
+		COMSIG_PIXELSHIFT_STOP,
+		COMSIG_KB_MOVEMENT_NORTH_DOWN,
+		COMSIG_PIXELSHIFT_POSY,
+		COMSIG_KB_MOVEMENT_EAST_DOWN,
+		COMSIG_PIXELSHIFT_POSX,
+		COMSIG_KB_MOVEMENT_SOUTH_DOWN,
+		COMSIG_PIXELSHIFT_NEGY,
+		COMSIG_KB_MOVEMENT_WEST_DOWN,
+		COMSIG_PIXELSHIFT_NEGX,
+	))
+
+	to_chat(parent, "<span class='notice'>You are no longer pixel shifting. Movement has been unlocked.</span>")
+	return ..()
+
+/datum/component/pixel_shift/proc/shift_pos_y(datum/source)
+	SIGNAL_HANDLER
+
+	y_shift = clamp(y_shift + 1, -16, 16)
 	update_offsets()
+
+/datum/component/pixel_shift/proc/shift_pos_x(datum/source)
+	SIGNAL_HANDLER
+
+	x_shift = clamp(x_shift + 1, -16, 16)
+	update_offsets()
+
+/datum/component/pixel_shift/proc/shift_neg_y(datum/source)
+	SIGNAL_HANDLER
+
+	y_shift = clamp(y_shift - 1, -16, 16)
+	update_offsets()
+
+/datum/component/pixel_shift/proc/shift_neg_x(datum/source)
+	SIGNAL_HANDLER
+
+	x_shift = clamp(x_shift - 1, -16, 16)
+	update_offsets()
+
+/datum/component/pixel_shift/proc/reset_offsets()
+	SIGNAL_HANDLER
+
+	x_shift = living_parent.base_pixel_x + living_parent.body_position_pixel_x_offset
+	y_shift = living_parent.base_pixel_y + living_parent.body_position_pixel_y_offset
+	update_offsets()
+
+/datum/component/pixel_shift/proc/stop_pixel_shift()
+	SIGNAL_HANDLER
+
+	reset_offsets()
+	qdel(src)
+
+/datum/component/pixel_shift/proc/update_offsets()
+	living_parent.pixel_x = x_shift
+	living_parent.pixel_y = y_shift

--- a/jollystation_modules/code/modules/mob/pixel_shift.dm
+++ b/jollystation_modules/code/modules/mob/pixel_shift.dm
@@ -13,7 +13,7 @@
 /// Signal to stop pixelshifting.
 #define COMSIG_PIXELSHIFT_STOP "pixelshift_stop"
 
-/// Defines for mins and maxs of each direction shift.
+/// Defines for mins and maxs of x and y shifts.
 #define PIXELSHIFT_Y_LIMIT 16
 #define PIXELSHIFT_X_LIMIT 16
 

--- a/jollystation_modules/code/modules/mob/pixel_shift.dm
+++ b/jollystation_modules/code/modules/mob/pixel_shift.dm
@@ -12,12 +12,16 @@
 		if(our_mob.pixel_shifted)
 			return FALSE
 	return ..()
+
 /mob/living
 	var/pixel_shifted = FALSE
 
 /mob/living/verb/open_pixel_shift_ui()
 	set name = "Pixel Shift"
 	set category = "IC"
+
+	if(pixel_shifted)
+		return
 
 	if(stat != CONSCIOUS)
 		to_chat(src, "<span class='danger'>You need to be conscious to use pixel shifting.</span>")
@@ -46,7 +50,7 @@
 		return UI_CLOSE
 	if(ui_user.stat != CONSCIOUS)
 		return UI_CLOSE
-	if(HAS_TRAIT(src, TRAIT_UI_BLOCKED) || ui_user.incapacitated())
+	if(ui_user.incapacitated())
 		return UI_DISABLED
 	return UI_INTERACTIVE
 

--- a/jollystation_modules/code/modules/mob/pixel_shift.dm
+++ b/jollystation_modules/code/modules/mob/pixel_shift.dm
@@ -1,0 +1,87 @@
+/mob/living
+	var/pixel_shifted = FALSE
+
+/mob/living/verb/open_pixel_shift_ui()
+	set name = "Pixel Shift"
+	set category = "IC"
+
+	if(pixel_shifted)
+		return
+
+	if(stat != CONSCIOUS)
+		to_chat(src, "<span class='danger'>You need to be conscious to use pixel shifting.</span>")
+		return
+
+	if(incapacitated())
+		to_chat(src, "<span class='danger'>You aren't able to use pixel shifting right now.</span>")
+		return
+
+	if(combat_mode)
+		to_chat(src, "<span class='danger'>You can't use pixel shifting while in combat mode.</span>")
+		return
+
+	var/datum/pixel_shift_ui/tgui = new(src)
+	tgui.ui_interact(src)
+
+/datum/pixel_shift_ui
+	var/mob/living/ui_user
+	var/x_shift = 0
+	var/y_shift = 0
+
+/datum/pixel_shift_ui/New(mob/living/user)
+	ui_user = user
+	ui_user.pixel_shifted = TRUE
+	if(!istype(ui_user))
+		CRASH("pixel_shift_ui passed a non-living mob")
+
+	x_shift = user.pixel_x
+	y_shift = user.pixel_y
+	RegisterSignal(ui_user, COMSIG_MOVABLE_PRE_MOVE, .proc/reset_offsets)
+
+/datum/pixel_shift_ui/ui_close(mob/user)
+	UnregisterSignal(ui_user, COMSIG_MOVABLE_PRE_MOVE)
+	reset_offsets()
+	ui_user.pixel_shifted = FALSE
+	qdel(src)
+
+/datum/pixel_shift_ui/ui_state(mob/user)
+	return GLOB.not_incapacitated_state
+
+/datum/pixel_shift_ui/ui_data(mob/user)
+	var/list/data = list()
+	data["x_shift"] = x_shift
+	data["y_shift"] = y_shift
+
+	return data
+
+/datum/pixel_shift_ui/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "_PixelShift")
+		ui.open()
+
+/datum/pixel_shift_ui/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	switch(action)
+		if("shift_x")
+			x_shift = clamp(params["shift_amount"] + x_shift, -16, 16)
+			update_offsets()
+		if("shift_y")
+			y_shift = clamp(params["shift_amount"] + y_shift, -16, 16)
+			update_offsets()
+		if("reset_shift")
+			reset_offsets()
+
+	return TRUE
+
+/datum/pixel_shift_ui/proc/update_offsets()
+	ui_user.pixel_x = x_shift
+	ui_user.pixel_y = y_shift
+
+/datum/pixel_shift_ui/proc/reset_offsets()
+	x_shift = ui_user.base_pixel_x + ui_user.body_position_pixel_x_offset
+	y_shift = ui_user.base_pixel_y + ui_user.body_position_pixel_y_offset
+	update_offsets()

--- a/tgui/packages/tgui/interfaces/_PixelShift.js
+++ b/tgui/packages/tgui/interfaces/_PixelShift.js
@@ -18,31 +18,31 @@ export const _PixelShift = (props, context) => {
           <Stack.Item>
             <Button
               align="center"
-              icon='arrow-up'
+              icon="arrow-up"
               onClick={() => act('shift_posy')} />
           </Stack.Item>
           <Stack.Item>
             <Stack>
               <Stack.Item>
                 <Button
-                icon='arrow-left'
-                onClick={() => act('shift_negx')} />
+                  icon="arrow-left"
+                  onClick={() => act('shift_negx')} />
               </Stack.Item>
               <Stack.Item>
                 <Button
-                  icon='times'
+                  icon="times"
                   onClick={() => act('reset_shift')} />
               </Stack.Item>
               <Stack.Item>
                 <Button
-                  icon='arrow-right'
+                  icon="arrow-right"
                   onClick={() => act('shift_posx')} />
               </Stack.Item>
             </Stack>
           </Stack.Item>
           <Stack.Item>
             <Button
-              icon='arrow-down'
+              icon="arrow-down"
               onClick={() => act('shift_negy')} />
           </Stack.Item>
           <Stack.Item>

--- a/tgui/packages/tgui/interfaces/_PixelShift.js
+++ b/tgui/packages/tgui/interfaces/_PixelShift.js
@@ -19,14 +19,14 @@ export const _PixelShift = (props, context) => {
             <Button
               align="center"
               icon='arrow-up'
-              onClick={() => act('shift_y', { shift_amount: 1 })} />
+              onClick={() => act('shift_posy')} />
           </Stack.Item>
           <Stack.Item>
             <Stack>
               <Stack.Item>
                 <Button
                 icon='arrow-left'
-                onClick={() => act('shift_x', { shift_amount: -1 })} />
+                onClick={() => act('shift_negx')} />
               </Stack.Item>
               <Stack.Item>
                 <Button
@@ -36,14 +36,14 @@ export const _PixelShift = (props, context) => {
               <Stack.Item>
                 <Button
                   icon='arrow-right'
-                  onClick={() => act('shift_x', { shift_amount: 1 })} />
+                  onClick={() => act('shift_posx')} />
               </Stack.Item>
             </Stack>
           </Stack.Item>
           <Stack.Item>
             <Button
               icon='arrow-down'
-              onClick={() => act('shift_y', { shift_amount: -1 })} />
+              onClick={() => act('shift_negy')} />
           </Stack.Item>
           <Stack.Item>
             <Box>

--- a/tgui/packages/tgui/interfaces/_PixelShift.js
+++ b/tgui/packages/tgui/interfaces/_PixelShift.js
@@ -1,0 +1,60 @@
+import { useBackend } from '../backend';
+import { Box, Button, Stack } from '../components';
+import { Window } from '../layouts';
+
+export const _PixelShift = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    x_shift,
+    y_shift,
+  } = data;
+  return (
+    <Window
+      title="Pixel Shift"
+      width={200}
+      height={150}>
+      <Window.Content>
+        <Stack vertical align="center">
+          <Stack.Item>
+            <Button
+              align="center"
+              icon='arrow-up'
+              onClick={() => act('shift_y', { shift_amount: 1 })} />
+          </Stack.Item>
+          <Stack.Item>
+            <Stack>
+              <Stack.Item>
+                <Button
+                icon='arrow-left'
+                onClick={() => act('shift_x', { shift_amount: -1 })} />
+              </Stack.Item>
+              <Stack.Item>
+                <Button
+                  icon='times'
+                  onClick={() => act('reset_shift')} />
+              </Stack.Item>
+              <Stack.Item>
+                <Button
+                  icon='arrow-right'
+                  onClick={() => act('shift_x', { shift_amount: 1 })} />
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+          <Stack.Item>
+            <Button
+              icon='arrow-down'
+              onClick={() => act('shift_y', { shift_amount: -1 })} />
+          </Stack.Item>
+          <Stack.Item>
+            <Box>
+              X offset: {x_shift}
+            </Box>
+            <Box>
+              Y offset: {y_shift}
+            </Box>
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/51863163/114355779-7dbc5a80-9b35-11eb-8720-5be59873c94e.png)

Requested feature, pixel shifting. Done entirely modularly. 

### Pixel shifting:

- You can begin pixel shifting by pressing "ALT+B" (default bind, rebindable) or by using the "Pixel Shift" verb in the IC tab.
- Starting pixel shifting will lock your movement and open the Pixel Shift UI. 
- While the UI is open, you cannot move. The buttons on the UI will shift you around, and using the movement keys will also shift you around.
- To stop pixel shifting and regain movement, you can resist, press the keybind again, or close the UI. Doing so will free you and reset you back to normal pixel offsets.

### Code-side explanation:

- This version of pixel-shifting is done via component and TGUI. The component handles all the signals for pixelshfiting certain directions, tracking where your original state is, and handling reseting your offset. It also handles locking and unlocking movement. This is done entirely modularly via signals. The corresponding TGUI coded sends signals to shift certain directions when buttons are pressed. 

### Also feedback is wanted

- I don't like how it locks movement tbh and would like feedback for people who use it in action.

