### PR TITLE
Fake Announcements Traitor Items + Minor AdvTraitor Fixes

### DIFF
--- a/jollystation.dme
+++ b/jollystation.dme
@@ -3599,5 +3599,7 @@
 #include "jollystation_modules\code\modules\mob\living\simple_animal\bot\bot.dm"
 #include "jollystation_modules\code\modules\modular_computers\computers\item\tablet_presets.dm"
 #include "jollystation_modules\code\modules\skrell\flavor_misc_js.dm"
+#include "jollystation_modules\code\modules\uplink\uplink_devices.dm"
+#include "jollystation_modules\code\modules\uplink\uplink_items.dm"
 #include "jollystation_modules\code\modules\vending\_vending.dm"
 // END_INCLUDE

--- a/jollystation_modules/code/modules/uplink/uplink_devices.dm
+++ b/jollystation_modules/code/modules/uplink/uplink_devices.dm
@@ -47,15 +47,17 @@
 	if(owner && owner != user)
 		to_chat(user, "<span class='warning'>Identity check failed.</span>")
 	else
-		if(trigger_announcement() && uses <= 0)
+		if(trigger_announcement(user) && uses <= 0)
 			break_item(user)
 
-/obj/item/item_announcer/preset/proc/trigger_announcement()
+/obj/item/item_announcer/preset/proc/trigger_announcement(mob/user)
 	var/datum/round_event_control/falsealarm/triggered_event = new()
 	if(!fake_event)
 		return FALSE
 	triggered_event.forced_type = fake_event
 	triggered_event.runEvent(FALSE)
+	to_chat(user, "<span class='notice'>You press the [src], triggering a false alarm for [fake_event_name].</span>")
+	message_admins("[ADMIN_LOOKUPFLW(user)] triggered a false alarm using a syndicate device: \"[fake_event_name]\".")
 	uses--
 
 	return TRUE
@@ -136,12 +138,13 @@
 	if(announce_contents)
 		priority_announce(command_report_content, null, SSstation.announcer.get_rand_report_sound(), has_important_message = TRUE)
 	print_command_report(command_report_content, "[announce_contents ? "" : "Classified "][fake_command_name] Update", !announce_contents)
-	uses--
 
 	change_command_name(original_command_name)
 
 	log_admin("[key_name(user)] has sent a fake command report: \"[command_report_content]\", sent from \"[fake_command_name]\".")
-	message_admins("[ADMIN_LOOKUPFLW(user)] has sent a fake command report.")
+	message_admins("[ADMIN_LOOKUPFLW(user)] has sent a fake command report using a syndicate device: \"[command_report_content]\".")
+	to_chat(user, "<span class='notice'>You tap on the [src], sending a [announce_contents ? "" : "classified "]report from [fake_command_name].</span>")
+	uses--
 
 	return TRUE
 

