### PR TITLE
(Hopefully fixes) sticky typing indicators + fixes y'all dumb DME error

### DIFF
--- a/jollystation.dme
+++ b/jollystation.dme
@@ -3598,6 +3598,7 @@
 #include "jollystation_modules\code\modules\mob\living\simple_animal\simple_animal.dm"
 #include "jollystation_modules\code\modules\mob\living\simple_animal\bot\bot.dm"
 #include "jollystation_modules\code\modules\modular_computers\computers\item\tablet_presets.dm"
+#include "jollystation_modules\code\modules\research\techweb\all_nodes.dm"
 #include "jollystation_modules\code\modules\skrell\flavor_misc_js.dm"
 #include "jollystation_modules\code\modules\vending\_vending.dm"
 // END_INCLUDE

--- a/jollystation_modules/code/modules/mob/typing_indicator.dm
+++ b/jollystation_modules/code/modules/mob/typing_indicator.dm
@@ -7,38 +7,34 @@
 	set name = ".say"
 	set hidden = TRUE
 
-	var/image/typing_indicator
-	if(!active_typing_indicator)
+	var/image/typing_indicator = active_typing_indicator
+	if(!typing_indicator)
 		if(isliving(src)) //only living mobs have the bubble_icon var
-			var/mob/living/L = src
-			typing_indicator = image('icons/mob/talk.dmi', src, L.bubble_icon + "0", FLY_LAYER) //get unique speech bubble icons for different species
+			var/mob/living/living_src = src
+			typing_indicator = image('icons/mob/talk.dmi', src, living_src.bubble_icon + "0", FLY_LAYER) //get unique speech bubble icons for different species
 		else
 			typing_indicator = image('icons/mob/talk.dmi', src, "default0", FLY_LAYER)
 
 		typing_indicator.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-		active_typing_indicator = typing_indicator
-		overlays += typing_indicator
 
-	if(ishuman(src))
-		var/mob/living/carbon/human/H = src
+		if(ishuman(src))
+			var/mob/living/carbon/human/human_src = src
+			if(human_src.dna.check_mutation(MUT_MUTE) || human_src.silent) //Check for mute or silent, remove the overlay if true
+				QDEL_NULL(typing_indicator)
 
-		if(H.dna.check_mutation(MUT_MUTE) || H.silent) //Check for mute or silent, remove the overlay if true
-			active_typing_indicator = null
-			if(typing_indicator)
-				overlays -= typing_indicator
-			return
-
-	if(client)
 		if(stat != CONSCIOUS || is_muzzled())
-			active_typing_indicator = null
-			if(typing_indicator)
-				overlays -= typing_indicator
+			QDEL_NULL(typing_indicator)
+
+		if(typing_indicator)
+			active_typing_indicator = typing_indicator
+			overlays += typing_indicator
 
 	var/message = input("", "Say \"text\"") as null|text
 
-	if(active_typing_indicator)
-		active_typing_indicator = null
+	if(typing_indicator)
 		overlays -= typing_indicator
+		active_typing_indicator = null
+		qdel(typing_indicator)
 
 	say_verb(message)
 
@@ -46,27 +42,23 @@
 	set name = ".me"
 	set hidden = TRUE
 
-	var/image/typing_indicator
-	if(!active_typing_indicator)
-		if(isliving(src)) //only living mobs have the bubble_icon var
-			typing_indicator = image('jollystation_modules/icons/mob/talk.dmi', src, "emoting", FLY_LAYER)
-		else
-			typing_indicator = image('jollystation_modules/icons/mob/talk.dmi', src, "default0", FLY_LAYER)
-
+	var/image/typing_indicator = active_typing_indicator
+	if(!typing_indicator)
+		typing_indicator = image('jollystation_modules/icons/mob/talk.dmi', src, "emoting", FLY_LAYER)
 		typing_indicator.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-		active_typing_indicator = typing_indicator
-		overlays += typing_indicator
 
-	if(client)
-		if(stat != CONSCIOUS)
-			active_typing_indicator = null
-			if(typing_indicator)
-				overlays -= typing_indicator
+		if(stat != CONSCIOUS || is_muzzled())
+			QDEL_NULL(typing_indicator)
+
+		if(typing_indicator)
+			active_typing_indicator = typing_indicator
+			overlays += typing_indicator
 
 	var/message = input("", "Me \"text\"") as null|text
 
-	if(active_typing_indicator)
-		active_typing_indicator = null
+	if(typing_indicator)
 		overlays -= typing_indicator
