### PR TITLE
Autotransfer vote / Crewtransfer (Automatic votes, config inside)

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -377,7 +377,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		return
 	if(SSvote.mode) //Theres already a vote running, default to rotation.
 		maprotate()
-	SSvote.initiate_vote("map", "automatic map rotation")
+	SSvote.initiate_vote("map", "automatic map rotation", TRUE) // NON-MODULE CHANGE: AUTOTRANSFER
 
 /datum/controller/subsystem/mapping/proc/changemap(datum/map_config/VM)
 	if(!VM.MakeNextMap())

--- a/config/config.txt
+++ b/config/config.txt
@@ -536,3 +536,20 @@ DEFAULT_VIEW_SQUARE 15x15
 
 ## Add the ID of the role you want assigning here
 #DISCORD_ROLEID 000000000000000000
+
+
+
+#############################
+#### MODULE CONFIG STUFF ####
+
+## allow players to OOCly vote for a shuttle call after a certain amount of time
+#ALLOW_VOTE_TRANSFER
+
+## whether or not transfer votes are automatically called at [TRANSFER_TIME_MIN_ALLOWED] and every [TRANSFER_TIME_BETWEEN_AUTO_VOTES] after.
+TRANSFER_AUTO_VOTE_ENABLED
+
+## minimum shift length allowed before transfer votes are enabled. Also when auto transfer votes begin, if enabled. (default 54000 = 1.5 hours)
+TRANSFER_TIME_MIN_ALLOWED 54000
+
+## amount of time between automatic transfer votes. (default 18000 = 30 minutes)
+TRANSFER_TIME_BETWEEN_AUTO_VOTES 18000

--- a/jollystation.dme
+++ b/jollystation.dme
@@ -3523,6 +3523,8 @@
 #include "jollystation_modules\code\__DEFINES\jobs.dm"
 #include "jollystation_modules\code\__DEFINES\keybinding.dm"
 #include "jollystation_modules\code\__HELPERS\text_helpers.dm"
+#include "jollystation_modules\code\controllers\configuration\entries\autotransfer.dm"
+#include "jollystation_modules\code\controllers\subsystem\autotransfer.dm"
 #include "jollystation_modules\code\datums\elements\unique_examine.dm"
 #include "jollystation_modules\code\datums\id_trim\jobs.dm"
 #include "jollystation_modules\code\datums\keybinding\communication.dm"

--- a/jollystation_modules/code/controllers/configuration/entries/autotransfer.dm
+++ b/jollystation_modules/code/controllers/configuration/entries/autotransfer.dm
@@ -1,0 +1,18 @@
+// Auto-transfer config values.
+/// Allow people to call votes for shuttle OOCly
+/datum/config_entry/flag/allow_vote_transfer
+
+/// Automatic crew transfer votes that start at [transfer_time_min_allowed] and happen every [transfer_time_between_auto_votes]
+/datum/config_entry/flag/transfer_auto_vote_enabled
+
+/// Minimum shift length before transfer votes can begin
+/datum/config_entry/number/transfer_time_min_allowed
+	config_entry_value = 1.5 HOURS
+	integer = FALSE
+	min_val = 5 MINUTES
+
+/// Time between auto transfer votes
+/datum/config_entry/number/transfer_time_between_auto_votes
+	config_entry_value = 30 MINUTES
+	integer = FALSE
+	min_val = 2 MINUTES