--- a/jollystation_modules/code/modules/uplink/uplink_devices.dm
+++ b/jollystation_modules/code/modules/uplink/uplink_devices.dm
@@ -1,0 +1,152 @@
+/// A small beacon / controller that can be used to send centcom reports IC.
+/obj/item/item_announcer
+	name = "FK-\"Deception\" Falty Announcement Device"
+	desc = "Designed by MI13, the FK-Deception Falty Announcement Device allows an \
+		enterprising syndicate agent attempting to maintain their cover a \
+		one-time faked message (announced or classified) from a certain source."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "locator"
+	w_class = WEIGHT_CLASS_SMALL
+	/// The syndicate who purchased this beacon - only they can use this item. No sharing.
+	var/mob/owner = null
+	/// The amount of reports we can send before breaking.
+	var/uses = 1
+
+/obj/item/item_announcer/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It has [uses] uses left.</span>"
+
+/// Deletes the item when it's used up.
+/obj/item/item_announcer/proc/break_item(mob/user)
+	to_chat(user, "<span class='notice'>The [src] breaks down into unrecognizable scrap and ash after being used.</span>")
+	new /obj/effect/decal/cleanable/ash(drop_location())
+	qdel(src)
+
+/// User sends a preset false alarm.
+/obj/item/item_announcer/preset
+	/// The name of the fake event, so we don't have to init it.
+	var/fake_event_name = ""
+	/// What false alarm this item triggers.
+	var/fake_event = null
+
+/obj/item/item_announcer/preset/Initialize()
+	. = ..()
+	if(fake_event)
+		for(var/datum/round_event_control/init_event in SSevents.control)
+			if(ispath(fake_event, init_event.type))
+				fake_event = init_event
+				break
+
+/obj/item/item_announcer/preset/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It causes a fake \"[fake_event_name]\" when used.</span>"
+
+/obj/item/item_announcer/preset/attack_self(mob/user)
+	. = ..()
+	if(owner && owner != user)
+		to_chat(user, "<span class='warning'>Identity check failed.</span>")
+	else
+		if(trigger_announcement() && uses <= 0)
+			break_item(user)
+
+/obj/item/item_announcer/preset/proc/trigger_announcement()
+	var/datum/round_event_control/falsealarm/triggered_event = new()
+	if(!fake_event)
+		return FALSE
+	triggered_event.forced_type = fake_event
+	triggered_event.runEvent(FALSE)
+	uses--
+
+	return TRUE
+
+/obj/item/item_announcer/preset/ion
+	fake_event_name = "Ion Storm"
+	fake_event = /datum/round_event_control/ion_storm
+
+/obj/item/item_announcer/preset/rad
+	fake_event_name = "Radiation Storm"
+	fake_event = /datum/round_event_control/radiation_storm
+
+/// Allows users to input a custom announcement message.
+/obj/item/item_announcer/input
+	/// The name of central command that will accompany our fake report.
+	var/fake_command_name = "???"
+	/// The actual contents of the report we're going to send.
+	var/command_report_content
+	/// Whether the report is an announced report or a classified report.
+	var/announce_contents = TRUE
+
+/obj/item/item_announcer/input/attack_self(mob/user)
+	if(owner && owner != user)
+		to_chat(user, "<span class='warning'>Identity check failed.</span>")
+		return TRUE
+	. = ..()
+
+/obj/item/item_announcer/input/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It sends messages from \"[fake_command_name]\".</span>"
+
+/obj/item/item_announcer/input/ui_state(mob/user)
+	return GLOB.inventory_state
+
+/obj/item/item_announcer/input/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "_FakeCommandReport")
+		ui.open()
+
+/obj/item/item_announcer/input/ui_data(mob/user)
+	var/list/data = list()
+	data["command_name"] = fake_command_name
+	data["command_report_content"] = command_report_content
+	data["announce_contents"] = announce_contents
+
+	return data
+
+/obj/item/item_announcer/input/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	switch(action)
+		if("update_report_contents")
+			command_report_content = params["updated_contents"]
+		if("toggle_announce")
+			announce_contents = !announce_contents
+		if("submit_report")
+			if(!command_report_content)
+				to_chat(usr, "<span class='danger'>You can't send a report with no contents.</span>")
+				return
+			if(owner && usr != owner)
+				to_chat(usr, "<span class='warning'>Identity check failed.</span>")
+				return
+			if(send_announcement(usr) && uses <= 0)
+				break_item(usr)
+				return
+
+	return TRUE
+
+/// Send our announcement from [user] and decrease the amount of uses.
+/obj/item/item_announcer/input/proc/send_announcement(mob/user)
+	/// Our current command name to swap back to after sending the report.
+	var/original_command_name = command_name()
+	change_command_name(fake_command_name)
+
+	if(announce_contents)
+		priority_announce(command_report_content, null, SSstation.announcer.get_rand_report_sound(), has_important_message = TRUE)
+	print_command_report(command_report_content, "[announce_contents ? "" : "Classified "][fake_command_name] Update", !announce_contents)
+	uses--
+
+	change_command_name(original_command_name)
+
+	log_admin("[key_name(user)] has sent a fake command report: \"[command_report_content]\", sent from \"[fake_command_name]\".")
+	message_admins("[ADMIN_LOOKUPFLW(user)] has sent a fake command report.")
+
+	return TRUE
+
+/obj/item/item_announcer/input/centcom
+	fake_command_name = "Central Command"
+
+/obj/item/item_announcer/input/syndicate
+	fake_command_name = "The Syndicate"
+	uses = 2