+		active_typing_indicator = null
+		qdel(typing_indicator)
 
 	me_verb(message)

--- a/jollystation_modules/code/modules/mob/typing_indicator.dm
+++ b/jollystation_modules/code/modules/mob/typing_indicator.dm
@@ -1,32 +1,44 @@
 /// Typing indicator wrappers, for the say hotkey and the emote hotkey.
 
+/mob
+	var/active_typing_indicator = null
+
 /mob/verb/say_wrapper()
 	set name = ".say"
 	set hidden = TRUE
 
-	var/image/typing_indicator = image('icons/mob/talk.dmi', src, "default0", FLY_LAYER)
-	if(isliving(src)) //only living mobs have the bubble_icon var
-		var/mob/living/L = src
-		typing_indicator = image('icons/mob/talk.dmi', src, L.bubble_icon + "0", FLY_LAYER) //get unique speech bubble icons for different species
+	var/image/typing_indicator
+	if(!active_typing_indicator)
+		if(isliving(src)) //only living mobs have the bubble_icon var
+			var/mob/living/L = src
+			typing_indicator = image('icons/mob/talk.dmi', src, L.bubble_icon + "0", FLY_LAYER) //get unique speech bubble icons for different species
+		else
+			typing_indicator = image('icons/mob/talk.dmi', src, "default0", FLY_LAYER)
 
-	typing_indicator.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-
-	overlays += typing_indicator
+		typing_indicator.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+		active_typing_indicator = typing_indicator
+		overlays += typing_indicator
 
 	if(ishuman(src))
 		var/mob/living/carbon/human/H = src
 
 		if(H.dna.check_mutation(MUT_MUTE) || H.silent) //Check for mute or silent, remove the overlay if true
-			overlays -= typing_indicator
+			active_typing_indicator = null
+			if(typing_indicator)
+				overlays -= typing_indicator
 			return
 
 	if(client)
 		if(stat != CONSCIOUS || is_muzzled())
-			overlays -= typing_indicator
+			active_typing_indicator = null
+			if(typing_indicator)
+				overlays -= typing_indicator
 
 	var/message = input("", "Say \"text\"") as null|text
 
-	overlays -= typing_indicator
+	if(active_typing_indicator)
+		active_typing_indicator = null
+		overlays -= typing_indicator
 
 	say_verb(message)
 
@@ -34,20 +46,27 @@
 	set name = ".me"
 	set hidden = TRUE
 
-	var/image/typing_indicator = image('jollystation_modules/icons/mob/talk.dmi', src, "default0", FLY_LAYER)
-	if(isliving(src)) //only living mobs have the bubble_icon var
-		typing_indicator = image('jollystation_modules/icons/mob/talk.dmi', src, "emoting", FLY_LAYER)
+	var/image/typing_indicator
+	if(!active_typing_indicator)
+		if(isliving(src)) //only living mobs have the bubble_icon var
+			typing_indicator = image('jollystation_modules/icons/mob/talk.dmi', src, "emoting", FLY_LAYER)
+		else
+			typing_indicator = image('jollystation_modules/icons/mob/talk.dmi', src, "default0", FLY_LAYER)
 
-	typing_indicator.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-
-	overlays += typing_indicator
+		typing_indicator.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+		active_typing_indicator = typing_indicator
+		overlays += typing_indicator
 
 	if(client)
 		if(stat != CONSCIOUS)
-			overlays -= typing_indicator
+			active_typing_indicator = null
+			if(typing_indicator)
+				overlays -= typing_indicator
 
 	var/message = input("", "Me \"text\"") as null|text
 
-	overlays -= typing_indicator
+	if(active_typing_indicator)
+		active_typing_indicator = null
+		overlays -= typing_indicator
 
 	me_verb(message)

--- a/jollystation_modules/code/modules/mob/typing_indicator.dm
+++ b/jollystation_modules/code/modules/mob/typing_indicator.dm
@@ -47,7 +47,7 @@
 		typing_indicator = image('jollystation_modules/icons/mob/talk.dmi', src, "emoting", FLY_LAYER)
 		typing_indicator.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 
-		if(stat != CONSCIOUS || is_muzzled())
+		if(stat != CONSCIOUS)
 			QDEL_NULL(typing_indicator)
 
 		if(typing_indicator)


### PR DESCRIPTION
- Ticks `all_nodes.dm`
- Tracks the active typing indicator, in an effort to prevent the typing indicator getting stuck on disconnect. Will this work? I'm not actually certain, but at the very least this allows admins to fix it easily (by clearing the active typing indicator var)