--- a/jollystation_modules/code/controllers/subsystem/autotransfer.dm
+++ b/jollystation_modules/code/controllers/subsystem/autotransfer.dm
@@ -1,0 +1,100 @@
+/** Crew Transfer Vote SS
+  *
+  * Tracks information about Crew transfer votes and calls auto transfer votes.
+  *
+  * If enabled, calls a vote [minimum_transfer_time] into the round, and every [minimum_time_between_votes] after that.
+  *
+  */
+SUBSYSTEM_DEF(crewtransfer)
+	name = "Crew Transfer Vote"
+	wait = 600
+	runlevels = RUNLEVEL_GAME
+	/// Number of votes attempted total, including auto and manual votes
+	var/transfer_votes_attempted = 0
+	/// Minimum shift length before automatic votes begin - from config.
+	var/minimum_transfer_time = 0
+	/// Minimum length of time between automatic votes - from config.
+	var/minimum_time_between_votes = 0
+	/// We stop calling votes if a vote passed
+	var/transfer_vote_successful = FALSE
+
+/datum/controller/subsystem/crewtransfer/Initialize(timeofday)
+
+	if(!CONFIG_GET(flag/transfer_auto_vote_enabled))
+		can_fire = FALSE
+
+	minimum_transfer_time = CONFIG_GET(number/transfer_time_min_allowed)
+	minimum_time_between_votes = CONFIG_GET(number/transfer_time_between_auto_votes)
+	wait = minimum_transfer_time //first vote will fire at [minimum_transfer_time]
+
+	return ..()
+
+/datum/controller/subsystem/crewtransfer/fire()
+	//we can't vote if we don't have a functioning democracy
+	if(!SSvote)
+		disable_vote()
+		CRASH("Voting subsystem not found, but the crew transfer vote subsystem is!")
+
+	//if it fires before it's supposed to be allowed, cut it out
+	if(world.time - SSticker.round_start_time < minimum_transfer_time)
+		return
+
+	//if the shuttle is called and uncreallable, docked or beyond, or a transfer vote succeeded, stop firing
+	if(EMERGENCY_PAST_POINT_OF_NO_RETURN || transfer_vote_successful)
+		disable_vote()
+		return
+
+	//time to actually call the transfer vote.
+	//if the transfer vote is unable to be called, try again in 2 minutes.
+	//if the transfer vote begins successfully, then we'll come back in [minimum_time_between_votes]
+	wait = autocall_crew_transfer_vote() ? minimum_time_between_votes : 2 MINUTES
+
+/// prevents the crew transfer SS from firing.
+/datum/controller/subsystem/crewtransfer/proc/disable_vote()
+	can_fire = FALSE
+	message_admins("[name] system has been disabled and automatic votes will no longer be called.")
+	return TRUE
+
+/// Call an crew transfer vote from the server if a vote isn't running.
+/// returns TRUE if it successfully called a vote, FALSE if it failed.
+/datum/controller/subsystem/crewtransfer/proc/autocall_crew_transfer_vote()
+	//we won't call a vote if we shouldn't be able to leave
+	if(SSshuttle.emergencyNoEscape)
+		message_admins("Automatic crew transfer vote prevented due to hostile situation.")
+		return FALSE
+
+	//we won't call a vote if a vote is running
+	if(SSvote.mode)
+		message_admins("Automatic crew transfer vote prevented due to ongoing vote.")
+		return FALSE
+
+	message_admins("Automatic crew transfer vote initiated.")
+	SSvote.initiate_vote("transfer", "the server", TRUE)
+	return TRUE
+
+/// initiates the shuttle call and logs it.
+/datum/controller/subsystem/crewtransfer/proc/initiate_crew_transfer()
+	if(EMERGENCY_IDLE_OR_RECALLED)
+		/// The multiplier on the shuttle's timer
+		var/shuttle_time_mult = 1
+		/// Security level (for timer multiplier)
+		var/security_num = seclevel2num(get_security_level())
+		switch(security_num)
+			if(SEC_LEVEL_GREEN)
+				shuttle_time_mult = 2 // = ~20 minutes
+			if(SEC_LEVEL_BLUE)
+				shuttle_time_mult = 1.5 // = ~15 minutes
+
+		SSshuttle.emergency.request(reason = "\nReason:\n\nCrew transfer vote successful, dispatching shuttle for shift transfer.", set_coefficient = shuttle_time_mult)
+
+		log_shuttle("A crew transfer vote has passed. The shuttle has been called, and recalling the shuttle ingame is disabled.")
+		message_admins("A crew transfer vote has passed. The shuttle has been called, and recalling the shuttle ingame is disabled.")
+		deadchat_broadcast("A crew transfer vote has passed. The shuttle is being dispatched.",  message_type = DEADCHAT_ANNOUNCEMENT)
+		SSblackbox.record_feedback("text", "shuttle_reason", 1, "Crew Transfer Vote")
+	else
+		message_admins("A crew transfer vote has passed, but the shuttle was already called. Recalling the shuttle ingame is disabled.")
+		to_chat(world, "<span style='boldannounce'>Crew transfer vote failed on account of shuttle being called.</span>")
+	SSshuttle.adminEmergencyNoRecall = TRUE // Don't let one guy overrule democracy by recalling afterwards
+	transfer_vote_successful = TRUE
+
+	return TRUE


### PR DESCRIPTION
## Auto-transfer vote.

By default, a vote is called at 1.5 hours and another is called every 30 minute afterwards.
Both of the above are configurable values by the server administrators.

A vote is called OOCly whether the shuttle will be called. If successful, the shuttle is called on an increased timer, and it becomes un-recallable by the players. Admins can still force-recall it, but you should be careful doing this.

Every YES voter counts for one vote.
Every NO voters counts for one vote.
Every NON voter counts for 1/3rd of a vote for the first and second crew transfer vote, then 1/4th of a vote for the third, 1/5th of a vote for the fourth vote, and so on until they're eventually not counted in the votes at all. This means players present but AFK or not paying attention vote towards NOT CALLING THE SHUTTLE for the first few votes but eventually their vote does not matter.