--- a/jollystation_modules/code/modules/uplink/uplink_devices.dm
+++ b/jollystation_modules/code/modules/uplink/uplink_devices.dm
@@ -19,7 +19,8 @@
 /// Deletes the item when it's used up.
 /obj/item/item_announcer/proc/break_item(mob/user)
 	to_chat(user, "<span class='notice'>The [src] breaks down into unrecognizable scrap and ash after being used.</span>")
-	new /obj/effect/decal/cleanable/ash(drop_location())
+	var/obj/effect/decal/cleanable/ash/spawned_ash = new(drop_location())
+	spawned_ash.desc = "Ashes to ashes, dust to dust. There's a few pieces of scrap in this pile."
 	qdel(src)
 
 /// User sends a preset false alarm.

--- a/jollystation_modules/code/modules/uplink/uplink_devices.dm
+++ b/jollystation_modules/code/modules/uplink/uplink_devices.dm
@@ -1,3 +1,4 @@
+// -- Modular minor gadgets/devices that go in the uplink. --
 /// A small beacon / controller that can be used to send centcom reports IC.
 /obj/item/item_announcer
 	name = "FK-\"Deception\" Falty Announcement Device"

--- a/jollystation_modules/code/modules/uplink/uplink_devices.dm
+++ b/jollystation_modules/code/modules/uplink/uplink_devices.dm
@@ -57,7 +57,9 @@
 	triggered_event.forced_type = fake_event
 	triggered_event.runEvent(FALSE)
 	to_chat(user, "<span class='notice'>You press the [src], triggering a false alarm for [fake_event_name].</span>")
-	message_admins("[ADMIN_LOOKUPFLW(user)] triggered a false alarm using a syndicate device: \"[fake_event_name]\".")
+	deadchat_broadcast("<span class='bold'>[user] has triggered a false alarm using a syndicate device!</span>", follow_target = user)
+	message_admins("[ADMIN_LOOKUPFLW(user)] has triggered a false alarm using a syndicate device: \"[fake_event_name]\".")
+	log_game("[key_name(user)] has triggered a false alarm using a syndicate device: \"[fake_event_name]\".")
 	uses--
 
 	return TRUE
@@ -141,9 +143,10 @@
 
 	change_command_name(original_command_name)
 
-	log_admin("[key_name(user)] has sent a fake command report: \"[command_report_content]\", sent from \"[fake_command_name]\".")
-	message_admins("[ADMIN_LOOKUPFLW(user)] has sent a fake command report using a syndicate device: \"[command_report_content]\".")
 	to_chat(user, "<span class='notice'>You tap on the [src], sending a [announce_contents ? "" : "classified "]report from [fake_command_name].</span>")
+	deadchat_broadcast("<span class='bold'>[user] has triggered an announcement using a syndicate device!</span>", follow_target = user)
+	message_admins("[ADMIN_LOOKUPFLW(user)] has sent a fake command report using a syndicate device: \"[command_report_content]\".")
+	log_game("[key_name(user)] has sent a fake command report using a syndicate device: \"[command_report_content]\", sent from \"[fake_command_name]\".")
 	uses--
 
 	return TRUE

--- a/jollystation_modules/code/modules/uplink/uplink_items.dm
+++ b/jollystation_modules/code/modules/uplink/uplink_items.dm
@@ -14,17 +14,17 @@
 
 /datum/uplink_item/device_tools/announcement/fake_ionstorm
 	name = "Fake Ion Storm Announcement"
-	desc = "Need to cause some chaos in the AI's realm? \
-		A beacon with one use that triggers a fake ion storm over the station, \
+	desc = "Ai, state flaws. A beacon with one use that triggers a fake ion storm, \
 		sending the crew clammering to investigate their nearest silicon."
 	item = /obj/item/item_announcer/preset/ion
 	cost = 4
 
 /datum/uplink_item/device_tools/announcement/fake_radstorm
 	name = "Fake Radiation Storm Announcement"
-	desc = "Radiation storm! Turn on emergency maintenance access! \
-		A beacon with one use that triggers a fake radiation storm over the station, \
-		causing mild panic and a mad dash for maintenance. Does not come with warm air."
+	desc = "Radiation storm! Turn on emergency maint! \
+		A beacon with one use that triggers a fake radiation storm, \
+		causing mild panic and a mad dash for maintenance. \
+		Does not come with warm air."
 	item = /obj/item/item_announcer/preset/rad
 	cost = 5
 
@@ -39,7 +39,7 @@
 
 /datum/uplink_item/device_tools/announcement/syndicate_announcement
 	name = "Syndicate Announcement"
-	desc = "Forgoing any semblence of stealth and security? Need to make yourself known? \
+	desc = "Forgoing any semblance of stealth and security? Need to make yourself known? \
 		A beacon with two uses that sends reports directly from The Syndicate to the station, classified or announced."
 	item = /obj/item/item_announcer/input/syndicate
 	cost = 8

--- a/jollystation_modules/code/modules/uplink/uplink_items.dm
+++ b/jollystation_modules/code/modules/uplink/uplink_items.dm
@@ -1,0 +1,45 @@
+/datum/uplink_item/device_tools/announcement
+	category = "Announcements"
+	surplus = 0
+	refundable = TRUE
+	cant_discount = TRUE
+	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
+
+/datum/uplink_item/device_tools/announcement/spawn_item(spawn_path, mob/user, datum/component/uplink/U)
+	. = ..()
+
+	var/obj/item/item_announcer/spawned_device = .
+	if(istype(spawned_device) && user)
+		spawned_device.owner = user
+
+/datum/uplink_item/device_tools/announcement/fake_ionstorm
+	name = "Fake Ion Storm Announcement"
+	desc = "Need to cause some chaos in the AI's realm? \
+		A beacon with one use that triggers a fake ion storm over the station, \
+		sending the crew clammering to investigate their nearest silicon."
+	item = /obj/item/item_announcer/preset/ion
+	cost = 4
+
+/datum/uplink_item/device_tools/announcement/fake_radstorm
+	name = "Fake Radiation Storm Announcement"
+	desc = "Radiation storm! Turn on emergency maintenance access! \
+		A beacon with one use that triggers a fake radiation storm over the station, \
+		causing mild panic and a mad dash for maintenance. Does not come with warm air."
+	item = /obj/item/item_announcer/preset/rad
+	cost = 5
+
+/datum/uplink_item/device_tools/announcement/cc_announcement
+	name = "\"Central Command\" Announcement"
+	desc = "Need some diplomatic immunity to go along side your infiltration? \
+		A beacon with one use that sends a fake report from \"Central Command\" \
+		written by yours truly (you!). This report can be classified \
+		or announced to everyone."
+	item = /obj/item/item_announcer/input/centcom
+	cost = 12
+
+/datum/uplink_item/device_tools/announcement/syndicate_announcement
+	name = "Syndicate Announcement"
+	desc = "Forgoing any semblence of stealth and security? Need to make yourself known? \
+		A beacon with two uses that sends reports directly from The Syndicate to the station, classified or announced."
+	item = /obj/item/item_announcer/input/syndicate
+	cost = 8

--- a/jollystation_modules/code/modules/uplink/uplink_items.dm
+++ b/jollystation_modules/code/modules/uplink/uplink_items.dm
@@ -12,6 +12,7 @@
 	if(istype(spawned_device) && user)
 		spawned_device.owner = user
 
+/// -- Modular/additional uplink items --
 /datum/uplink_item/device_tools/announcement/fake_ionstorm
 	name = "Fake Ion Storm Announcement"
 	desc = "Ai, state flaws. A beacon with one use that triggers a fake ion storm, \

--- a/tgui/packages/tgui/index.js
+++ b/tgui/packages/tgui/index.js
@@ -17,6 +17,8 @@ import './styles/themes/retro.scss';
 import './styles/themes/syndicate.scss';
 import './styles/themes/wizard.scss';
 
+import './styles/themes/jolly-syndicate.scss'; // NON-MODULE CHANGE
+
 import { perf } from 'common/perf';
 import { setupHotReloading } from 'tgui-dev-server/link/client';
 import { setupHotKeys } from './hotkeys';

--- a/tgui/packages/tgui/interfaces/_FakeCommandReport.js
+++ b/tgui/packages/tgui/interfaces/_FakeCommandReport.js
@@ -22,7 +22,7 @@ export const _FakeCommandReport = (props, context) => {
               <Dropdown
                 width="100%"
                 selected={command_name}
-                disabled={1}/>
+                disabled={1} />
             </Section>
           </Stack.Item>
           <Stack.Item>

--- a/tgui/packages/tgui/interfaces/_FakeCommandReport.js
+++ b/tgui/packages/tgui/interfaces/_FakeCommandReport.js
@@ -1,0 +1,62 @@
+import { useBackend } from '../backend';
+import { Button, Dropdown, Input, Section, Stack, TextArea } from '../components';
+import { Window } from '../layouts';
+
+export const _FakeCommandReport = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    command_name,
+    command_report_content,
+    announce_contents,
+  } = data;
+  return (
+    <Window
+      title="Send Faked Command Report"
+      width={325}
+      height={425}
+      theme="syndicate">
+      <Window.Content>
+        <Stack vertical>
+          <Stack.Item>
+            <Section title="Central Command Name:" textAlign="center">
+              <Dropdown
+                width="100%"
+                selected={command_name}
+                disabled={1}/>
+            </Section>
+          </Stack.Item>
+          <Stack.Item>
+            <Section title="Report Text:" textAlign="center">
+              <TextArea
+                height="200px"
+                mb={1}
+                value={command_report_content}
+                onChange={(e, value) => act("update_report_contents", {
+                  updated_contents: value,
+                })} />
+              <Stack vertical>
+                <Stack.Item>
+                  <Button.Checkbox
+                    fluid
+                    checked={announce_contents}
+                    onClick={() => act("toggle_announce")}>
+                    Announce Contents
+                  </Button.Checkbox>
+                </Stack.Item>
+                <Stack.Item>
+                  <Button.Confirm
+                    fluid
+                    icon="check"
+                    color="good"
+                    textAlign="center"
+                    content="Submit Fake Report"
+                    onClick={() => act("submit_report")} />
+                </Stack.Item>
+              </Stack>
+            </Section>
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
Advanced Traitor has the potential to give more than 20 TC, but the amount of items in the uplink in general is pretty mediocre for someone looking to do something grand. So, why not fill out the uplink with some more RP-centric stuff?

![image](https://user-images.githubusercontent.com/51863163/117623448-7179ec00-b139-11eb-86b3-fc91a5325c78.png)

Traitors can now buy various fake announcements from the traitor uplink. Idea inspired by CEV Eris, which has a similar category for their uplink. 

- Fake Ion Storm: Triggers "False Alarm" with the "Ion Storm" event being chosen.
- Fake Rad Storm: Triggers "False Alarm" with the "Radiation Storm" event being chosen.
- CC Announcement - Lets the traitor input a centcom report to be sent to the station. They can make it classified or announced. The text does not currently go through admin approval or anything before being sent, so this one is mostly a trust system that it's not abused. (It probably won't be.)
- Syndicate Announcement - Identical to above, but sends it from "The Syndicate" instead of "Central Command".


Also fixes a but with advanced traitor panel's style not showing up due to the last merge breaking it.