### PR TITLE
The Great Lima-ning: Lima 3(?) (Or something like that) (Remastered)

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -3895,9 +3895,6 @@
 "aEq" = (
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"aEw" = (
-/turf/closed/wall,
-/area/ai_monitored/command/storage/eva)
 "aED" = (
 /obj/structure/displaycase/trophy{
 	pixel_y = 5
@@ -12024,9 +12021,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
-	dir = 4
-	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "dwf" = (
@@ -13843,9 +13837,9 @@
 /area/command/heads_quarters/hop)
 "epn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	name = "Air Output to Air Supply"
+	name = "Air Outlet to Air Supply"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -14518,7 +14512,9 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "eJJ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/tank_holder/extinguisher/advanced,
+/obj/structure/tank_holder/extinguisher/advanced{
+	anchored = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/upper)
 "eJQ" = (
@@ -20922,6 +20918,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/iron,
 /area/command/bridge)
 "ieR" = (
@@ -35896,13 +35895,6 @@
 "qtf" = (
 /turf/closed/indestructible/riveted,
 /area/science/test_area)
-"qtt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "qtz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -36480,8 +36472,8 @@
 	dir = 1
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/machinery/status_display/evac/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "qNv" = (
@@ -37801,6 +37793,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/gateway)
 "rEm" = (
@@ -39634,6 +39627,15 @@
 "sEy" = (
 /turf/closed/wall,
 /area/medical/morgue)
+"sEE" = (
+/obj/structure/cable/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/tcommsat/computer)
 "sES" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -43612,6 +43614,7 @@
 	id = "stationawaygate";
 	name = "Gateway Access Shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/gateway)
 "uBW" = (
@@ -68467,7 +68470,7 @@ mrT
 mrT
 xyS
 sIv
-qtt
+xyS
 spv
 osZ
 wBx
@@ -84219,7 +84222,7 @@ gpl
 vHG
 gpl
 gpl
-aEw
+puT
 puT
 puT
 fYR
@@ -84478,7 +84481,7 @@ rAx
 mXI
 mZo
 hGr
-aEw
+puT
 mXt
 fBA
 tiI
@@ -84735,7 +84738,7 @@ pxP
 rAx
 rAx
 rAx
-aEw
+puT
 pwa
 vcp
 lzQ
@@ -84992,7 +84995,7 @@ mRS
 pFR
 qiG
 mXI
-aEw
+puT
 pOe
 wTv
 kJn
@@ -96059,7 +96062,7 @@ gfQ
 gfQ
 mfS
 oiJ
-hLU
+sEE
 oiJ
 gfQ
 gfQ

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -55,26 +55,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/airless,
 /area/space/nearstation)
-"aaG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "aaH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -174,25 +154,6 @@
 /obj/structure/table_frame,
 /turf/open/floor/iron/airless,
 /area/space/nearstation)
-"aby" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "abB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -826,9 +787,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -1304,7 +1262,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
@@ -1540,11 +1497,6 @@
 /obj/machinery/vending/games,
 /turf/open/floor/wood/large,
 /area/service/library)
-"ali" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "alm" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
@@ -2503,6 +2455,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "asi" = (
@@ -2992,6 +2945,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "avT" = (
@@ -3313,8 +3268,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "ayo" = (
@@ -3512,8 +3465,8 @@
 	dir = 1
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "azZ" = (
@@ -5820,10 +5773,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/red,
 /area/service/chapel/main)
-"aVc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/red,
-/area/service/chapel/main)
 "aVe" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -6248,8 +6197,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aYz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aYB" = (
@@ -6352,8 +6301,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -7100,8 +7047,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/modular_computer/console/preset/cargochat/medical{
 	dir = 8
@@ -7416,6 +7361,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "bgV" = (
@@ -7512,7 +7458,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/machinery/newscaster/directional/north,
@@ -7588,7 +7533,6 @@
 /area/engineering/break_room)
 "bhX" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/bar)
 "bhZ" = (
@@ -7607,15 +7551,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/engineering/main)
-"bij" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine,
 /area/engineering/main)
 "bim" = (
 /obj/machinery/light{
@@ -7657,7 +7592,6 @@
 "biz" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "biD" = (
@@ -7899,24 +7833,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"bjW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "bjZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7974,7 +7890,6 @@
 "bkk" = (
 /obj/structure/table,
 /obj/item/holosign_creator/robot_seat/restaurant,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -9061,13 +8976,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"bIZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "bJr" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -9354,13 +9262,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/engineering/break_room)
-"bTh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/brig)
 "bTm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -9396,14 +9297,6 @@
 /obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron/white,
 /area/science/research)
-"bUm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/port/aft)
 "bUD" = (
 /obj/machinery/light,
 /obj/machinery/suit_storage_unit/security,
@@ -9881,18 +9774,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/service/bar)
-"cgJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/execution/transfer)
 "cgN" = (
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/showroomfloor,
@@ -10137,11 +10018,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"cro" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "crC" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -10791,7 +10667,7 @@
 	freq = 1400;
 	location = "Bridge"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/command/corporate_showroom)
 "cPz" = (
 /obj/machinery/door/airlock/public/glass{
@@ -11238,14 +11114,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"dbl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/security/prison)
 "dbq" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
@@ -11266,11 +11134,12 @@
 "dbX" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
 /obj/item/paper/guides/jobs/engi/gravity_gen,
 /obj/item/pen/blue,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/textured_half,
 /area/engineering/gravity_generator)
 "dcp" = (
@@ -11810,7 +11679,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -13008,12 +12876,9 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargodelivery2"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "dRA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/service,
 /obj/machinery/light/cold/directional/south,
@@ -13599,7 +13464,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "ejX" = (
@@ -14034,7 +13899,7 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "ewP" = (
@@ -14251,8 +14116,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "eCf" = (
@@ -14349,13 +14212,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"eHx" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "eHF" = (
 /obj/structure/table,
 /obj/machinery/door/poddoor/shutters{
@@ -15040,8 +14896,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -15238,7 +15092,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -16054,7 +15907,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "fxZ" = (
@@ -16535,9 +16387,6 @@
 /area/service/chapel/main)
 "fPC" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "fPF" = (
@@ -16715,8 +16564,6 @@
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -16725,7 +16572,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -16851,7 +16697,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -17062,6 +16907,10 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"gce" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "gcu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17141,7 +16990,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
@@ -17191,20 +17039,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/cargo/qm)
-"ggx" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "ggF" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17245,7 +17079,6 @@
 	req_access_txt = "5; 33"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -17542,6 +17375,7 @@
 	name = "qm sorting disposal pipe";
 	sortType = 3
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "gtj" = (
@@ -17704,6 +17538,12 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"gvE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "gwv" = (
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
@@ -17755,7 +17595,7 @@
 /obj/structure/window/plasma/reinforced,
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "gxw" = (
@@ -17829,7 +17669,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gyC" = (
@@ -17911,10 +17751,11 @@
 	pixel_y = 5
 	},
 /obj/item/stock_parts/cell/high/plus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/stock_parts/cell/high/plus{
 	pixel_y = -4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -18364,7 +18205,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -19580,6 +19420,12 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"hyx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hzP" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
@@ -19829,16 +19675,6 @@
 /obj/item/food/donut/chaos,
 /turf/open/floor/plating,
 /area/security/brig)
-"hGZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "hHa" = (
 /obj/structure/window{
 	dir = 1
@@ -19850,6 +19686,11 @@
 /obj/structure/flora/bush,
 /turf/open/floor/grass,
 /area/command/bridge)
+"hHp" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hHv" = (
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood/large,
@@ -19873,6 +19714,18 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
+"hHR" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "hHW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
@@ -19965,8 +19818,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "hKA" = (
@@ -19987,12 +19840,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/wood,
 /area/service/bar)
-"hKJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/security/brig)
 "hKK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20148,8 +19995,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hQP" = (
@@ -20342,13 +20189,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"hXX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "hYd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -20486,6 +20326,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "idc" = (
@@ -20580,9 +20422,8 @@
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "ife" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "iff" = (
@@ -20720,7 +20561,6 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -21374,7 +21214,6 @@
 	uses = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -21785,13 +21624,10 @@
 /turf/open/floor/wood,
 /area/service/library)
 "iTj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iTt" = (
@@ -23177,10 +23013,9 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "jHw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "jHD" = (
@@ -23697,16 +23532,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"jXG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "jXO" = (
 /obj/structure/cable,
 /obj/structure/cable/layer3,
@@ -23781,26 +23606,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"kal" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
-"kam" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/carpet/red,
-/area/service/chapel/main)
 "kaC" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -23965,26 +23770,6 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
-"kgY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "khn" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -25678,14 +25463,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/commons/storage/art)
-"lfI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig)
 "lfK" = (
 /obj/structure/table/wood,
 /obj/machinery/door/window/northright{
@@ -25707,6 +25484,8 @@
 /area/engineering/atmos)
 "lfZ" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "lgb" = (
@@ -25771,7 +25550,6 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -26452,6 +26230,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "lAa" = (
@@ -27609,6 +27389,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"mhF" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig)
 "mhN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -27930,10 +27727,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"moO" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "moX" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -27966,6 +27759,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "mpE" = (
@@ -27975,8 +27769,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "mpM" = (
@@ -28368,25 +28160,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"mDM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "mDX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -28458,7 +28231,6 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "mFB" = (
@@ -28502,12 +28274,6 @@
 /obj/item/analyzer,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
-"mGD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "mGG" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -28570,6 +28336,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "mJh" = (
@@ -31008,7 +30775,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nZh" = (
-/obj/machinery/meter,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Ports"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nZE" = (
@@ -31571,11 +31342,11 @@
 /area/maintenance/port/aft)
 "opa" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "opY" = (
@@ -32684,14 +32455,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
-"oVR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Ports"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oVW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/light{
@@ -33458,13 +33221,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
-"pua" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "pub" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating{
@@ -33590,7 +33346,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -34250,13 +34005,6 @@
 "pSt" = (
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"pTb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pTu" = (
 /obj/structure/table,
 /turf/open/floor/iron/white,
@@ -35024,13 +34772,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
-"qqk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "qqn" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/showroomfloor,
@@ -35080,7 +34821,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "qrt" = (
@@ -35155,7 +34895,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/cargo/office)
+/area/space)
 "qtc" = (
 /obj/structure/displaycase/captain,
 /obj/effect/turf_decal/stripes/line{
@@ -35663,17 +35403,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"qMi" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/warehouse)
 "qMx" = (
 /obj/structure/cable,
 /obj/machinery/light_switch{
@@ -35812,6 +35541,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "qRb" = (
@@ -35961,6 +35691,11 @@
 /obj/structure/closet/wardrobe/miner,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
+"qXE" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qXP" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 9
@@ -36038,9 +35773,6 @@
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
 	},
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/textured_half,
@@ -36315,7 +36047,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/command/corporate_showroom)
 "rgq" = (
 /obj/structure/lattice,
@@ -36575,15 +36307,6 @@
 	},
 /turf/open/floor/iron/textured_corner,
 /area/engineering/gravity_generator)
-"roz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/port/aft)
 "rpj" = (
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/iron/dark,
@@ -36772,8 +36495,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
@@ -36811,14 +36532,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
-"ruR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "rvp" = (
 /obj/effect/spawner/randomcolavend,
 /obj/machinery/status_display/evac/directional/north,
@@ -37767,7 +37480,6 @@
 /area/maintenance/disposal)
 "rZy" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/service/bar)
@@ -37937,7 +37649,6 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -38534,6 +38245,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "svX" = (
@@ -38864,8 +38576,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "sFT" = (
@@ -38884,7 +38596,6 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sGv" = (
@@ -39995,6 +39706,16 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"tix" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Prison Gate";
+	name = "Security Blast Door"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig)
 "tiI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40130,18 +39851,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"tkD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tll" = (
 /turf/open/floor/grass,
 /area/security/prison)
+"tlu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad/secure,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/tcommsat/computer)
 "tlF" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plating,
@@ -41096,7 +40814,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tKA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "tKZ" = (
@@ -41630,14 +41348,6 @@
 /obj/structure/flora/junglebush,
 /turf/open/floor/grass,
 /area/service/library)
-"uaN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "ubb" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -41873,14 +41583,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"ugo" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
 "ugC" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -42419,12 +42121,6 @@
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
 /area/maintenance/port/aft)
-"uuH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "uuZ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -42755,16 +42451,6 @@
 	name = "black plastitanium floor"
 	},
 /area/service/bar)
-"uCU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "uDc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43000,6 +42686,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
+"uJF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uJY" = (
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -43608,7 +43298,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uYE" = (
@@ -43684,7 +43374,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "vbq" = (
@@ -43951,7 +43641,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/bar)
 "vkU" = (
@@ -44412,10 +44101,8 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/holopad/secure,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "vuN" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -44581,6 +44268,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "vyo" = (
@@ -45093,7 +44781,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vJJ" = (
@@ -45317,7 +45005,6 @@
 "vPZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
@@ -45771,7 +45458,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "wdH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "wec" = (
@@ -45809,6 +45496,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"weR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wfm" = (
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -45820,15 +45512,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
-"wfN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/depsec/medical,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "wfT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -46463,7 +46146,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -47369,6 +47051,8 @@
 	name = "Tech Storage";
 	req_access_txt = "23"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "wXl" = (
@@ -47776,6 +47460,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xho" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "xhx" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/green{
@@ -47879,7 +47567,6 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
 "xky" = (
@@ -47911,10 +47598,6 @@
 "xkT" = (
 /turf/open/floor/plating,
 /area/engineering/main)
-"xkU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "xlm" = (
 /obj/structure/closet/wardrobe,
 /obj/machinery/firealarm/directional/west,
@@ -47944,6 +47627,13 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"xlX" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/aft)
 "xmb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -48529,19 +48219,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"xyI" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "xyS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48572,6 +48249,17 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
+"xAe" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/security/glass{
+	name = "Prison Wing";
+	req_access_txt = "1"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig)
 "xAj" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -48944,7 +48632,6 @@
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/bot,
@@ -49418,6 +49105,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "yal" = (
@@ -49737,7 +49426,6 @@
 	sortType = 15
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -61896,11 +61584,11 @@ aix
 ajv
 akP
 osZ
-pua
+osZ
 osZ
 amy
 osZ
-dbl
+jev
 jev
 dnN
 ygB
@@ -63459,7 +63147,7 @@ wwo
 ftA
 gQk
 bzC
-cgJ
+dEF
 hlW
 fIE
 ihX
@@ -63700,7 +63388,7 @@ dOY
 tll
 nei
 ygB
-nIo
+jev
 jbw
 imL
 avd
@@ -65588,7 +65276,7 @@ vSI
 hKh
 wGl
 lrA
-wGl
+qXE
 hud
 afo
 wGl
@@ -65841,12 +65529,12 @@ xzY
 xzY
 xzY
 irn
+uJF
+uJF
 xzY
-ffW
-xzY
-xzY
+elh
 nZh
-xzY
+bwc
 hTo
 xXh
 fBy
@@ -66098,15 +65786,15 @@ xzY
 xzY
 xzY
 irn
-xzY
-tkD
-xzY
-elh
-oVR
-bwc
-xzY
+uJF
 jdo
 xzY
+ubS
+mWH
+mWH
+xzY
+jdo
+sXJ
 waO
 wOk
 xzY
@@ -66331,7 +66019,7 @@ ife
 qZG
 wVb
 fLo
-bij
+nbU
 gxV
 sOW
 svO
@@ -66342,7 +66030,7 @@ jCj
 oyv
 sxJ
 sOW
-uCU
+gxV
 nbU
 abB
 wVb
@@ -66355,12 +66043,12 @@ iSm
 qiF
 xzY
 irn
+uJF
+nbI
 xzY
-pTb
+mWH
 xzY
-ubS
-vSI
-fuX
+mWH
 xzY
 nbI
 sXJ
@@ -66583,7 +66271,7 @@ uMh
 bgb
 aTv
 gKI
-jLl
+xho
 dYb
 dbX
 wVb
@@ -66612,7 +66300,7 @@ rgD
 sAA
 xzY
 tVv
-tHy
+weR
 iTj
 eig
 mWH
@@ -66869,8 +66557,8 @@ rgD
 foE
 xzY
 xzY
-xzY
-mGD
+uJF
+uJF
 wRF
 mWH
 xzY
@@ -67300,7 +66988,7 @@ jev
 jev
 jev
 jev
-dbl
+jev
 xyS
 sIv
 jev
@@ -67311,10 +66999,10 @@ osZ
 pMx
 osZ
 osZ
-hKJ
+vHv
 mpE
 aym
-bTh
+vHv
 oHf
 fDa
 rhI
@@ -67381,7 +67069,7 @@ eJJ
 aKR
 rgD
 dDI
-xzY
+hHp
 xzY
 xzY
 xzY
@@ -67567,11 +67255,11 @@ lNw
 xlD
 ute
 xlD
-xlD
-aCA
-aFk
+jbw
+xAe
+tix
 avN
-eDb
+mhF
 azA
 fDa
 rhI
@@ -70198,8 +69886,8 @@ kNc
 wth
 uOy
 nBp
-uuH
 fmE
+gvE
 fPC
 wth
 sBb
@@ -70406,7 +70094,7 @@ aMA
 gPZ
 vQo
 aYB
-lfI
+sHE
 kcR
 bVO
 biP
@@ -70711,7 +70399,7 @@ olV
 alJ
 wth
 fYt
-moO
+nBp
 gAC
 biy
 bio
@@ -70968,8 +70656,8 @@ sOf
 sOf
 wth
 dlE
-moO
-cro
+nBp
+fmE
 fmE
 fmE
 wth
@@ -71482,7 +71170,7 @@ lfZ
 lfZ
 yaj
 icd
-gaf
+hHR
 gaf
 inV
 lJm
@@ -71996,7 +71684,7 @@ wGg
 sTz
 mDY
 alH
-mFo
+vYu
 iNF
 xqz
 rVs
@@ -72253,7 +71941,7 @@ rrv
 eBB
 nhw
 xCJ
-mFo
+vYu
 pIn
 rqR
 bnA
@@ -72510,7 +72198,7 @@ wGg
 eac
 nhw
 vbv
-dCo
+gce
 pIn
 tkB
 vZs
@@ -72767,7 +72455,7 @@ mDY
 mDY
 nhw
 tNn
-etw
+gce
 yfs
 nTG
 vZs
@@ -72984,7 +72672,7 @@ xMu
 eCf
 hWW
 vYu
-ggx
+uqd
 pwe
 iVw
 ePA
@@ -73784,13 +73472,13 @@ lAk
 aFv
 lAk
 lAk
-vHE
 lAk
 lAk
 lAk
 lAk
-xyI
-xyI
+lAk
+lAk
+lAk
 wAv
 wAv
 wAv
@@ -73798,7 +73486,7 @@ wAv
 fXf
 aDB
 vZs
-tuj
+ids
 aof
 neN
 gfQ
@@ -74055,7 +73743,7 @@ vYu
 wAv
 dSR
 vZs
-tuj
+ids
 qSY
 neN
 gfQ
@@ -74269,7 +73957,7 @@ rPv
 xke
 fcR
 ybn
-aaG
+aaH
 dSu
 wXl
 wXl
@@ -74312,7 +74000,7 @@ vYu
 wAv
 gqQ
 vZs
-tuj
+ids
 aof
 neN
 gfQ
@@ -74569,7 +74257,7 @@ vYu
 wAv
 gwP
 vZs
-tuj
+ids
 lib
 neN
 gfQ
@@ -74783,7 +74471,7 @@ bES
 eCf
 fcR
 ybn
-aby
+jUZ
 rUC
 wXl
 ePQ
@@ -74826,7 +74514,7 @@ vYu
 wAv
 vYu
 vZs
-jpD
+xlX
 jpD
 aHw
 gfQ
@@ -75083,7 +74771,7 @@ vYu
 wAv
 vYu
 vZs
-tuj
+hyx
 dAn
 aHw
 gfQ
@@ -75106,7 +74794,7 @@ cmm
 jfV
 gVT
 gVT
-roz
+pyL
 sqP
 puR
 vvc
@@ -75296,8 +74984,8 @@ bnh
 bFs
 cbY
 cEi
-vYu
-kgY
+ybn
+jUZ
 ybn
 hBV
 rkx
@@ -75543,7 +75231,7 @@ sVb
 bAH
 vUW
 vUW
-agP
+vUW
 aWu
 adH
 wyf
@@ -75810,7 +75498,7 @@ xAw
 vUW
 hsp
 ybn
-vYu
+ybn
 jUZ
 ybn
 hBV
@@ -75855,19 +75543,19 @@ hEB
 cfI
 vZs
 tuj
-xkU
+tuj
 sGc
 xkh
 xkh
 xkh
 xkh
-hXX
+buH
 nft
 mhN
 nft
 dRd
 fch
-qMi
+eCe
 eCe
 voR
 mcr
@@ -76058,7 +75746,7 @@ vUW
 aGF
 vUW
 vUW
-kam
+wKA
 nRK
 wKA
 nRK
@@ -77085,7 +76773,7 @@ rPO
 wyf
 vUW
 vUW
-aVc
+vUW
 aWG
 aao
 wyf
@@ -77610,7 +77298,7 @@ sVb
 sVb
 sVb
 bjJ
-mDM
+jUZ
 ybn
 hPr
 xtO
@@ -77650,7 +77338,7 @@ cVt
 fqf
 buI
 aSi
-ruR
+hEB
 iuU
 smo
 mOJ
@@ -78432,7 +78120,7 @@ lMQ
 vPT
 mKV
 mKV
-jtX
+mKV
 mKV
 mKV
 tJA
@@ -79471,7 +79159,7 @@ kFX
 rEK
 iTS
 ids
-bUm
+aof
 vGt
 fBs
 fBs
@@ -80733,7 +80421,7 @@ bhX
 rZy
 bhX
 vkH
-ali
+vqK
 saq
 wPB
 rxU
@@ -81270,7 +80958,7 @@ gfQ
 gfQ
 gfQ
 meS
-qBL
+otG
 tuj
 cxf
 xWs
@@ -81465,7 +81153,7 @@ bDt
 bjz
 nAA
 dak
-bjW
+jUZ
 ybn
 exn
 eVc
@@ -82509,7 +82197,7 @@ tzr
 tzr
 tzr
 tzr
-bIZ
+tzr
 tzr
 tzr
 tzr
@@ -82533,13 +82221,13 @@ tzr
 tzr
 pzd
 hEB
-kal
+rLe
 fTC
 pty
 stt
-eHx
-eHx
-eHx
+stt
+stt
+stt
 stt
 stt
 stt
@@ -85067,7 +84755,7 @@ bjU
 ybn
 hBV
 fho
-qqk
+vNy
 hee
 hee
 auw
@@ -85328,11 +85016,11 @@ beu
 xUe
 beN
 jad
-jXG
+yez
 wSE
 mPg
 jzd
-wfN
+jzd
 wSE
 wSE
 jzd
@@ -88187,7 +87875,7 @@ pnn
 pnn
 pay
 cfI
-uaN
+rLe
 gRN
 mph
 eVo
@@ -88714,7 +88402,7 @@ qiA
 prw
 eQX
 cND
-mVv
+qAe
 jsM
 qLb
 nog
@@ -88958,7 +88646,7 @@ onR
 onR
 onR
 uWM
-hGZ
+iMZ
 iAp
 rst
 tjx
@@ -89485,7 +89173,7 @@ mVv
 ieQ
 qAe
 qAe
-mVv
+qAe
 cND
 ezH
 erg
@@ -94638,7 +94326,7 @@ gfQ
 gfQ
 gfQ
 xBZ
-ugo
+hLU
 xBZ
 gfQ
 gfQ
@@ -95920,7 +95608,7 @@ gfQ
 gfQ
 xBZ
 gQY
-jMZ
+tlu
 rST
 oiJ
 iLO

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -312,7 +312,7 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "acs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "act" = (
@@ -1554,6 +1554,7 @@
 	pixel_y = 5
 	},
 /obj/structure/table,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron,
 /area/security/prison/rec)
 "alD" = (
@@ -2191,6 +2192,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
+"apb" = (
+/obj/structure/chair,
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "apc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -2257,7 +2263,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Cargo - Mining Shuttle Dock";
-	dir = 4
+	dir = 4;
+	network = list("ss13","qm")
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
@@ -2885,6 +2892,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "auV" = (
@@ -3056,6 +3064,9 @@
 /area/service/chapel/main)
 "awf" = (
 /obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/plumbed{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -3449,21 +3460,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "azA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
-"azD" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -4153,15 +4149,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/radio/intercom{
-	pixel_x = -29
-	},
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
 /obj/item/dest_tagger,
 /obj/item/crowbar,
+/obj/machinery/airalarm/directional/west,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "aHo" = (
@@ -4441,6 +4436,7 @@
 	req_access_txt = "28"
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/maintenance/central)
 "aJZ" = (
@@ -4474,6 +4470,7 @@
 /area/maintenance/central)
 "aKk" = (
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "aKl" = (
@@ -5387,6 +5384,12 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
+"aRD" = (
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aRE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -6003,7 +6006,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering - Supermatter - Fore";
 	dir = 1;
-	network = list("ss13","engine")
+	network = list("ss13","engine","sm")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
@@ -6276,13 +6279,6 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"aYx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aYz" = (
@@ -7009,6 +7005,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "bdJ" = (
@@ -8186,6 +8183,7 @@
 /area/science/robotics/mechbay)
 "bmH" = (
 /obj/structure/rack,
+/obj/item/fuel_pellet,
 /obj/item/fuel_pellet,
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
@@ -9379,11 +9377,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
-"bTW" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "bUl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -11527,6 +11520,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "dgp" = (
@@ -11606,6 +11602,7 @@
 /area/engineering/atmos)
 "dka" = (
 /obj/machinery/vending/cigarette,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/command/bridge)
 "dkR" = (
@@ -12208,6 +12205,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"dzJ" = (
+/obj/effect/landmark/start/cook,
+/obj/machinery/duct,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "dzX" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -12717,7 +12719,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering - Supermatter Chamber";
 	dir = 4;
-	network = list("ss13","engine")
+	network = list("ss13","engine","sm")
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -13482,6 +13484,9 @@
 /obj/structure/cable,
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eeo" = (
@@ -14248,7 +14253,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Supermatter - Aft";
-	network = list("ss13","engine")
+	network = list("ss13","engine","sm")
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -15075,7 +15080,7 @@
 /area/science/mixing)
 "eZw" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/pink/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -15789,6 +15794,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "foV" = (
@@ -17053,6 +17061,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "fYm" = (
@@ -17093,12 +17102,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engineering/main)
 "fZq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "fZM" = (
@@ -17159,6 +17168,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "gay" = (
@@ -17211,6 +17221,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "gbY" = (
@@ -17486,6 +17497,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"gkD" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "glm" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
@@ -17852,6 +17867,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/explab)
+"gut" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/command/bridge)
 "guN" = (
 /obj/machinery/button/door{
 	id = "telelab";
@@ -19020,7 +19042,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/meter,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -19295,6 +19316,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
+"hjO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "hjS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -19353,13 +19379,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain)
-"hlP" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/closed/wall,
-/area/cargo/sorting)
 "hlR" = (
 /obj/item/trash/raisins,
 /obj/structure/cable,
@@ -20366,6 +20385,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "hQc" = (
@@ -20460,7 +20480,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Aux Base Construction";
-	dir = 1
+	dir = 1;
+	network = list("ss13","auxbase")
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
@@ -20604,7 +20625,8 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/camera{
 	c_tag = "Cargo - Mech Pad";
-	dir = 6
+	dir = 6;
+	network = list("ss13","qm")
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -20668,6 +20690,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"ial" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "ibb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -21252,6 +21279,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "isb" = (
@@ -21379,7 +21407,7 @@
 /area/commons/dorms)
 "iwb" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig - Exterior Recreation";
+	c_tag = "Permabrig - Exterior - Recreation";
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -22276,7 +22304,8 @@
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /obj/machinery/camera{
 	c_tag = "Cargo - Bay";
-	dir = 1
+	dir = 1;
+	network = list("ss13","qm")
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -22902,10 +22931,6 @@
 	pixel_x = -29
 	},
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Command - Port Bridge Entrance";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -24807,7 +24832,8 @@
 "kuM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
-	c_tag = "Cargo - Warehouse"
+	c_tag = "Cargo - Warehouse";
+	network = list("ss13","qm")
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -25135,6 +25161,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "kEo" = (
@@ -25823,6 +25850,7 @@
 "kVM" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "kVZ" = (
@@ -25860,7 +25888,6 @@
 "kXw" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "kXR" = (
@@ -26161,10 +26188,10 @@
 /area/maintenance/port/aft)
 "lid" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/light/small,
 /obj/structure/closet/crate,
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "lie" = (
@@ -26635,7 +26662,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Command - Quartermaster's Office";
-	dir = 4
+	dir = 4;
+	network = list("ss13","qm")
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
@@ -26687,6 +26715,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "lvL" = (
@@ -27036,8 +27065,8 @@
 /obj/machinery/meter{
 	name = "Distro Gas Meter"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lIv" = (
@@ -27122,6 +27151,7 @@
 	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "lLh" = (
@@ -27213,7 +27243,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Office";
-	dir = 4
+	dir = 4;
+	network = list("ss13","qm")
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27224,10 +27255,6 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
-	},
-/obj/machinery/camera{
-	c_tag = "Command - Starboard Bridge Entrance";
-	dir = 4
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -27412,7 +27439,8 @@
 "lRx" = (
 /obj/machinery/camera{
 	c_tag = "Cargo - Mining Office Processing";
-	dir = 8
+	dir = 8;
+	network = list("ss13","qm")
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
@@ -27992,6 +28020,7 @@
 /obj/item/poster/random_official,
 /obj/effect/spawner/lootdrop/prison_contraband,
 /obj/effect/spawner/lootdrop/prison_contraband,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "mht" = (
@@ -29510,6 +29539,7 @@
 	pixel_y = 2
 	},
 /obj/item/pen,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "mWH" = (
@@ -29960,7 +29990,7 @@
 /obj/structure/sign/picture_frame/showroom/four{
 	pixel_y = -32
 	},
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/command/corporate_showroom)
 "niq" = (
@@ -30005,7 +30035,8 @@
 "njN" = (
 /obj/machinery/computer/cargo/request,
 /obj/machinery/camera{
-	c_tag = "Cargo - Lobby"
+	c_tag = "Cargo - Lobby";
+	network = list("ss13","qm")
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
@@ -30326,7 +30357,7 @@
 /area/security/prison/safe)
 "ntJ" = (
 /obj/item/ectoplasm,
-/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "ntV" = (
@@ -30583,6 +30614,7 @@
 "nBW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "nCc" = (
@@ -31155,7 +31187,7 @@
 	},
 /obj/effect/mapping_helpers/iannewyear,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/command/corporate_showroom)
 "nSz" = (
@@ -31279,6 +31311,7 @@
 "nVl" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/landmark/xeno_spawn,
+/obj/structure/closet/crate,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -31408,7 +31441,8 @@
 "nXT" = (
 /obj/machinery/camera{
 	c_tag = "Cargo - Mining Office";
-	dir = 4
+	dir = 4;
+	network = list("ss13","qm")
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
@@ -31678,11 +31712,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"ofl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ofn" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -31909,7 +31938,8 @@
 "olV" = (
 /obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
-	pixel_x = 24;
+	network = list("sm");
+	pixel_x = 27;
 	pixel_y = -4
 	},
 /turf/open/floor/iron/dark,
@@ -32214,6 +32244,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
+"ovD" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "owh" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -32779,7 +32813,8 @@
 /area/security/brig)
 "oKh" = (
 /obj/machinery/camera{
-	c_tag = "Cargo - Drone Bay"
+	c_tag = "Cargo - Drone Bay";
+	network = list("ss13","qm")
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -33932,6 +33967,7 @@
 /area/command/heads_quarters/hop)
 "prx" = (
 /obj/structure/cable,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/command/bridge)
 "prA" = (
@@ -34273,6 +34309,10 @@
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
 	pixel_y = -30
+	},
+/obj/machinery/computer/security/telescreen/prison{
+	dir = 1;
+	name = "security camera monitor"
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
@@ -35137,7 +35177,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Delivery Office";
-	dir = 4
+	dir = 4;
+	network = list("ss13","qm")
 	},
 /obj/item/hand_labeler{
 	pixel_y = 8
@@ -35574,7 +35615,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering - Supermatter - Port";
 	dir = 4;
-	network = list("ss13","engine")
+	network = list("ss13","engine","sm")
 	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
@@ -35738,6 +35779,13 @@
 "qtf" = (
 /turf/closed/indestructible/riveted,
 /area/science/test_area)
+"qtt" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/turf/open/floor/iron,
+/area/security/prison)
 "qtz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -36210,6 +36258,7 @@
 /obj/item/storage/crayons,
 /obj/structure/cable,
 /obj/effect/spawner/lootdrop/prison_contraband,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron/grimy,
 /area/security/prison/rec)
 "qKs" = (
@@ -37394,6 +37443,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
+"rtN" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "ruP" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/airalarm/mixingchamber{
@@ -37470,7 +37525,7 @@
 /mob/living/simple_animal/pet/dog/corgi/ian,
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/evac/directional/west,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/command/corporate_showroom)
 "rxU" = (
@@ -38293,7 +38348,7 @@
 "rYg" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Emitter Room";
-	network = list("ss13","engine")
+	network = list("ss13","engine","sm")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -39186,7 +39241,8 @@
 /area/science/mixing/chamber)
 "swN" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
-	dir = 1
+	dir = 1;
+	pipe_color = "#00FFFF"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -39364,6 +39420,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "sBT" = (
@@ -40040,6 +40097,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "sST" = (
@@ -40275,7 +40333,7 @@
 /area/security/courtroom)
 "sXu" = (
 /obj/machinery/camera{
-	c_tag = "Security - Armory Interal";
+	c_tag = "Security - Armory Interior";
 	dir = 4;
 	network = list("ss13","prison")
 	},
@@ -40974,11 +41032,11 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/newscaster/directional/west,
 /obj/machinery/camera{
 	c_tag = "Security - Warden's Office";
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "tqB" = (
@@ -41660,6 +41718,20 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"tFW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Supermatter - Starboard";
+	dir = 4;
+	network = list("ss13","engine","sm")
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "tGb" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -41959,6 +42031,9 @@
 /area/science/test_area)
 "tPD" = (
 /obj/effect/spawner/lootdrop/botanical_waste,
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "tPL" = (
@@ -42958,6 +43033,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "uoM" = (
@@ -44082,6 +44158,10 @@
 "uSf" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/camera{
+	c_tag = "Command - Starboard Bridge Entrance";
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/command/bridge)
 "uSk" = (
@@ -44477,6 +44557,13 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/service/bar)
+"vbQ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Ports to Mix"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vbT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45236,7 +45323,8 @@
 "vvc" = (
 /obj/machinery/camera{
 	c_tag = "Disposals";
-	dir = 8
+	dir = 8;
+	network = list("ss13","qm")
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
@@ -45349,6 +45437,7 @@
 /area/science/xenobiology)
 "vxV" = (
 /obj/effect/spawner/randomsnackvend,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/command/bridge)
 "vyd" = (
@@ -46077,7 +46166,7 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Supermatter Entrance";
 	dir = 4;
-	network = list("ss13","engine");
+	network = list("ss13","engine","sm");
 	view_range = 10
 	},
 /turf/open/floor/iron,
@@ -46836,13 +46925,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
-"wlb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wlQ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
@@ -47291,6 +47373,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "wzD" = (
@@ -47951,6 +48035,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/camera{
+	c_tag = "Command - Port Bridge Entrance";
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/command/bridge)
 "wQP" = (
@@ -48015,6 +48103,7 @@
 	name = "Pete"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "wSA" = (
@@ -48387,8 +48476,8 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "xbu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xbv" = (
@@ -62614,16 +62703,16 @@ gfQ
 rpu
 fsz
 fsz
-bTW
 fsz
 fsz
-bTW
 fsz
 fsz
-bTW
 fsz
 fsz
-bTW
+fsz
+fsz
+fsz
+fsz
 fsz
 fsz
 xlO
@@ -64323,7 +64412,7 @@ gfQ
 gfQ
 gfQ
 tRB
-agc
+apb
 ghC
 buj
 ags
@@ -66475,7 +66564,7 @@ tHy
 tHy
 oMm
 xzY
-irn
+vbQ
 vSI
 hKh
 wGl
@@ -66973,7 +67062,7 @@ vbm
 sdY
 dcJ
 kxP
-dcJ
+tFW
 tBF
 csU
 wrn
@@ -67950,7 +68039,7 @@ aCA
 aFk
 oSs
 eDb
-azD
+azA
 fDa
 rhI
 rYZ
@@ -68023,7 +68112,7 @@ xzY
 qrH
 mWH
 xzY
-ofl
+mWH
 djS
 wZU
 sXJ
@@ -68195,7 +68284,7 @@ mrT
 mrT
 xyS
 sIv
-jev
+qtt
 spv
 osZ
 wBx
@@ -70330,14 +70419,14 @@ ggn
 oSP
 foV
 riF
-aYx
+tNf
 riF
 wRu
-wlb
+tNf
 cjL
 vPR
 eZw
-wlb
+tNf
 tPW
 riF
 riF
@@ -76764,7 +76853,7 @@ eCe
 voR
 mcr
 bYN
-tuj
+ovD
 gKd
 vqR
 oKh
@@ -77519,7 +77608,7 @@ exH
 smo
 qdO
 aHn
-hlP
+aHm
 aHm
 acp
 aHm
@@ -77777,7 +77866,7 @@ smo
 mOJ
 aHo
 ofn
-vSt
+hjO
 nfi
 aHm
 kLm
@@ -79540,16 +79629,16 @@ gLp
 ybR
 wyW
 xvt
-uMp
-aXZ
+ial
+aRD
 tdq
 oqm
 bai
 rEw
 adA
 tdq
-xGY
-xGY
+nvk
+nvk
 xGY
 xGY
 pVM
@@ -79582,7 +79671,7 @@ pjf
 acz
 acE
 nia
-pjf
+rtN
 hsV
 qUi
 pLz
@@ -79797,8 +79886,8 @@ uoG
 bdI
 aKk
 aJU
-uMp
-nvk
+ial
+vyu
 vyu
 vyu
 vyu
@@ -80820,7 +80909,7 @@ dVp
 xvt
 aJf
 gbO
-bki
+dzJ
 tZG
 aJQ
 bki
@@ -81077,7 +81166,7 @@ ybn
 xvt
 xvt
 khu
-tZG
+gkD
 ifh
 aJR
 tZG
@@ -85237,7 +85326,7 @@ qAe
 qAe
 ciJ
 tEs
-qAe
+gut
 rYy
 qKN
 jFo
@@ -89104,7 +89193,7 @@ qCG
 cZt
 hQU
 orD
-vmQ
+hWU
 pMJ
 tYw
 gfQ

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -176,12 +176,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"abR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/medical/virology)
 "abS" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/xeno_spawn,
@@ -996,15 +990,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"agy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "agA" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
@@ -1355,13 +1340,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"akh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "akj" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -1787,13 +1765,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"amL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "amM" = (
 /obj/machinery/light{
 	dir = 4
@@ -3455,7 +3426,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -6354,13 +6324,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"aZh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "aZi" = (
 /obj/structure/chair{
 	dir = 4
@@ -6697,7 +6660,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -7337,13 +7299,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"bgK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "bgQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -8666,18 +8621,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"bxg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "bxj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8793,16 +8736,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
-/area/security/brig)
-"bAz" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
 /area/security/brig)
 "bAE" = (
 /obj/structure/sign/directions/evac{
@@ -9859,7 +9792,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -12245,13 +12177,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"dDP" = (
-/obj/effect/landmark/start/botanist,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/service/hydroponics)
 "dDQ" = (
 /obj/structure/window{
 	dir = 4
@@ -15548,7 +15473,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -15662,7 +15586,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -17947,7 +17870,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/bridge)
 "gHi" = (
@@ -19496,8 +19418,6 @@
 	sortType = 30
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -20486,7 +20406,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -22148,14 +22067,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"jhM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "jhS" = (
 /obj/structure/sign/poster/official/obey{
 	pixel_x = 30
@@ -22536,13 +22447,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
-"jtX" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/office)
 "juh" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -23765,7 +23669,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
@@ -24242,11 +24145,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"ksw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
 "ksz" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -24409,7 +24307,6 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -25530,7 +25427,6 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "lgw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -28477,7 +28373,6 @@
 /area/cargo/office)
 "mLZ" = (
 /obj/structure/cable,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
@@ -28821,13 +28716,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
-"mVv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/command/bridge)
 "mVJ" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -30168,14 +30056,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/transit_tube)
-"nIo" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/security/prison)
 "nIx" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -31938,13 +31818,6 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"oGy" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "oGQ" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/showroomfloor,
@@ -31955,19 +31828,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"oHf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "oHg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -32679,7 +32539,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/white,
@@ -33832,14 +33691,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"pMS" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "pNw" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
@@ -34268,19 +34119,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
-"qcW" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/main)
 "qde" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -35495,13 +35333,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
-"qQd" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/exam_room)
 "qQf" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -35970,7 +35801,6 @@
 /area/science/genetics)
 "rei" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
@@ -36953,16 +36783,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/brig)
-"rJK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "rKi" = (
 /obj/machinery/door/airlock/external{
 	name = "Tcoms External Access";
@@ -40727,7 +40547,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tHM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/bounty_board/directional/west,
 /turf/open/floor/plating,
@@ -44675,19 +44494,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
-"vHE" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "vHG" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage";
@@ -44925,7 +44731,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "vOL" = (
@@ -44956,7 +44761,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vPH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
@@ -45174,7 +44978,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -46074,7 +45877,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -48761,8 +48563,6 @@
 "xPV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -63898,7 +63698,7 @@ jev
 ndS
 jev
 jev
-nIo
+jev
 jev
 jev
 jev
@@ -65441,7 +65241,7 @@ ygB
 jbw
 jbw
 gNZ
-amL
+jbw
 jbw
 adY
 jev
@@ -67003,7 +66803,7 @@ vHv
 mpE
 aym
 vHv
-oHf
+azA
 fDa
 rhI
 tia
@@ -67047,7 +66847,7 @@ vSN
 vSN
 wjH
 pPS
-qcW
+biM
 biL
 kqh
 jXT
@@ -69329,13 +69129,13 @@ deM
 ihf
 olZ
 dcP
-bxg
+dcP
 dcP
 dcP
 jjA
 emM
 feI
-jhM
+jdu
 jdu
 jdu
 dPY
@@ -73226,7 +73026,7 @@ pLL
 pLL
 pLL
 qyn
-bgK
+hlG
 hlG
 aTu
 qKS
@@ -73435,7 +73235,7 @@ vLQ
 foq
 xke
 vUV
-bAz
+mFB
 mnh
 ecm
 bkL
@@ -73463,7 +73263,7 @@ orB
 orB
 kEt
 lAk
-vHE
+lAk
 lAk
 lAk
 lAk
@@ -74966,7 +74766,7 @@ sVb
 sVb
 sVb
 atV
-ksw
+aCs
 aCs
 aWu
 aWu
@@ -78115,7 +77915,7 @@ rxU
 eEl
 acJ
 mKV
-jtX
+mKV
 lMQ
 vPT
 mKV
@@ -78366,7 +78166,7 @@ qks
 iMU
 qks
 hgw
-rJK
+rLe
 exH
 rxU
 anc
@@ -80654,7 +80454,7 @@ nwW
 axd
 axd
 qHj
-dDP
+bbw
 axd
 udM
 bbw
@@ -80866,7 +80666,7 @@ nrY
 wYX
 jPf
 ygg
-akh
+arN
 arN
 alO
 ame
@@ -80936,7 +80736,7 @@ mQA
 aRH
 aRJ
 cfI
-rJK
+rLe
 exH
 fMo
 sIc
@@ -81193,7 +80993,7 @@ mQA
 kGL
 yfY
 cfI
-rJK
+rLe
 exH
 rmb
 sIc
@@ -83239,7 +83039,7 @@ mEb
 cwc
 cwc
 oaP
-abR
+cwc
 gIr
 rpM
 cwc
@@ -84033,7 +83833,7 @@ qAe
 qAe
 ciJ
 tEs
-mVv
+qAe
 rYy
 qKN
 jFo
@@ -84486,7 +84286,7 @@ aUg
 aVz
 aWR
 aYI
-aZh
+aZT
 uKk
 bdK
 bqU
@@ -85048,7 +84848,7 @@ xcl
 aKO
 pnn
 jJn
-rJK
+rLe
 uio
 bQI
 yal
@@ -85562,7 +85362,7 @@ msF
 aKO
 pnn
 wNb
-rJK
+rLe
 nNO
 wmw
 rfU
@@ -86050,7 +85850,7 @@ mRb
 nBH
 bkZ
 blg
-qQd
+nFu
 iie
 tec
 ygp
@@ -89169,7 +88969,7 @@ pMf
 vWc
 gQg
 cKk
-mVv
+qAe
 ieQ
 qAe
 qAe
@@ -89923,7 +89723,7 @@ ydj
 lqD
 ydj
 ydj
-pMS
+ydj
 ydj
 ydj
 ydj
@@ -93276,7 +93076,7 @@ jig
 jig
 dCK
 tmj
-agy
+tLd
 dXn
 nqN
 nqN
@@ -94810,7 +94610,7 @@ jig
 jig
 nSz
 kxZ
-oGy
+wjQ
 vTl
 pys
 dmt

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -507,7 +507,7 @@
 /area/service/hydroponics)
 "adH" = (
 /obj/machinery/camera{
-	c_tag = "Chapel";
+	c_tag = "Service - Chapel";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -521,7 +521,7 @@
 /area/service/chapel/main)
 "adJ" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals North - East";
+	c_tag = "Arrivals Hallway - Starboard Escape Pod";
 	dir = 8
 	},
 /obj/structure/sign/warning/pods{
@@ -571,7 +571,7 @@
 /area/security/prison)
 "adY" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Cellblock B";
+	c_tag = "Permabrig - Cellblock B - Aft";
 	dir = 4;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -742,7 +742,7 @@
 /area/hallway/secondary/entry)
 "aeX" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Exterior Hydro";
+	c_tag = "Permabrig - Exterior - Hydroponics";
 	dir = 8;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -1044,7 +1044,7 @@
 /area/maintenance/starboard/aft)
 "ahh" = (
 /obj/machinery/camera{
-	c_tag = "East Hallway - Chapel";
+	c_tag = "Fore Hallway - Chapel";
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -1057,7 +1057,7 @@
 "ahs" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/machinery/camera{
-	c_tag = "Permabrig Recreation Room";
+	c_tag = "Permabrig - Recreation Room";
 	dir = 8;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -1106,7 +1106,7 @@
 "ahP" = (
 /obj/structure/closet/athletic_mixed,
 /obj/machinery/camera{
-	c_tag = "Holodeck";
+	c_tag = "Holodeck - Starboard";
 	dir = 8;
 	network = list("ss13","rd")
 	},
@@ -1264,7 +1264,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Permabrig Cafeteria";
+	c_tag = "Permabrig - Cafeteria";
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -1418,13 +1418,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
-"akV" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals East";
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "akX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1437,6 +1430,10 @@
 	pixel_y = -24
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/machinery/camera{
+	c_tag = "Arrivals Hallway - Port Wing";
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ald" = (
@@ -1483,7 +1480,7 @@
 /area/hallway/secondary/entry)
 "alq" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals West";
+	c_tag = "Arrivals Hallway - Starboard Wing";
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/south,
@@ -1510,7 +1507,7 @@
 /area/security/prison)
 "alD" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Cellblock B - North";
+	c_tag = "Permabrig - Cellblock B - Fore";
 	dir = 8;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -1519,7 +1516,7 @@
 /area/security/prison)
 "alG" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Cellblock A - North";
+	c_tag = "Permabrig - Cellblock A - Fore";
 	dir = 4;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -1745,7 +1742,7 @@
 /area/maintenance/fore)
 "amK" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals North - West";
+	c_tag = "Arrivals Hallway - Port Escape Pod";
 	dir = 4
 	},
 /obj/structure/sign/warning/pods{
@@ -1875,7 +1872,7 @@
 /obj/item/seeds/apple,
 /obj/item/seeds/cabbage,
 /obj/machinery/camera{
-	c_tag = "Permabrig Hydrophonics";
+	c_tag = "Permabrig - Hydrophonics";
 	dir = 4;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -2095,7 +2092,7 @@
 "aoZ" = (
 /obj/structure/closet/secure_closet/security,
 /obj/machinery/camera{
-	c_tag = "Security Checkpoint";
+	c_tag = "Arrivals Security Checkpoint";
 	dir = 1
 	},
 /obj/item/crowbar,
@@ -2361,7 +2358,7 @@
 /area/hallway/secondary/entry)
 "arS" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Hallway - South"
+	c_tag = "Arrivals Hallway - Lounge"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -2528,7 +2525,7 @@
 /area/security/prison)
 "asP" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Cellblock A";
+	c_tag = "Permabrig - Cellblock A - Aft";
 	dir = 8;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -2617,7 +2614,7 @@
 	dir = 9
 	},
 /obj/machinery/camera{
-	c_tag = "Chapel Crematorium";
+	c_tag = "Service - Chapel Crematorium";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -2837,7 +2834,7 @@
 /area/service/chapel/main)
 "avq" = (
 /obj/machinery/camera{
-	c_tag = "Chapel Viewing Room";
+	c_tag = "Service - Chapel Viewing Room";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3053,7 +3050,7 @@
 /area/service/chapel/main)
 "awT" = (
 /obj/machinery/camera{
-	c_tag = "East Hallway - Vault";
+	c_tag = "Port Hallway - Vault";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -3395,7 +3392,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/camera{
-	c_tag = "Brig Prison Hallway North East";
+	c_tag = "Security - Fore Hallway";
 	network = list("ss13","prison")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3530,7 +3527,7 @@
 /area/maintenance/port/fore)
 "aAY" = (
 /obj/machinery/camera{
-	c_tag = "Dormitory North"
+	c_tag = "Dormitory - Main"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3957,7 +3954,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Garden";
+	c_tag = "Public Garden";
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -5580,7 +5577,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/camera{
-	c_tag = "North Hallway - Holodeck";
+	c_tag = "Fore Hallway - Garden";
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -6253,10 +6250,6 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "aYQ" = (
-/obj/machinery/camera{
-	c_tag = "Security - EVA Storage";
-	dir = 10
-	},
 /obj/machinery/suit_storage_unit/security,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -6325,7 +6318,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Holodeck";
+	c_tag = "Holodeck - Port";
 	dir = 4;
 	network = list("ss13","rd")
 	},
@@ -6511,6 +6504,10 @@
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/newscaster/directional/east,
+/obj/machinery/camera{
+	c_tag = "Service - Service Hall";
+	dir = 8
+	},
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "bak" = (
@@ -6665,7 +6662,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Permabrig Visitation";
+	c_tag = "Permabrig - Visitation";
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
@@ -8132,6 +8129,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"boj" = (
+/obj/structure/lattice,
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Room";
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "bor" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -8867,16 +8872,6 @@
 "bHB" = (
 /turf/closed/wall/r_wall,
 /area/engineering/transit_tube)
-"bHK" = (
-/obj/machinery/camera{
-	c_tag = "Escape North";
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit/departure_lounge)
 "bHL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9109,11 +9104,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/camera{
-	c_tag = "Labor Shuttle Dock";
-	dir = 1;
-	network = list("ss13","prison")
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
@@ -9131,7 +9121,7 @@
 /area/maintenance/starboard/aft)
 "bRe" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Library";
+	c_tag = "Permabrig - Library";
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -9214,7 +9204,7 @@
 /area/ai_monitored/turret_protected/ai)
 "bTw" = (
 /obj/machinery/camera{
-	c_tag = "Security Cells West";
+	c_tag = "Security -  Entrance";
 	network = list("ss13","prison")
 	},
 /obj/effect/turf_decal/tile/red{
@@ -9490,8 +9480,8 @@
 /area/service/chapel/main)
 "ccc" = (
 /obj/machinery/camera{
-	c_tag = "Firing Range";
-	dir = 4
+	c_tag = "Security - Firing Range";
+	dir = 1
 	},
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -9672,7 +9662,7 @@
 /area/maintenance/starboard/aft)
 "cgf" = (
 /obj/machinery/camera{
-	c_tag = "Dormitory Toilets";
+	c_tag = "Dormitory - Toilets";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10043,7 +10033,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Hydrophonics Backroom";
+	c_tag = "Service - Hydrophonics Backroom";
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
@@ -10292,7 +10282,7 @@
 /area/hallway/primary/port)
 "cBO" = (
 /obj/machinery/camera{
-	c_tag = "Dormitory South";
+	c_tag = "Dormitory - Entrance";
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -10631,7 +10621,7 @@
 "cPT" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/machinery/camera{
-	c_tag = "Detective Office"
+	c_tag = "Security - Detective's Office"
 	},
 /obj/item/book/manual/wiki/detective,
 /turf/open/floor/iron/grimy,
@@ -11060,7 +11050,7 @@
 /area/engineering/atmos)
 "dbF" = (
 /obj/machinery/camera{
-	c_tag = "North Hallway - Intersection"
+	c_tag = "Fore Hallway - Intersection"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -11079,6 +11069,10 @@
 /obj/item/pen/blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Room";
+	dir = 10
 	},
 /turf/open/floor/iron/textured_half,
 /area/engineering/gravity_generator)
@@ -11101,7 +11095,7 @@
 	},
 /obj/structure/closet/crate/trashcart,
 /obj/machinery/camera{
-	c_tag = "South Hallway - Intersection";
+	c_tag = "Service - Custodial Closet";
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -11187,7 +11181,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Security Central";
+	c_tag = "Security - Central Hallway";
 	dir = 8;
 	network = list("ss13","prison")
 	},
@@ -11515,6 +11509,7 @@
 /area/maintenance/disposal)
 "doY" = (
 /obj/structure/closet/secure_closet/atmospherics,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/upper)
@@ -12656,7 +12651,7 @@
 	pixel_x = 29
 	},
 /obj/machinery/camera{
-	c_tag = "Arrivals Middle - West";
+	c_tag = "Arrivals Hallway - Port";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -12867,7 +12862,7 @@
 /area/hallway/primary/fore)
 "dTw" = (
 /obj/machinery/camera{
-	c_tag = "North Hallway - East";
+	c_tag = "Fore Hallway - Art Storage";
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -12976,7 +12971,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/camera{
-	c_tag = "North Hallway - West";
+	c_tag = "Fore Hallway - Holodeck";
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
@@ -13048,7 +13043,7 @@
 /area/science/xenobiology)
 "dYP" = (
 /obj/machinery/camera{
-	c_tag = "West Hallway - North";
+	c_tag = "Starboard Hallway - Fore Corner";
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -13557,7 +13552,7 @@
 	pixel_x = -29
 	},
 /obj/machinery/camera{
-	c_tag = "Arrivals Middle East";
+	c_tag = "Arrivals Hallway - Starboard";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -14396,7 +14391,7 @@
 	pixel_y = -26
 	},
 /obj/machinery/camera{
-	c_tag = "Theatre Backstage";
+	c_tag = "Service - Theatre Backstage";
 	dir = 8;
 	name = "service camera"
 	},
@@ -14411,7 +14406,7 @@
 /area/maintenance/starboard/fore)
 "ePA" = (
 /obj/machinery/camera{
-	c_tag = "Courtroom North";
+	c_tag = "Courtroom Stand";
 	dir = 8;
 	network = list("ss13","prison")
 	},
@@ -14709,6 +14704,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"eYx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/camera{
+	c_tag = "Port Hallway - Security"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "eYG" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -14848,7 +14856,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Bar Lounge";
+	c_tag = "Service - Bar Lounge";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -16131,6 +16139,11 @@
 "fIE" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/status_display/evac/directional/south,
+/obj/machinery/camera{
+	c_tag = "Security - Labor Shuttle Dock";
+	dir = 1;
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "fIJ" = (
@@ -16222,6 +16235,7 @@
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/upper)
 "fMo" = (
@@ -17245,7 +17259,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/l3closet/security,
 /obj/machinery/camera{
-	c_tag = "Security Briefing Room North";
+	c_tag = "Security - Fore Briefing Room";
 	dir = 4;
 	network = list("ss13","prison")
 	},
@@ -17265,7 +17279,7 @@
 /area/science/lab)
 "gqQ" = (
 /obj/machinery/camera{
-	c_tag = "East Hallway South";
+	c_tag = "Port Hallway - Aft Corner";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -19109,7 +19123,7 @@
 "hqz" = (
 /obj/structure/chair,
 /obj/machinery/camera{
-	c_tag = "Escape Sec Checkpoint"
+	c_tag = "Departures Security Checkpoint"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -19278,7 +19292,7 @@
 /area/engineering/atmos)
 "hvT" = (
 /obj/machinery/camera{
-	c_tag = "East Hallway - Engineering";
+	c_tag = "Port Hallway - Engineering";
 	dir = 8
 	},
 /obj/structure/noticeboard{
@@ -20110,9 +20124,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "East Hallway - Sec"
-	},
 /obj/structure/chair{
 	dir = 1
 	},
@@ -20368,7 +20379,7 @@
 	name = "CondiMaster Neo"
 	},
 /obj/machinery/camera{
-	c_tag = "Kitchen Coldroom";
+	c_tag = "Service - Kitchen Coldroom";
 	dir = 8
 	},
 /turf/open/floor/iron/freezer,
@@ -20422,7 +20433,7 @@
 /area/service/kitchen)
 "igv" = (
 /obj/machinery/camera{
-	c_tag = "Brig Interrogation";
+	c_tag = "Security - Interrogation";
 	dir = 8;
 	network = list("interrogation")
 	},
@@ -20459,7 +20470,7 @@
 /area/security/courtroom)
 "ihU" = (
 /obj/machinery/camera{
-	c_tag = "Escape Hallway South";
+	c_tag = "Escape Hallway - Teleporter";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -20879,21 +20890,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"iuU" = (
-/obj/machinery/camera{
-	c_tag = "South Hallway - East";
-	dir = 1;
-	view_range = 10
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "iuZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
@@ -20903,7 +20899,7 @@
 /area/commons/dorms)
 "iwb" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Exterior Recreation";
+	c_tag = "Permabrig - Exterior Recreation";
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -21271,6 +21267,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"iJM" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "iKe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -21575,7 +21579,7 @@
 /area/engineering/atmos)
 "iTt" = (
 /obj/machinery/camera{
-	c_tag = "West Hallway - South";
+	c_tag = "Starboard Hallway - Aft Corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -21730,7 +21734,7 @@
 /area/maintenance/aft)
 "iXz" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway - North";
+	c_tag = "Central Hallway - Kitchen";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -21752,9 +21756,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/maintenance/aft)
 "iXW" = (
 /obj/structure/window{
@@ -21980,7 +21982,7 @@
 /area/service/chapel/main)
 "jcZ" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/engineering/gravity_generator)
 "jdd" = (
 /obj/structure/flora/ausbushes/pointybush,
@@ -22144,7 +22146,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/camera{
-	c_tag = "Security Armory Exterior";
+	c_tag = "Security - Armory Hallway";
 	dir = 8;
 	network = list("ss13","prison")
 	},
@@ -22248,22 +22250,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"jna" = (
-/obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Security Cells East";
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "jne" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -23004,7 +22990,7 @@
 /area/medical/medbay/central)
 "jJn" = (
 /obj/machinery/camera{
-	c_tag = "South Hallway West"
+	c_tag = "Aft Hallway - Ian's Room"
 	},
 /obj/structure/chair{
 	dir = 4
@@ -23265,7 +23251,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/camera{
-	c_tag = "Hydrophonics";
+	c_tag = "Service - Hydrophonics";
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -23509,7 +23495,7 @@
 /area/command/bridge)
 "jYu" = (
 /obj/machinery/camera/motion{
-	c_tag = "Armory External";
+	c_tag = "Security - Armory External";
 	dir = 8
 	},
 /turf/open/space/basic,
@@ -25186,6 +25172,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"kUI" = (
+/turf/closed/wall/r_wall,
+/area/construction/mining/aux_base)
 "kVx" = (
 /obj/machinery/light{
 	dir = 4
@@ -25222,6 +25211,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"kWq" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig - Exterior - Showers";
+	dir = 1;
+	name = "Perma Camera";
+	network = list("ss13","prison")
+	},
+/turf/open/space/basic,
+/area/space)
 "kWL" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -25681,6 +25679,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"lkW" = (
+/obj/structure/reagent_dispensers/plumbed,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "lli" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -26561,7 +26563,7 @@
 /area/medical/chemistry)
 "lMI" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Prisoner Processing";
+	c_tag = "Permabrig - Entrance";
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -26950,7 +26952,7 @@
 /area/security/office)
 "lWC" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway - South";
+	c_tag = "Central Hallway - Bar";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -27755,7 +27757,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/camera{
-	c_tag = "Security Hall South";
+	c_tag = "Security - External Airlock";
 	dir = 8;
 	network = list("ss13","prison")
 	},
@@ -28299,7 +28301,7 @@
 /area/service/chapel/main)
 "mJh" = (
 /obj/machinery/camera{
-	c_tag = "Bar Storage";
+	c_tag = "Service - Bar Storage";
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/bar_wardrobe,
@@ -28874,7 +28876,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Teleporter"
+	c_tag = "Command - Teleporter"
 	},
 /turf/open/floor/iron,
 /area/command/teleporter)
@@ -29249,7 +29251,7 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "nio" = (
 /obj/machinery/camera{
-	c_tag = "Ian's Room";
+	c_tag = "Command - Ian's Room";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29648,6 +29650,10 @@
 	dir = 4
 	},
 /obj/machinery/bounty_board/directional/west,
+/obj/machinery/camera{
+	c_tag = "Departures - Port";
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "nuO" = (
@@ -29953,7 +29959,7 @@
 /area/medical/cryo)
 "nDC" = (
 /obj/machinery/camera{
-	c_tag = "West Hallway - Robotics";
+	c_tag = "Starboard Hallway - Science";
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -30235,7 +30241,7 @@
 /area/science/xenobiology)
 "nMR" = (
 /obj/machinery/camera/motion{
-	c_tag = "Vault";
+	c_tag = "Vault - Interior";
 	dir = 1;
 	network = list("vault")
 	},
@@ -30243,7 +30249,7 @@
 /area/ai_monitored/command/nuke_storage)
 "nNy" = (
 /obj/machinery/camera{
-	c_tag = "West Hallway - Robotics";
+	c_tag = "Starboard Hallway - Robotics";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -30691,7 +30697,7 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "nYk" = (
 /obj/machinery/camera{
-	c_tag = "Kitchen";
+	c_tag = "Service - Kitchen";
 	dir = 4
 	},
 /obj/machinery/airalarm{
@@ -30956,7 +30962,7 @@
 /area/hallway/primary/port)
 "ofA" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Visitation Exterior";
+	c_tag = "Permabrig - Visitation Exterior";
 	dir = 4;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -31147,19 +31153,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"olN" = (
-/obj/machinery/camera{
-	c_tag = "Warden's Office";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/security/warden)
 "olU" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -31362,9 +31355,6 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "orv" = (
-/obj/machinery/camera{
-	c_tag = "Escape South"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -31540,7 +31530,7 @@
 "oxT" = (
 /obj/structure/closet/secure_closet/exile,
 /obj/machinery/camera{
-	c_tag = "Gateway";
+	c_tag = "Command - Gateway";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -31631,7 +31621,7 @@
 /area/maintenance/port)
 "ozR" = (
 /obj/machinery/camera{
-	c_tag = "Courtroom South";
+	c_tag = "Courtroom";
 	dir = 1;
 	network = list("ss13","prison")
 	},
@@ -32163,9 +32153,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
+/turf/open/floor/plating,
 /area/maintenance/port)
 "oPa" = (
 /obj/structure/table,
@@ -32184,6 +32172,15 @@
 /obj/item/pen,
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
+"oPr" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig - Prisoner Processing";
+	dir = 4;
+	name = "Perma Camera";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "oPN" = (
 /obj/item/trash/cheesie,
 /obj/structure/cable,
@@ -35091,7 +35088,9 @@
 /area/maintenance/central)
 "qDX" = (
 /obj/structure/cable,
-/obj/machinery/camera,
+/obj/machinery/camera{
+	c_tag = "Command - EVA Storage"
+	},
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
@@ -36200,7 +36199,7 @@
 /area/cargo/warehouse)
 "rnH" = (
 /obj/machinery/camera{
-	c_tag = "Chapel Office";
+	c_tag = "Service - Chapel Office";
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
@@ -38792,7 +38791,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/camera{
-	c_tag = "Escape Hallway North";
+	c_tag = "Escape Hallway - EVA";
 	dir = 4
 	},
 /obj/item/kirbyplants/random,
@@ -38830,7 +38829,7 @@
 /area/maintenance/central)
 "sOt" = (
 /obj/machinery/camera{
-	c_tag = "HoS' Room";
+	c_tag = "Command - Head of Security's Office";
 	network = list("ss13","prison")
 	},
 /obj/machinery/keycard_auth{
@@ -38944,9 +38943,7 @@
 "sRw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
+/turf/open/floor/plating,
 /area/maintenance/port)
 "sRB" = (
 /obj/structure/girder,
@@ -39014,7 +39011,7 @@
 /obj/item/book/manual/wiki/cooking_to_serve_man,
 /obj/item/kitchen/rollingpin,
 /obj/machinery/camera{
-	c_tag = "Permabrig Kitchen";
+	c_tag = "Permabrig - Kitchen";
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -39220,7 +39217,7 @@
 /area/security/courtroom)
 "sXu" = (
 /obj/machinery/camera{
-	c_tag = "Security Armory";
+	c_tag = "Security - Armory Interal";
 	dir = 4;
 	network = list("ss13","prison")
 	},
@@ -39893,6 +39890,10 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/camera{
+	c_tag = "Security - Warden's Office";
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "tqB" = (
@@ -40977,7 +40978,7 @@
 "tRX" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/machinery/camera{
-	c_tag = "Head of Personnel's Office";
+	c_tag = "Command - Head of Personnel's Office";
 	dir = 1
 	},
 /obj/item/gun/energy/e_gun/mini,
@@ -41086,7 +41087,7 @@
 /area/service/hydroponics/garden)
 "tVM" = (
 /obj/machinery/camera{
-	c_tag = "Vault Exterior";
+	c_tag = "Vault - Exterior";
 	dir = 8
 	},
 /turf/open/space/basic,
@@ -41476,7 +41477,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/camera{
-	c_tag = "Bar Lounge";
+	c_tag = "Service - Bar Piano";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -41920,7 +41921,7 @@
 "urj" = (
 /obj/structure/table,
 /obj/machinery/camera{
-	c_tag = "Bar Counter"
+	c_tag = "Service - Bar Counter"
 	},
 /obj/item/holosign_creator/robot_seat/bar,
 /turf/open/floor/mineral/plastitanium{
@@ -42165,6 +42166,10 @@
 "uzz" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Security - EVA Storage & Brigmed";
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "uAk" = (
@@ -42350,7 +42355,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/camera{
-	c_tag = "Dormitory Cryogenics";
+	c_tag = "Dormitory - Cryogenics";
 	dir = 1
 	},
 /turf/open/floor/iron/freezer,
@@ -43601,6 +43606,21 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
+"vmG" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Aft Hallway - Custodial Closet";
+	dir = 1;
+	view_range = 10
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "vmO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
@@ -43926,6 +43946,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Departures - Fore";
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "vtD" = (
@@ -44191,7 +44215,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera{
-	c_tag = "South Hallway - Intersection";
+	c_tag = "Aft Hallway - Intersection";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -44300,6 +44324,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/camera{
+	c_tag = "Security - Cells";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron,
 /area/security/brig)
 "vAS" = (
@@ -44949,7 +44977,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/camera{
-	c_tag = "East Hallway North";
+	c_tag = "Port Hallway - Fore Corner";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -45396,7 +45424,7 @@
 "wgu" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /obj/machinery/camera{
-	c_tag = "Law Office";
+	c_tag = "Service - Law Office";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -45994,7 +46022,7 @@
 "wyY" = (
 /obj/machinery/light,
 /obj/machinery/camera{
-	c_tag = "Security Visitation";
+	c_tag = "Security - Visitation";
 	dir = 1;
 	network = list("ss13","prison")
 	},
@@ -46290,7 +46318,7 @@
 /area/science/mixing)
 "wHJ" = (
 /obj/machinery/camera{
-	c_tag = "Security Briefing Room South";
+	c_tag = "Security - Aft Briefing Room";
 	dir = 1;
 	network = list("ss13","prison")
 	},
@@ -48310,7 +48338,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/camera{
-	c_tag = "South Hallway - HoP Line";
+	c_tag = "Aft Hallway - HoP Line";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -48375,6 +48403,10 @@
 	dir = 8
 	},
 /obj/machinery/bounty_board/directional/east,
+/obj/machinery/camera{
+	c_tag = "Departures - Starboard";
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "xFu" = (
@@ -49103,7 +49135,7 @@
 /area/service/hydroponics)
 "ycG" = (
 /obj/machinery/camera{
-	c_tag = "Centra Hallway";
+	c_tag = "Centra Hallway - Hydroponics";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -64852,7 +64884,7 @@ gfQ
 gfQ
 aUP
 fsz
-fsz
+boj
 fsz
 fsz
 fsz
@@ -66588,7 +66620,7 @@ gfQ
 sHc
 fsz
 fsz
-gfQ
+kWq
 yin
 aic
 vNQ
@@ -66612,7 +66644,7 @@ lNw
 wZE
 ouN
 hPS
-xlD
+oPr
 aCA
 aFk
 gQW
@@ -69484,7 +69516,7 @@ xUm
 waV
 waV
 waV
-wGn
+lkW
 iJh
 wVb
 cpP
@@ -69712,7 +69744,7 @@ sHE
 kcR
 bVO
 tqr
-olN
+dfH
 dfH
 iVV
 dfH
@@ -72045,7 +72077,7 @@ aEq
 eVu
 sov
 mpc
-oCT
+wFw
 tZa
 aEk
 gfQ
@@ -72284,7 +72316,7 @@ xke
 vHv
 vHv
 xke
-uCE
+eYx
 vYu
 uqd
 tIA
@@ -73820,7 +73852,7 @@ uJa
 oxh
 lSd
 xke
-jna
+vVw
 kcR
 xke
 rPv
@@ -76462,17 +76494,17 @@ bYN
 iuu
 tuj
 rfR
-fBs
-fBs
-fBs
-fBs
-fBs
-fBs
-fBs
-fBs
-fBs
-fBs
-fBs
+kUI
+kUI
+kUI
+kUI
+kUI
+kUI
+kUI
+kUI
+kUI
+kUI
+kUI
 gfQ
 gfQ
 gfQ
@@ -76719,7 +76751,7 @@ bYN
 iuu
 tuj
 veV
-fBs
+kUI
 rwm
 rwm
 rwm
@@ -76729,7 +76761,7 @@ rwm
 rwm
 rwm
 rwm
-fBs
+kUI
 gfQ
 gfQ
 gfQ
@@ -76976,7 +77008,7 @@ sCZ
 hAR
 vZs
 vZs
-fBs
+kUI
 rwm
 rwm
 rwm
@@ -76986,7 +77018,7 @@ rwm
 rwm
 rwm
 rwm
-fBs
+kUI
 gfQ
 gfQ
 gfQ
@@ -77210,7 +77242,7 @@ fqf
 buI
 aSi
 hEB
-iuU
+exH
 smo
 mOJ
 mOJ
@@ -77233,7 +77265,7 @@ tuj
 iuu
 vZs
 hnF
-fBs
+kUI
 rwm
 rwm
 rwm
@@ -77243,7 +77275,7 @@ rwm
 rwm
 rwm
 rwm
-fBs
+kUI
 gfQ
 gfQ
 gfQ
@@ -77490,7 +77522,7 @@ qNv
 nnD
 jls
 vQC
-fBs
+kUI
 rwm
 rwm
 rwm
@@ -77500,7 +77532,7 @@ rwm
 rwm
 rwm
 rwm
-fBs
+kUI
 gfQ
 gfQ
 gfQ
@@ -77724,7 +77756,7 @@ cOR
 qks
 qCa
 rLe
-exH
+vmG
 aHm
 aHm
 lrT
@@ -77747,7 +77779,7 @@ fuI
 ids
 vZs
 qaL
-fBs
+kUI
 rwm
 rwm
 rwm
@@ -77757,7 +77789,7 @@ rwm
 rwm
 rwm
 rwm
-fBs
+kUI
 gfQ
 gfQ
 gfQ
@@ -78004,7 +78036,7 @@ vGt
 kyY
 vZs
 vZs
-fBs
+kUI
 rwm
 rwm
 rwm
@@ -78014,7 +78046,7 @@ rwm
 rwm
 rwm
 rwm
-fBs
+kUI
 gfQ
 gfQ
 gfQ
@@ -78261,7 +78293,7 @@ vGt
 xRS
 dVD
 nIf
-fBs
+kUI
 rwm
 rwm
 rwm
@@ -78271,7 +78303,7 @@ rwm
 rwm
 rwm
 rwm
-fBs
+kUI
 gfQ
 gfQ
 gfQ
@@ -78518,7 +78550,7 @@ oqU
 cKZ
 tuj
 vGt
-fBs
+kUI
 rwm
 rwm
 rwm
@@ -78528,7 +78560,7 @@ rwm
 rwm
 rwm
 rwm
-fBs
+kUI
 gfQ
 gfQ
 gfQ
@@ -78775,7 +78807,7 @@ xEU
 fkL
 vZs
 tvB
-fBs
+kUI
 rwm
 rwm
 rwm
@@ -78785,7 +78817,7 @@ rwm
 rwm
 rwm
 rwm
-fBs
+kUI
 gfQ
 gfQ
 gfQ
@@ -79032,7 +79064,7 @@ iTS
 ids
 aof
 vGt
-fBs
+kUI
 fBs
 fBs
 gKa
@@ -79042,7 +79074,7 @@ qfX
 qfX
 qfX
 qfX
-fBs
+kUI
 gfQ
 gfQ
 gfQ
@@ -79967,7 +79999,7 @@ tCm
 aid
 ygg
 akb
-akV
+ygg
 wYX
 nrY
 nrY
@@ -82119,7 +82151,7 @@ pty
 xcD
 dSQ
 qrr
-bHK
+orv
 inz
 cxf
 cxf
@@ -82367,7 +82399,7 @@ qde
 ulu
 ulu
 ulu
-gPP
+iJM
 gPP
 cLX
 ulu

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -163,6 +163,7 @@
 "abK" = (
 /obj/structure/chair,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "abL" = (
@@ -2859,6 +2860,7 @@
 /area/service/chapel/office)
 "aup" = (
 /obj/structure/chair/sofa/right,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "auq" = (
@@ -5697,6 +5699,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/plating,
 /area/engineering/main)
+"aTY" = (
+/obj/structure/chair/sofa{
+	name = "plush sofa"
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/service/bar)
 "aUa" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -6453,6 +6462,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aZk" = (
@@ -7037,6 +7047,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "bdR" = (
@@ -9036,6 +9047,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
+/obj/effect/landmark/start/xenobiologist,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "bHS" = (
@@ -10017,6 +10029,13 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"ckE" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/service/bar)
 "ckL" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10097,6 +10116,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cne" = (
@@ -10729,6 +10749,15 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"cLs" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "cLV" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
@@ -12402,6 +12431,11 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/science/lab)
+"dDt" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood/large,
+/area/service/library)
 "dDu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -13270,6 +13304,12 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"dXh" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "dXn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
@@ -13434,6 +13474,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
+/obj/effect/landmark/start/bridge_officer,
 /turf/open/floor/carpet/royalblue,
 /area/command/bridge)
 "ecm" = (
@@ -13672,6 +13713,7 @@
 	dir = 8
 	},
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
 "ekh" = (
@@ -14409,6 +14451,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "eFv" = (
@@ -15102,6 +15145,11 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psychology)
+"faD" = (
+/obj/structure/chair,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "fbm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -15985,6 +16033,7 @@
 "fuF" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
 /area/science/nanite)
 "fuI" = (
@@ -16445,6 +16494,7 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "fHM" = (
@@ -16519,10 +16569,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "fKe" = (
-/obj/effect/landmark/start/scientist,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/landmark/start/toxicologist,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "fKk" = (
@@ -19653,6 +19703,13 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/cargo/office)
+"hti" = (
+/obj/structure/chair/sofa/right{
+	name = "plush sofa"
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/service/bar)
 "htu" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -20324,6 +20381,13 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
+"hNp" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet/red,
+/area/service/chapel/main)
 "hND" = (
 /obj/structure/window{
 	dir = 1
@@ -20342,6 +20406,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/corporate_showroom)
+"hNU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/research)
 "hOO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -20766,6 +20837,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"ich" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet/red,
+/area/service/chapel/main)
 "idc" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/satellite)
@@ -20929,6 +21009,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/security/brig)
+"igV" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet/cyan,
+/area/hallway/primary/starboard)
 "ihf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/flip{
@@ -21023,6 +21110,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/xenobiologist,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "ilJ" = (
@@ -21247,6 +21335,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"irw" = (
+/obj/structure/chair,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "irD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21435,6 +21528,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "iwr" = (
@@ -21689,6 +21783,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"iHq" = (
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "iHs" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
@@ -22974,6 +23072,7 @@
 /obj/structure/chair/sofa/left{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "jtt" = (
@@ -23582,6 +23681,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "jJD" = (
@@ -24811,6 +24911,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "ktq" = (
@@ -25056,6 +25157,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/research)
 "kBm" = (
@@ -27519,8 +27621,8 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "lUg" = (
-/obj/effect/landmark/start/scientist,
 /obj/structure/cable,
+/obj/effect/landmark/start/toxicologist,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "lUD" = (
@@ -29249,6 +29351,7 @@
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "mPW" = (
@@ -32492,6 +32595,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "oAV" = (
@@ -32515,6 +32619,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /obj/machinery/duct,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "oBJ" = (
@@ -32911,6 +33016,17 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
+"oMN" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "oNa" = (
@@ -33816,6 +33932,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pmW" = (
+/obj/effect/landmark/start/botanist,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "pnb" = (
@@ -39311,6 +39428,7 @@
 "szl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/botanist,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "szK" = (
@@ -39430,6 +39548,7 @@
 /area/security/warden)
 "sCb" = (
 /obj/effect/turf_decal/stripes/corner,
+/obj/effect/landmark/start/toxicologist,
 /turf/open/floor/iron,
 /area/science/mixing)
 "sCk" = (
@@ -40962,6 +41081,7 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "tnP" = (
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/green,
 /area/service/library)
 "tnU" = (
@@ -41191,6 +41311,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "tsH" = (
@@ -42221,6 +42342,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"tSQ" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/hangover,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "tTs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/north,
@@ -42498,6 +42626,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/starboard)
 "ucZ" = (
@@ -43150,6 +43279,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
 "urs" = (
@@ -43587,6 +43717,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
+"uDt" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "uDw" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -45100,6 +45237,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "vrL" = (
@@ -45529,6 +45667,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
+"vyS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/scientist,
+/turf/open/floor/iron/white,
+/area/science/research)
 "vyY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -45566,6 +45713,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"vAb" = (
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "vAe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -46050,6 +46204,16 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"vLc" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "vLQ" = (
 /obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/plating,
@@ -46236,6 +46400,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -46244,6 +46409,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
+/obj/effect/landmark/start/bridge_officer,
 /turf/open/floor/carpet/royalblue,
 /area/command/bridge)
 "vRx" = (
@@ -47458,6 +47624,7 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "wBI" = (
+/obj/effect/landmark/start/toxicologist,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
 "wBR" = (
@@ -47706,6 +47873,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/start/toxicologist,
 /turf/open/floor/iron,
 /area/science/mixing)
 "wJB" = (
@@ -48288,6 +48456,7 @@
 /area/service/theater)
 "wWt" = (
 /obj/structure/chair/wood,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/service/bar)
 "wWv" = (
@@ -48670,6 +48839,13 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
+"xfp" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "xfF" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -50776,6 +50952,13 @@
 "ygB" = (
 /turf/closed/wall,
 /area/security/prison)
+"yhb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/xenobiologist,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "yhG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -73712,7 +73895,7 @@ uqd
 tIA
 mmn
 vJh
-pWJ
+faD
 evz
 smM
 xun
@@ -75512,7 +75695,7 @@ aei
 wXl
 ePD
 fTj
-uBm
+dDt
 hXq
 lPO
 uBm
@@ -75769,7 +75952,7 @@ rUC
 wXl
 ePQ
 aQv
-uBm
+dDt
 hXK
 iQW
 uBm
@@ -77041,9 +77224,9 @@ vUW
 vUW
 wKA
 nRK
-wKA
+ich
 nRK
-wKA
+ich
 nRK
 nRK
 eLv
@@ -77555,9 +77738,9 @@ vUW
 vUW
 cIR
 vUW
-ykS
+hNp
 vUW
-ykS
+hNp
 agP
 vUW
 hsp
@@ -81191,7 +81374,7 @@ dDF
 tBG
 tBG
 gzf
-lbL
+ckE
 vbG
 xMg
 xMg
@@ -81448,7 +81631,7 @@ aYL
 twI
 soY
 nCc
-lbL
+ckE
 xMg
 hKH
 xMg
@@ -82001,8 +82184,8 @@ kHG
 azc
 azc
 gmz
-gmz
-gmz
+uDt
+uDt
 gmz
 azc
 azc
@@ -82221,7 +82404,7 @@ kEX
 wjE
 pxG
 hOZ
-sbE
+hti
 pWr
 aRH
 sbE
@@ -82478,7 +82661,7 @@ gvi
 xMg
 ske
 xMg
-aRt
+aTY
 pWr
 xrp
 aRt
@@ -82771,7 +82954,7 @@ cxf
 dDQ
 fBp
 azc
-vKo
+xfp
 iwr
 vKo
 vKo
@@ -82966,8 +83149,8 @@ ybn
 eWe
 bkd
 gSZ
-ijE
-tpP
+dXh
+tSQ
 tpP
 ijE
 xvt
@@ -83799,7 +83982,7 @@ dpC
 azc
 vPZ
 tOi
-soK
+cLs
 oDP
 soK
 nau
@@ -84313,9 +84496,9 @@ cxf
 yaC
 fBp
 mTd
-gmz
-gmz
-gmz
+uDt
+uDt
+uDt
 gmz
 azc
 azc
@@ -84482,7 +84665,7 @@ iMO
 agj
 agj
 agj
-cXz
+vAb
 vrH
 cXz
 xNm
@@ -85086,13 +85269,13 @@ azc
 mTd
 vKo
 vKo
-vKo
+xfp
 vKo
 azc
 azc
 vHl
 suB
-lpI
+irw
 eko
 gfQ
 gfQ
@@ -87370,7 +87553,7 @@ fwo
 pnn
 qCa
 rLe
-uio
+oMN
 fdc
 etA
 ppj
@@ -87627,7 +87810,7 @@ lyG
 pnn
 rau
 rLe
-uio
+oMN
 uln
 nck
 nck
@@ -88656,7 +88839,7 @@ pnn
 vuR
 rLe
 gRN
-mph
+vLc
 eYG
 nOK
 prw
@@ -88913,7 +89096,7 @@ qol
 vIc
 rLe
 gRN
-mph
+vLc
 vpr
 lqk
 vwz
@@ -90191,7 +90374,7 @@ yeH
 jVW
 vvO
 lkE
-cbj
+igV
 ucK
 cbj
 eTf
@@ -90663,7 +90846,7 @@ aMz
 aMJ
 uJv
 bdP
-uJv
+iHq
 uJv
 uJv
 bAg
@@ -92729,7 +92912,7 @@ xAk
 xLw
 pjZ
 rpj
-oec
+aPm
 aPm
 cnA
 dao
@@ -92986,7 +93169,7 @@ xAk
 gFf
 pjZ
 pnB
-oec
+aPm
 aPm
 oec
 kpE
@@ -93765,7 +93948,7 @@ jyy
 ezk
 wRL
 oeI
-nIB
+vyS
 oeI
 oeI
 oeI
@@ -94533,7 +94716,7 @@ rME
 hoB
 qeW
 jAG
-kyH
+hNU
 vEU
 qss
 nQm
@@ -96617,7 +96800,7 @@ cKi
 hou
 mqn
 cQR
-wjQ
+yhb
 jsA
 lwL
 hsb

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -14872,7 +14872,9 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "eRN" = (
-/obj/structure/transit_tube/station/dispenser/reverse/flipped,
+/obj/structure/transit_tube/station/dispenser{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
 "eSn" = (
@@ -32270,6 +32272,7 @@
 	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
 "ooZ" = (

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -660,6 +660,7 @@
 	},
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "aem" = (
@@ -1933,6 +1934,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "anh" = (
@@ -1962,6 +1964,7 @@
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "anu" = (
@@ -2068,6 +2071,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "aoa" = (
@@ -2078,6 +2082,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "aob" = (
@@ -2087,6 +2092,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "aoc" = (
@@ -3022,6 +3028,7 @@
 /obj/item/food/grown/harebell,
 /obj/item/food/grown/harebell,
 /obj/item/food/grown/harebell,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "awc" = (
@@ -3109,6 +3116,7 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/machinery/light,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "awM" = (
@@ -3633,6 +3641,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aBn" = (
@@ -4301,6 +4310,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
+"aIV" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/science/mixing)
 "aJa" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/glass,
@@ -4352,6 +4367,7 @@
 /area/security/brig)
 "aJt" = (
 /obj/structure/reagent_dispensers/cooking_oil,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "aJy" = (
@@ -4674,6 +4690,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aMX" = (
@@ -5063,6 +5080,7 @@
 	pixel_y = 15
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/white,
 /area/science/research)
 "aPU" = (
@@ -5520,6 +5538,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "aTn" = (
@@ -6659,6 +6678,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "bbc" = (
@@ -7984,6 +8004,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "bkA" = (
@@ -8295,6 +8316,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"bqE" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/carpet/black,
+/area/security/prison)
 "bqS" = (
 /obj/machinery/button/door{
 	id = "xenobio8";
@@ -8320,6 +8345,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "bqZ" = (
@@ -9228,6 +9254,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/range)
+"bQI" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "bRe" = (
 /obj/machinery/camera{
 	c_tag = "Permabrig Library";
@@ -9235,6 +9268,7 @@
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/security/prison)
 "bRx" = (
@@ -9288,6 +9322,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/status_display/evac/directional/south,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bSQ" = (
@@ -9738,6 +9773,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "cff" = (
@@ -9927,6 +9963,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/bridge)
 "cjL" = (
@@ -10193,6 +10230,14 @@
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"cvB" = (
+/obj/machinery/conveyor{
+	id = "cargodelivery2";
+	name = "Cargo Belt"
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/cargo/storage)
 "cvJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10283,6 +10328,7 @@
 	name = "Captain's Quarters";
 	req_access_txt = "20"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "cyi" = (
@@ -10426,6 +10472,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"cCg" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "cCs" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -11011,6 +11067,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "cXp" = (
@@ -11059,6 +11116,13 @@
 /obj/item/phone,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"cZt" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/command/bridge)
 "cZH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
@@ -11426,6 +11490,7 @@
 	dir = 8;
 	pixel_x = 11
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "djA" = (
@@ -11467,6 +11532,7 @@
 /area/command/bridge)
 "dkR" = (
 /obj/machinery/light/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "dld" = (
@@ -11854,6 +11920,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/bridge)
 "dvV" = (
@@ -11910,6 +11977,11 @@
 /obj/structure/chair/stool,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
+"dwF" = (
+/obj/machinery/light,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "dwP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12481,6 +12553,11 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"dJd" = (
+/obj/machinery/light,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/command/bridge)
 "dJf" = (
 /turf/closed/wall/r_wall,
 /area/science/nanite)
@@ -13699,6 +13776,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "err" = (
@@ -14477,6 +14555,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"eNd" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "eNh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -15511,6 +15593,7 @@
 "fng" = (
 /obj/structure/chair/sofa/right,
 /obj/machinery/status_display/evac/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
 "fnr" = (
@@ -16077,6 +16160,7 @@
 	dir = 1
 	},
 /obj/item/gun/energy/e_gun/mini,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "fBW" = (
@@ -16590,6 +16674,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "fVr" = (
@@ -17433,6 +17518,7 @@
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "gtr" = (
@@ -18132,6 +18218,12 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"gNZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/security/prison)
 "gOk" = (
 /obj/machinery/light{
 	dir = 4
@@ -18556,6 +18648,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "gZr" = (
@@ -19244,6 +19337,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/cargo_technician,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/cargo/office)
 "htu" = (
@@ -19725,6 +19819,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
+"hHW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/tcommsat/computer)
 "hIq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19746,6 +19845,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "hJi" = (
 /obj/machinery/light/directional/east,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "hJH" = (
@@ -20046,6 +20146,10 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"hTK" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/security/prison)
 "hUo" = (
 /obj/machinery/light_switch{
 	pixel_x = 22;
@@ -20067,6 +20171,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/freezer,
 /area/commons/cryopods)
 "hUH" = (
@@ -20587,6 +20692,7 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/pipe_dispenser,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "imH" = (
@@ -20644,6 +20750,10 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
+"inN" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/engineering/transit_tube)
 "inV" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow{
@@ -21367,6 +21477,7 @@
 	dir = 4
 	},
 /obj/structure/cable/layer1,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/computer)
 "iLT" = (
@@ -21558,6 +21669,7 @@
 "iRr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "iRR" = (
@@ -22158,6 +22270,7 @@
 /area/medical/break_room)
 "jjd" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/cargo/office)
 "jje" = (
@@ -22172,6 +22285,7 @@
 /area/command/bridge)
 "jjq" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "jjA" = (
@@ -24537,6 +24651,7 @@
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_y = -32
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "kCc" = (
@@ -24681,6 +24796,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "kGh" = (
@@ -24712,6 +24828,7 @@
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "kGs" = (
@@ -25255,6 +25372,7 @@
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "kVM" = (
@@ -25529,6 +25647,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/bridge)
 "lgw" = (
@@ -25572,6 +25691,7 @@
 /obj/machinery/light/small,
 /obj/structure/closet/crate,
 /obj/machinery/newscaster/directional/south,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "lie" = (
@@ -25617,6 +25737,17 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
+"ljl" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/command/bridge)
 "ljx" = (
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 1;
@@ -25941,6 +26072,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "lqY" = (
@@ -26705,6 +26837,7 @@
 /obj/item/hfr_box/corner,
 /obj/item/hfr_box/corner,
 /obj/item/hfr_box/corner,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "lPk" = (
@@ -26807,6 +26940,7 @@
 	c_tag = "Mining Dock East";
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "lRA" = (
@@ -26942,6 +27076,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"lWe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit/departure_lounge)
 "lWs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27003,6 +27145,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lXg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "lXm" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Telecomms and AI";
@@ -28427,6 +28576,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "mLq" = (
@@ -28633,6 +28783,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/color_adapter,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "mRJ" = (
@@ -28642,6 +28793,7 @@
 /area/security/prison)
 "mRS" = (
 /obj/structure/tank_dispenser/oxygen,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "mSU" = (
@@ -30082,6 +30234,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/science/research)
 "nGv" = (
@@ -30187,6 +30340,10 @@
 /obj/machinery/plate_press,
 /turf/open/floor/plating,
 /area/security/prison/safe)
+"nJJ" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "nJO" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30444,6 +30601,13 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"nSG" = (
+/obj/structure/cable/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/showroomfloor,
+/area/tcommsat/computer)
 "nTe" = (
 /obj/effect/turf_decal,
 /obj/machinery/airalarm{
@@ -30567,6 +30731,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/server)
+"nWa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/command/bridge)
 "nWg" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30639,6 +30810,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/bridge)
 "nXD" = (
@@ -30717,6 +30889,10 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/iron,
 /area/engineering/main)
+"nYN" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "nYX" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 4;
@@ -31300,6 +31476,7 @@
 "oqd" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/item/gun/energy/e_gun/mini,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "oql" = (
@@ -31330,6 +31507,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/security/prison)
 "oqU" = (
@@ -31445,6 +31623,10 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"ouN" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/security/prison)
 "ovm" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -31873,6 +32055,7 @@
 	machinedir = 8;
 	pixel_x = 32
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "oGy" = (
@@ -33192,6 +33375,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "puG" = (
@@ -34200,6 +34384,7 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "qcr" = (
@@ -34350,6 +34535,7 @@
 /area/security/range)
 "qgk" = (
 /obj/machinery/light/small,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/science/server)
 "qgB" = (
@@ -34443,6 +34629,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "qiF" = (
@@ -34699,6 +34886,7 @@
 /obj/machinery/doppler_array/research/science{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "qqh" = (
@@ -35235,6 +35423,7 @@
 /obj/item/cartridge/quartermaster,
 /obj/item/cartridge/quartermaster,
 /obj/item/cartridge/quartermaster,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "qIB" = (
@@ -35631,6 +35820,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "qXs" = (
@@ -35989,6 +36179,7 @@
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/corporate_showroom)
 "rgq" = (
@@ -36240,6 +36431,7 @@
 	c_tag = "Chapel Office";
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "rnY" = (
@@ -36406,6 +36598,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "rsu" = (
@@ -36435,6 +36628,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "rtd" = (
@@ -36455,6 +36649,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"rtF" = (
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "rtK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -36525,6 +36723,7 @@
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "rwr" = (
@@ -37650,6 +37849,8 @@
 "sfI" = (
 /obj/machinery/rnd/production/techfab/department/security,
 /obj/effect/turf_decal/stripes/box,
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "sgp" = (
@@ -37834,6 +38035,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/bridge)
 "slU" = (
@@ -38279,6 +38481,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "syF" = (
@@ -39696,6 +39899,7 @@
 	req_access_txt = "19"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/bridge)
 "tjH" = (
@@ -41480,6 +41684,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/corporate_showroom)
 "ufi" = (
@@ -42665,6 +42870,19 @@
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
+"uKu" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "uKT" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
@@ -42953,6 +43171,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"uSf" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/command/bridge)
 "uSk" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/tile/green{
@@ -43337,6 +43560,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "vbG" = (
@@ -43817,6 +44041,7 @@
 	dir = 1;
 	network = list("minisat")
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "vqK" = (
@@ -44075,6 +44300,12 @@
 	dir = 1
 	},
 /area/maintenance/disposal)
+"vvi" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/secure_closet/security/sec,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "vvx" = (
 /obj/machinery/light{
 	dir = 1
@@ -44365,6 +44596,12 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"vBh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "vBA" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -46506,6 +46743,7 @@
 	name = "Ian's Quarters";
 	req_access_txt = "57"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
 "wLQ" = (
@@ -46707,6 +46945,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/command/bridge)
 "wQP" = (
@@ -47282,6 +47521,7 @@
 	c_tag = "Bridge Hallway East";
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/command/bridge)
 "xee" = (
@@ -47428,6 +47668,7 @@
 	name = "HoP Queue Shutters"
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "xjx" = (
@@ -47508,6 +47749,7 @@
 /area/maintenance/port/aft)
 "xlm" = (
 /obj/structure/closet/wardrobe,
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "xlt" = (
@@ -47657,6 +47899,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "xqi" = (
@@ -47776,6 +48019,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
+"xsh" = (
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "xsj" = (
@@ -48428,6 +48675,7 @@
 "xGC" = (
 /obj/structure/closet/secure_closet/cytology,
 /obj/item/circuitboard/machine/gibber,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "xGD" = (
@@ -48704,6 +48952,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"xRA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/toxins,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/science/storage)
 "xRI" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -49283,6 +49538,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/security/prison)
 "yfs" = (
@@ -49378,6 +49634,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "yiA" = (
@@ -49537,6 +49794,12 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"ylt" = (
+/obj/machinery/nanite_program_hub,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "ylK" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -62219,7 +62482,7 @@ gfQ
 fsz
 gfQ
 yin
-qzX
+bqE
 qzX
 ahk
 qzX
@@ -62232,7 +62495,7 @@ amz
 iDu
 ygB
 jev
-xlD
+hTK
 ygB
 nJA
 jMR
@@ -64553,7 +64816,7 @@ dxP
 yin
 sJJ
 fVD
-wDc
+rtF
 cdG
 nqF
 oWZ
@@ -65311,7 +65574,7 @@ ygB
 ygB
 jbw
 jbw
-jbw
+gNZ
 amL
 jbw
 adY
@@ -65575,7 +65838,7 @@ xlD
 cJQ
 xlD
 jbw
-xlD
+hTK
 yin
 yin
 yin
@@ -66610,7 +66873,7 @@ ldL
 xlD
 lNw
 wZE
-xlD
+ouN
 hPS
 xlD
 aCA
@@ -67740,7 +68003,7 @@ toN
 xzY
 xzY
 xzY
-rCg
+dwF
 bnA
 bnA
 gfQ
@@ -67923,7 +68186,7 @@ nuO
 eLX
 nuO
 oJl
-nuO
+xsh
 wlQ
 xke
 xke
@@ -68165,9 +68428,9 @@ rhI
 gyC
 aXs
 tia
-tia
+vvi
 sfI
-tia
+vvi
 dWa
 bcN
 tRl
@@ -68423,7 +68686,7 @@ rhI
 rhI
 rhI
 rhI
-rhI
+xIr
 rhI
 rhI
 bhG
@@ -68675,7 +68938,7 @@ veT
 gny
 azA
 cXp
-bfv
+dii
 bfv
 bfv
 bfv
@@ -75159,7 +75422,7 @@ vZs
 tuj
 vQC
 vZs
-gpP
+cvB
 gpP
 gpP
 csh
@@ -80323,7 +80586,7 @@ wSA
 qsm
 ito
 tLj
-ito
+lXg
 nuD
 sRr
 jBo
@@ -84412,7 +84675,7 @@ tjx
 buL
 jje
 buL
-inj
+ljl
 wZK
 cND
 cND
@@ -84437,7 +84700,7 @@ yam
 vmQ
 vmQ
 cxf
-wIe
+lWe
 wIe
 lUD
 vlD
@@ -84593,7 +84856,7 @@ gfQ
 wYX
 aju
 ygg
-ygg
+eNd
 uwV
 gfQ
 gfQ
@@ -84921,7 +85184,7 @@ pnn
 jJn
 rJK
 uio
-tmT
+bQI
 yal
 yal
 yal
@@ -85930,7 +86193,7 @@ vYs
 xqj
 bYn
 ygp
-jIV
+vBh
 mjV
 fCn
 shF
@@ -86473,8 +86736,8 @@ tTH
 tTH
 tTH
 tTH
-cND
-qAe
+wZK
+nWa
 slM
 tJB
 ldl
@@ -86989,7 +87252,7 @@ prw
 ohS
 cND
 qAe
-lkI
+dJd
 tJB
 uVl
 vhk
@@ -87768,7 +88031,7 @@ qCG
 cND
 qCG
 qCG
-qCG
+cZt
 hQU
 orD
 vmQ
@@ -88230,7 +88493,7 @@ loU
 jlf
 kor
 fnK
-evf
+nYN
 awt
 nyO
 nyO
@@ -88521,7 +88784,7 @@ hGZ
 iAp
 rst
 tjx
-buL
+uSf
 lMX
 buL
 inj
@@ -89313,7 +89576,7 @@ gAL
 qAC
 pOS
 orD
-pHi
+inN
 rei
 ooP
 bHB
@@ -89502,7 +89765,7 @@ aZZ
 jtc
 sLV
 vzM
-uJv
+nJJ
 bdj
 uWM
 dCM
@@ -90035,7 +90298,7 @@ uWM
 tin
 tin
 rWW
-tin
+cCg
 tin
 dfT
 dfT
@@ -90060,7 +90323,7 @@ xuR
 iTt
 rGu
 laE
-tkA
+uKu
 tkA
 ksb
 vAz
@@ -93876,7 +94139,7 @@ xII
 fBE
 dJf
 qmS
-rMn
+ylt
 anN
 anO
 anP
@@ -94711,7 +94974,7 @@ xBZ
 xBZ
 xBZ
 xBZ
-hLU
+nSG
 xBZ
 xBZ
 xBZ
@@ -94924,7 +95187,7 @@ vuN
 wsM
 xAc
 iAb
-fiW
+xRA
 skp
 fWk
 mgE
@@ -94965,7 +95228,7 @@ fsz
 gfQ
 xBZ
 xBZ
-jMZ
+hHW
 hTx
 thn
 hLU
@@ -98265,7 +98528,7 @@ vnF
 vBA
 xEN
 pyP
-kPq
+aIV
 kPq
 kPq
 wKH

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -573,7 +573,7 @@
 /obj/item/kitchen/spoon/plastic,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "adY" = (
 /obj/machinery/camera{
 	c_tag = "Permabrig - Cellblock B - Aft";
@@ -690,7 +690,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "aeJ" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -708,7 +708,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "aeM" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -897,18 +897,18 @@
 "aga" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/carpet/black,
-/area/security/prison)
+/area/security/prison/workout)
 "agc" = (
 /obj/structure/chair,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "agd" = (
 /obj/structure/window{
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "agf" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow{
@@ -932,7 +932,7 @@
 "agk" = (
 /obj/structure/closet/secure_closet/freezer/meat/open,
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "agn" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -956,8 +956,9 @@
 "ags" = (
 /obj/structure/table,
 /obj/item/kitchen/fork/plastic,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "agt" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation B";
@@ -987,7 +988,7 @@
 	pixel_y = 5
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "agA" = (
 /obj/structure/table,
 /obj/item/radio/intercom{
@@ -1011,7 +1012,7 @@
 "agN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "agP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/red,
@@ -1026,7 +1027,7 @@
 "agS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/grimy,
-/area/security/prison)
+/area/security/prison/rec)
 "agU" = (
 /obj/machinery/shower{
 	dir = 1
@@ -1039,11 +1040,11 @@
 "agZ" = (
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/grimy,
-/area/security/prison)
+/area/security/prison/rec)
 "ahe" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/carpet/black,
-/area/security/prison)
+/area/security/prison/workout)
 "ahf" = (
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
@@ -1058,7 +1059,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/grimy,
-/area/security/prison)
+/area/security/prison/workout)
 "ahs" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/machinery/camera{
@@ -1068,7 +1069,7 @@
 	network = list("ss13","prison")
 	},
 /turf/open/floor/carpet/black,
-/area/security/prison)
+/area/security/prison/workout)
 "ahv" = (
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/holopad,
@@ -1077,13 +1078,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "ahz" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "ahC" = (
 /obj/machinery/door/window/westleft{
 	name = "Kitchen"
@@ -1091,7 +1092,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "ahD" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -1101,7 +1102,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "ahL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -1122,7 +1123,7 @@
 "ahR" = (
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "ahS" = (
 /turf/closed/wall,
 /area/science/nanite)
@@ -1138,7 +1139,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "aid" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -1166,11 +1167,11 @@
 /obj/structure/easel,
 /obj/item/canvas/twentythree_twentythree,
 /turf/open/floor/iron/grimy,
-/area/security/prison)
+/area/security/prison/rec)
 "aix" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
-/area/security/prison)
+/area/security/prison/rec)
 "aiA" = (
 /obj/structure/chair/sofa/corner{
 	dir = 8;
@@ -1208,12 +1209,13 @@
 /area/hallway/primary/aft)
 "aiU" = (
 /obj/machinery/griddle,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "aiZ" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/iron/grimy,
-/area/security/prison)
+/area/security/prison/rec)
 "aja" = (
 /obj/machinery/light{
 	dir = 8
@@ -1222,12 +1224,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "aje" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "ajg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -1236,11 +1238,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "ajp" = (
 /obj/structure/bookcase,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "ajt" = (
 /obj/machinery/light{
 	dir = 4
@@ -1250,7 +1252,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "aju" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/white/side{
@@ -1262,13 +1264,14 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
-/area/security/prison)
+/area/security/prison/rec)
 "ajA" = (
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
-/area/security/prison)
+/area/security/prison/workout)
 "ajB" = (
 /obj/structure/chair{
 	dir = 1
@@ -1279,15 +1282,17 @@
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "ajE" = (
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "ajO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -1420,14 +1425,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "akR" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Recreation"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "akX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1514,7 +1519,7 @@
 	},
 /obj/structure/table,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "alD" = (
 /obj/machinery/camera{
 	c_tag = "Permabrig - Cellblock B - Fore";
@@ -1587,7 +1592,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "alR" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
@@ -1595,8 +1600,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "amd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/closed/wall,
@@ -1625,28 +1631,27 @@
 "amj" = (
 /obj/structure/table,
 /obj/item/camera,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "amk" = (
 /obj/structure/table,
 /obj/item/paper_bin/bundlenatural,
 /obj/item/pen,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "amm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "amn" = (
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "amo" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -1734,17 +1739,17 @@
 "amz" = (
 /obj/structure/flora/grass/green,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "amA" = (
 /obj/structure/flora/grass/jungle,
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "amC" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "amH" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -1839,6 +1844,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera{
+	c_tag = "Arrivals Hallway - Starboard Checkpoint Hall";
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "anc" = (
@@ -1858,15 +1867,16 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "anh" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/item/kitchen/knife/plastic,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "ank" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/structure/cable,
@@ -1888,8 +1898,10 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "anu" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
@@ -1911,8 +1923,9 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "anG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Maintenance";
@@ -1958,28 +1971,28 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "anU" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/poppy,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "anV" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/tea,
 /obj/machinery/camera{
-	c_tag = "Permabrig Garden";
+	c_tag = "Permabrig - Garden";
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "anX" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/watermelon,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "anY" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
@@ -2041,7 +2054,7 @@
 "aow" = (
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "aoE" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -2065,7 +2078,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "aoP" = (
 /obj/structure/window{
 	dir = 4
@@ -2128,7 +2141,7 @@
 "apc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "apm" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
@@ -2180,7 +2193,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "apC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2210,7 +2223,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "apR" = (
 /obj/machinery/light{
 	dir = 8
@@ -2223,14 +2236,14 @@
 	pixel_x = -12
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "apU" = (
 /obj/effect/landmark/start/prisoner,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "aqg" = (
 /obj/structure/chair{
 	dir = 4
@@ -2293,7 +2306,7 @@
 	pixel_x = 2
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "arq" = (
 /obj/machinery/door/airlock/security{
 	name = "Perma Brig"
@@ -2506,7 +2519,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "asJ" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Firing Range";
@@ -2517,7 +2530,7 @@
 /area/security/office)
 "asK" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Recreation Wing";
+	c_tag = "Permabrig - Recreation Wing Hall";
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -2550,7 +2563,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "asU" = (
 /obj/machinery/camera{
 	c_tag = "Fore Port Solar Control";
@@ -3236,9 +3249,6 @@
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
 /area/engineering/main)
-"aye" = (
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "aym" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -3320,7 +3330,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/visit)
 "ayK" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/light/small{
@@ -4466,8 +4476,11 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/machinery/power/apc{
+	name = "Atmospherics Control Center APC";
+	pixel_y = -24
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/upper)
 "aLc" = (
@@ -4689,6 +4702,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aNo" = (
@@ -6688,7 +6702,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/prison/visit)
 "bbR" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
@@ -7938,6 +7952,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bkU" = (
@@ -8007,7 +8022,7 @@
 /area/security/office)
 "blo" = (
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "blp" = (
 /obj/machinery/telecomms/server/presets/command,
 /obj/effect/turf_decal/tile/blue,
@@ -8221,7 +8236,7 @@
 "bqE" = (
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/carpet/black,
-/area/security/prison)
+/area/security/prison/workout)
 "bqS" = (
 /obj/machinery/button/door{
 	id = "xenobio8";
@@ -8248,6 +8263,13 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Warden";
+	departmentType = 5;
+	name = "Warden's RC";
+	pixel_x = 32
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "bqZ" = (
@@ -8507,7 +8529,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "bux" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -9155,7 +9177,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "bRx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -9703,6 +9725,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "cgq" = (
@@ -9812,6 +9835,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
+"ciL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/science/lab)
 "ciT" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -10290,6 +10319,7 @@
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cAP" = (
@@ -10447,6 +10477,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/camera{
+	c_tag = "Engineering - Airlock";
+	dir = 4;
+	network = list("ss13","engine")
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "cHo" = (
@@ -10460,15 +10495,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "cHu" = (
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/structure/table,
 /obj/machinery/cell_charger{
 	pixel_y = 2
 	},
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
@@ -10615,6 +10648,9 @@
 "cOy" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard)
+"cOF" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/rec)
 "cOP" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/junglebush/b,
@@ -10766,6 +10802,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
+"cRO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "cSc" = (
 /obj/machinery/telecomms/server/presets/medical,
 /obj/effect/turf_decal/tile/blue,
@@ -11114,7 +11154,7 @@
 /obj/machinery/processor,
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "dcy" = (
 /obj/machinery/light{
 	dir = 1
@@ -11356,7 +11396,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "djA" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
@@ -12133,6 +12173,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"dCP" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/landmark/start/prisoner,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/grimy,
+/area/security/prison/safe)
 "dCS" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -12262,7 +12309,10 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/prison/visit)
+"dEO" = (
+/turf/open/floor/iron/grimy,
+/area/security/prison/rec)
 "dEU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue,
@@ -12306,9 +12356,6 @@
 /area/science/lab)
 "dFV" = (
 /obj/structure/closet/crate/bin,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
@@ -12657,6 +12704,9 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"dNM" = (
+/turf/open/floor/plating,
+/area/security/prison/work)
 "dNR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12718,7 +12768,7 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "dPc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -12918,7 +12968,7 @@
 "dUI" = (
 /obj/structure/chair/stool,
 /turf/open/floor/iron/grimy,
-/area/security/prison)
+/area/security/prison/rec)
 "dUW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -13206,6 +13256,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"ecW" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/command/bridge)
 "edi" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
@@ -13238,8 +13292,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eeo" = (
@@ -13787,7 +13841,7 @@
 "euO" = (
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "evf" = (
 /turf/open/floor/iron/white,
 /area/medical/cryo)
@@ -13843,12 +13897,18 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "exn" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"exq" = (
+/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "exu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -14138,6 +14198,9 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
+"eFv" = (
+/turf/closed/wall,
+/area/security/prison/mess)
 "eGz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14160,7 +14223,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/prison/visit)
 "eId" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14431,7 +14494,7 @@
 /area/maintenance/starboard/fore)
 "ePA" = (
 /obj/machinery/camera{
-	c_tag = "Courtroom Stand";
+	c_tag = "Courtroom Stands";
 	dir = 8;
 	network = list("ss13","prison")
 	},
@@ -14687,6 +14750,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/command/bridge)
 "eWx" = (
@@ -14826,6 +14890,7 @@
 /obj/item/folder/yellow,
 /obj/item/stamp/qm,
 /obj/machinery/requests_console{
+	announcementConsole = 1;
 	department = "Quartermaster's Desk";
 	departmentType = 2;
 	name = "Quartermaster RC";
@@ -14933,7 +14998,7 @@
 "fdq" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/iron/grimy,
-/area/security/prison)
+/area/security/prison/rec)
 "fdw" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -16354,6 +16419,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"fPq" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/grimy,
+/area/security/prison/safe)
 "fPw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16404,7 +16479,7 @@
 "fQN" = (
 /obj/machinery/shower,
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "fRi" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister,
@@ -16510,6 +16585,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/engineering/main)
+"fTM" = (
+/obj/structure/cable,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/lab)
 "fUf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -16862,6 +16944,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "gbO" = (
@@ -17022,8 +17105,8 @@
 /turf/open/floor/grass,
 /area/cargo/qm)
 "ggn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ggF" = (
@@ -17034,12 +17117,9 @@
 "ghC" = (
 /obj/structure/table,
 /obj/item/kitchen/spoon/plastic,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "ghD" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -17116,6 +17196,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "gjL" = (
@@ -17141,6 +17222,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"glm" = (
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/security/prison)
 "glU" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
@@ -17156,6 +17241,9 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"gmq" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/work)
 "gmx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/plating{
@@ -17249,6 +17337,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"goy" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/security/prison/shower)
 "goG" = (
 /obj/machinery/button/door{
 	id = "rnd";
@@ -17442,6 +17534,9 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"gtW" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/mess)
 "guc" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Core";
@@ -17504,7 +17599,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "gvd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -17820,6 +17915,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"gDm" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "gDq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -17885,6 +17988,13 @@
 /obj/machinery/bounty_board/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
+"gFY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison/garden)
 "gFZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -17995,6 +18105,7 @@
 /area/science/storage)
 "gJK" = (
 /obj/machinery/suit_storage_unit/ce,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "gKa" = (
@@ -18628,7 +18739,7 @@
 /area/ai_monitored/turret_protected/ai)
 "hbq" = (
 /obj/machinery/camera{
-	c_tag = "MiniSat- Exterior - Fore Port";
+	c_tag = "MiniSat - Exterior - Fore Port";
 	dir = 9;
 	network = list("minisat")
 	},
@@ -18690,6 +18801,9 @@
 	},
 /turf/open/floor/iron,
 /area/security/execution/transfer)
+"hea" = (
+/turf/closed/wall,
+/area/security/prison/rec)
 "hee" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -18771,6 +18885,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
+"hga" = (
+/obj/structure/table,
+/obj/item/kitchen/fork/plastic,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "hgr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18996,7 +19115,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/prison/visit)
 "hmk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -19008,7 +19127,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "hmI" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -20449,6 +20568,10 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
+"ifz" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "ifE" = (
 /obj/effect/landmark/start/quartermaster,
 /turf/open/floor/iron,
@@ -21116,7 +21239,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/prison/visit)
 "iBp" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -21176,7 +21299,7 @@
 /obj/item/seeds/onion,
 /obj/machinery/light,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "iDE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -21338,6 +21461,9 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron,
 /area/command/bridge)
+"iKG" = (
+/turf/open/floor/iron/dark,
+/area/security/prison/visit)
 "iKS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -21398,6 +21524,13 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/security/brig)
+"iMO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "iMP" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -21464,7 +21597,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "iOj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -22161,7 +22294,7 @@
 	pixel_x = 30
 	},
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/prison/visit)
 "jig" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -22455,6 +22588,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"jsL" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron/dark,
+/area/science/robotics/lab)
 "jsM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22546,6 +22683,7 @@
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "jur" = (
@@ -22658,8 +22796,10 @@
 /area/engineering/atmos)
 "jxE" = (
 /obj/item/bikehorn/rubberducky,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "jym" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -22728,6 +22868,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/white,
 /area/science/research)
 "jzs" = (
@@ -22813,7 +22954,6 @@
 /obj/machinery/computer/security/telescreen/ce{
 	pixel_y = 28
 	},
-/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "jAT" = (
@@ -22909,6 +23049,9 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/medical/virology)
+"jCO" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/garden)
 "jDr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -23187,16 +23330,14 @@
 /area/solars/starboard/aft)
 "jMO" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jMR" = (
-/obj/structure/closet/crate,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/obj/item/stack/license_plates/empty/fifty,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/machinery/plate_press,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "jMZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
@@ -24021,7 +24162,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/prison/visit)
 "kmG" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -24039,6 +24180,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
+"knl" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/grimy,
+/area/security/prison/safe)
 "knw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/machinery/firealarm/directional/south,
@@ -24168,8 +24317,9 @@
 /obj/item/plant_analyzer,
 /obj/item/plant_analyzer,
 /obj/item/reagent_containers/glass/bucket,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "krK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -24308,6 +24458,18 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"kuP" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig - Exterior - Workshop";
+	dir = 9;
+	name = "Perma Camera";
+	network = list("ss13","prison")
+	},
+/turf/open/space/basic,
+/area/space)
+"kuZ" = (
+/turf/open/floor/iron,
+/area/security/prison/rec)
 "kvd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -24426,6 +24588,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/white,
 /area/science/research)
 "kxZ" = (
@@ -24543,8 +24706,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "kCc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -24618,7 +24782,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/prison/visit)
 "kEo" = (
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 8
@@ -25028,7 +25192,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/carpet/black,
-/area/security/prison)
+/area/security/prison/workout)
 "kMr" = (
 /obj/structure/window{
 	dir = 1
@@ -25295,6 +25459,13 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
+"kVZ" = (
+/obj/machinery/camera{
+	c_tag = "Arrivals Hallway - Port Checkpoint Hall";
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "kWh" = (
 /obj/machinery/light{
 	dir = 8
@@ -25320,6 +25491,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
+"kXw" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "kXR" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/iron/freezer,
@@ -25822,7 +25999,7 @@
 	},
 /obj/machinery/door/window/southleft,
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/prison/visit)
 "lmy" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay";
@@ -25865,7 +26042,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "lnY" = (
 /obj/structure/cable,
 /obj/machinery/requests_console{
@@ -26325,7 +26502,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "lCc" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -26498,6 +26675,9 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"lIR" = (
+/turf/open/floor/iron,
+/area/security/prison/garden)
 "lJm" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
@@ -26571,7 +26751,7 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/prison/visit)
 "lLh" = (
 /obj/machinery/light{
 	dir = 8
@@ -26974,8 +27154,12 @@
 /area/security/brig)
 "lVC" = (
 /obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/security/prison/safe)
+/area/security/prison/work)
 "lVG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -27083,6 +27267,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
+"lXF" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/garden)
 "lYe" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -27299,6 +27487,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
+"meJ" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "meM" = (
 /obj/structure/chair{
 	dir = 8
@@ -27758,7 +27950,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "mor" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28188,6 +28380,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/engineering/main)
+"mCD" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/shower)
 "mCN" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -28673,7 +28868,7 @@
 	},
 /obj/machinery/door/window/southright,
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/prison/visit)
 "mRi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -28708,7 +28903,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "mRS" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/machinery/firealarm/directional/east,
@@ -28717,7 +28912,7 @@
 "mSU" = (
 /obj/structure/sign/poster/official/obey,
 /turf/closed/wall,
-/area/security/prison)
+/area/security/prison/garden)
 "mSY" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
@@ -28803,6 +28998,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"mTD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/rec)
 "mTW" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/delivery,
@@ -29186,7 +29386,7 @@
 /obj/item/seeds/sunflower,
 /obj/machinery/light,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "neC" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/cmo)
@@ -29547,7 +29747,7 @@
 /obj/structure/chair,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "nqc" = (
 /obj/structure/table,
 /obj/item/disk/tech_disk{
@@ -29846,7 +30046,7 @@
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "nyS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nyU" = (
@@ -29950,7 +30150,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/prison/visit)
 "nCc" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30169,6 +30369,9 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/plating,
 /area/security/execution/education)
+"nGZ" = (
+/turf/closed/wall,
+/area/security/prison/workout)
 "nHc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30214,6 +30417,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/transit_tube)
+"nIr" = (
+/obj/item/bikehorn/rubberducky,
+/turf/open/floor/iron/freezer,
+/area/security/prison/shower)
 "nIx" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -30247,8 +30454,10 @@
 /area/engineering/atmos)
 "nJA" = (
 /obj/machinery/plate_press,
-/turf/open/floor/plating,
-/area/security/prison/safe)
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/security/prison/work)
 "nJJ" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30265,7 +30474,7 @@
 /area/commons/vacant_room/office)
 "nJW" = (
 /obj/machinery/camera{
-	c_tag = "Permabrig Laundry";
+	c_tag = "Permabrig - Laundry";
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
@@ -30277,7 +30486,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/black,
-/area/security/prison)
+/area/security/prison/workout)
 "nKt" = (
 /obj/structure/filingcabinet,
 /obj/structure/disposalpipe/segment{
@@ -30520,6 +30729,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Telecommunications";
+	req_access_txt = "61"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "nTe" = (
@@ -30637,6 +30850,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/science/server)
 "nVB" = (
@@ -30862,7 +31076,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "obW" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -31779,6 +31993,14 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
+"oAN" = (
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/iron/textured,
+/area/security/prison/work)
 "oAU" = (
 /obj/structure/chair{
 	dir = 1
@@ -32049,7 +32271,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/prison/visit)
 "oHS" = (
 /obj/structure/chair,
 /turf/open/floor/iron,
@@ -32215,6 +32437,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"oNV" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable,
+/turf/open/floor/carpet/black,
+/area/security/prison/workout)
 "oNX" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/bookmanagement,
@@ -32342,7 +32569,7 @@
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/rec)
 "oRw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32398,7 +32625,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "oSV" = (
@@ -32432,6 +32659,14 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
+"oUv" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "oUE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -32483,10 +32718,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "oVW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "oWd" = (
@@ -32674,6 +32909,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"pce" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/workout)
 "pcg" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -32688,6 +32926,10 @@
 "pcm" = (
 /obj/item/kirbyplants/random,
 /obj/item/radio/intercom/directional/south,
+/obj/machinery/camera{
+	c_tag = "Arrivals Hallway - Port Maintenance Entrance";
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "pcs" = (
@@ -33140,6 +33382,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"poD" = (
+/obj/structure/closet/crate,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/item/stack/license_plates/empty/fifty,
+/obj/machinery/camera{
+	c_tag = "Permabrig - Workshop";
+	dir = 9;
+	name = "Perma Camera";
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/bot/right,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/textured,
+/area/security/prison/work)
 "poL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33881,7 +34138,7 @@
 "pMF" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "pMJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34320,6 +34577,23 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
+"qct" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/iron,
+/area/security/prison/work)
+"qcW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera{
+	c_tag = "Science - Hallway";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "qde" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -34933,6 +35207,9 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"qtb" = (
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "qtc" = (
 /obj/structure/displaycase/captain,
 /obj/effect/turf_decal/stripes/line{
@@ -35001,6 +35278,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"qwi" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/safe)
 "qwl" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -35093,8 +35374,9 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qzX" = (
+/obj/structure/cable,
 /turf/open/floor/carpet/black,
-/area/security/prison)
+/area/security/prison/workout)
 "qzZ" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35113,7 +35395,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/prison/visit)
 "qAC" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron,
@@ -35259,6 +35541,11 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"qEV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/garden)
 "qFh" = (
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
@@ -35404,7 +35691,7 @@
 /obj/item/storage/crayons,
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/security/prison)
+/area/security/prison/rec)
 "qKs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35527,7 +35814,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "qPY" = (
 /obj/machinery/photocopier,
 /obj/item/radio/intercom{
@@ -35699,6 +35986,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"qVB" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/security/prison/garden)
 "qVF" = (
 /obj/machinery/mecha_part_fabricator,
 /turf/open/floor/iron/dark/textured,
@@ -36243,7 +36534,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "rla" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -36454,8 +36745,15 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/closet/crate,
 /obj/item/crowbar,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"rri" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "rrr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -36846,7 +37144,7 @@
 "rFn" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "rFE" = (
 /obj/structure/window{
 	dir = 4
@@ -37057,6 +37355,7 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/status_display/evac/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_corner{
 	dir = 8
 	},
@@ -37547,7 +37846,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/mess)
 "sbk" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -37667,15 +37966,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
-"seW" = (
-/obj/machinery/camera{
-	c_tag = "Science - Hallway";
-	network = list("ss13","rd")
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/research)
 "seZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38150,7 +38440,7 @@
 "srQ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/security/prison)
+/area/security/prison/garden)
 "srX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38367,6 +38657,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"szK" = (
+/turf/closed/wall,
+/area/security/prison/garden)
 "szL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38472,7 +38765,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/prison/visit)
 "sBT" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red,
@@ -38551,6 +38844,9 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"sDA" = (
+/turf/closed/wall,
+/area/security/prison/work)
 "sEr" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
@@ -38664,6 +38960,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"sHJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/plating,
+/area/security/prison/work)
 "sHP" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'BOMB RANGE";
@@ -39126,7 +39427,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/security/prison)
+/area/security/prison/visit)
 "sST" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/effect/landmark/blobstart,
@@ -39156,7 +39457,7 @@
 	network = list("ss13","prison")
 	},
 /turf/open/floor/iron/cafeteria,
-/area/security/prison)
+/area/security/prison/mess)
 "sTy" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -39523,6 +39824,12 @@
 /obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"tda" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/rec)
 "tdm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -39794,6 +40101,12 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/assembly/flash/handheld,
 /obj/structure/cable,
+/obj/machinery/requests_console{
+	department = "Security";
+	departmentType = 5;
+	name = "Security RC";
+	pixel_x = 32
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "tjQ" = (
@@ -39881,7 +40194,7 @@
 /area/hallway/primary/port)
 "tll" = (
 /turf/open/floor/grass,
-/area/security/prison)
+/area/security/prison/garden)
 "tlu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
@@ -40484,6 +40797,10 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"tAy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/security/prison/rec)
 "tAP" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album{
@@ -40759,6 +41076,10 @@
 /obj/machinery/bounty_board/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"tIe" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "tIA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41091,6 +41412,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
 /area/medical/storage)
+"tRB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/mess)
 "tRG" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -41431,6 +41757,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
+"ucs" = (
+/obj/machinery/camera{
+	c_tag = "Permabrig - Exterior - Cells";
+	dir = 5;
+	name = "Perma Camera";
+	network = list("ss13","prison")
+	},
+/turf/open/space/basic,
+/area/space)
 "ucy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41694,7 +42029,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "ujo" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -42283,6 +42618,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
+"uyK" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/security/prison/mess)
 "uyT" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/iron/half,
@@ -42583,6 +42922,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"uFN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/prison/shower)
 "uGs" = (
 /obj/structure/window{
 	dir = 8
@@ -42852,6 +43196,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"uMt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison/work)
 "uMy" = (
 /obj/item/beacon,
 /turf/open/indestructible{
@@ -43000,6 +43355,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"uQN" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "uQW" = (
 /obj/structure/chair,
 /obj/structure/cable,
@@ -43280,6 +43643,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -43664,6 +44028,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"vkj" = (
+/turf/closed/wall/r_wall,
+/area/security/prison/visit)
 "vkG" = (
 /obj/structure/rack,
 /obj/item/storage/box/lights,
@@ -43817,7 +44184,7 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "vnL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vnX" = (
@@ -44377,6 +44744,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"vyC" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/security/prison/workout)
 "vyG" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -44492,7 +44863,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "vBh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44954,7 +45325,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/security/prison)
+/area/security/prison/shower)
 "vNW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45228,6 +45599,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"vVA" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "vVZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/window/preopen{
@@ -45542,13 +45918,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "weO" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "weR" = (
@@ -45827,6 +46203,7 @@
 /area/science/server)
 "wnI" = (
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "woo" = (
@@ -46135,6 +46512,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"wxu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison/rec)
 "wxH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46190,7 +46573,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/security/brig)
+/area/security/prison/visit)
 "wzD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -46765,8 +47148,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wOt" = (
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/security/prison)
+/area/security/prison/rec)
 "wOE" = (
 /turf/open/floor/iron/smooth_large,
 /area/engineering/gravity_generator)
@@ -47140,6 +47524,13 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/corporate_showroom)
+"wXD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "wXQ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -47242,7 +47633,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/security/prison)
+/area/security/prison/garden)
 "xbi" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
@@ -47534,6 +47925,9 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xib" = (
+/turf/open/floor/carpet/black,
+/area/security/prison/workout)
 "xih" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -48553,10 +48947,6 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"xFp" = (
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron/smooth,
-/area/engineering/main)
 "xFq" = (
 /obj/machinery/light{
 	dir = 4
@@ -48734,8 +49124,11 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Workshop"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/security/prison/safe)
+/area/security/prison/work)
 "xMg" = (
 /turf/open/floor/wood,
 /area/service/bar)
@@ -49284,6 +49677,10 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
+"ybV" = (
+/obj/item/radio/intercom/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "ycD" = (
 /obj/structure/window{
 	dir = 8
@@ -49297,7 +49694,7 @@
 /area/service/hydroponics)
 "ycG" = (
 /obj/machinery/camera{
-	c_tag = "Centra Hallway - Hydroponics";
+	c_tag = "Central Hallway - Hydroponics";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -60095,17 +60492,17 @@ gfQ
 fsz
 gfQ
 gfQ
-yin
-yin
-yin
-yin
-yin
-yin
-yin
-uRW
-yhG
-yhG
-yhG
+cOF
+cOF
+cOF
+cOF
+jCO
+jCO
+jCO
+qVB
+qEV
+qEV
+qEV
 fsz
 fsz
 fsz
@@ -60352,17 +60749,17 @@ gfQ
 fsz
 gfQ
 gfQ
-yin
+cOF
 alw
 alQ
-xlD
-ygB
+kuZ
+szK
 anq
 apI
 apT
-uDr
+lXF
 pMF
-yhG
+qEV
 gfQ
 gfQ
 fsz
@@ -60609,17 +61006,17 @@ fsz
 fsz
 fsz
 fsz
-yin
-thl
+cOF
+tAy
 oRu
 bRe
-ygB
+szK
 anC
 weJ
 apU
 asI
 pMF
-uRW
+qVB
 gfQ
 gfQ
 fsz
@@ -60866,17 +61263,17 @@ gfQ
 gfQ
 fsz
 yfx
-yin
+cOF
 lnP
 guT
 amj
-ygB
+szK
 krw
 qPW
 asT
-xlD
+lIR
 pMF
-yin
+jCO
 fsz
 fsz
 fsz
@@ -61117,25 +61514,25 @@ sHc
 fsz
 fsz
 gfQ
-yhG
-yhG
-yhG
-yhG
-yhG
-yhG
-yin
+mTD
+mTD
+mTD
+mTD
+mTD
+mTD
+cOF
 ajp
-jbw
+tda
 amk
-ygB
+szK
 anT
-jev
-xlD
-xlD
+gFY
+lIR
+lIR
 vBc
-yin
+jCO
 gfQ
-gfQ
+kuP
 fsz
 gfQ
 gfQ
@@ -61374,25 +61771,25 @@ sHc
 gfQ
 fsz
 gfQ
-yhG
+mTD
 aiZ
 dUI
-wOt
+dEO
 aiu
 qJP
-ygB
-ygB
+hea
+hea
 alR
-ygB
-ygB
-ygB
+hea
+szK
+szK
 apA
 arl
-ygB
-ygB
-yin
-yin
-yin
+szK
+sDA
+gmq
+gmq
+gmq
 fsz
 gfQ
 gfQ
@@ -61631,25 +62028,25 @@ sHc
 gfQ
 fsz
 fsz
-yhG
+mTD
 fdq
 dUI
 agS
 aix
 ajv
 akP
-osZ
-osZ
-osZ
+wxu
+wxu
+wxu
 amy
 osZ
 jev
 jev
 dnN
-ygB
+sDA
 nJA
 jMR
-yin
+gmq
 fsz
 gfQ
 gfQ
@@ -61888,26 +62285,26 @@ sHc
 gfQ
 fsz
 gfQ
-yhG
-wOt
-wOt
+mTD
+dEO
+dEO
 agZ
-wOt
+dEO
 wOt
 akR
-xlD
-xlD
+kuZ
+kuZ
 apc
 xlD
 xlD
 arz
 jev
-xlD
+rri
 xLR
-rmy
+uMt
 lVC
-yin
-fsz
+gmq
+gmq
 gfQ
 gfQ
 gfQ
@@ -62145,13 +62542,13 @@ sHc
 fsz
 fsz
 iwb
-uRW
+vyC
 aga
-qzX
+xib
 ahe
+xib
 qzX
-qzX
-ygB
+szK
 srQ
 srQ
 xaQ
@@ -62160,11 +62557,11 @@ srQ
 mSU
 jev
 xlD
-ygB
-rmy
-rmy
-yin
-fsz
+sDA
+qct
+dNM
+dNM
+gmq
 gfQ
 gfQ
 gfQ
@@ -62402,26 +62799,26 @@ sHc
 gfQ
 fsz
 gfQ
-yin
+pce
 bqE
-qzX
+xib
 ahk
-qzX
+xib
 ajA
-ygB
+szK
 aoL
 rFn
 amm
 amz
 iDu
-ygB
+szK
 jev
 hTK
-ygB
-nJA
-jMR
-yin
-fsz
+sDA
+sHJ
+poD
+oAN
+gmq
 gfQ
 gfQ
 gfQ
@@ -62659,19 +63056,19 @@ gfQ
 gfQ
 fsz
 gfQ
-yin
+pce
 aga
 nKc
 ahs
 kMo
-qzX
-ygB
+oNV
+szK
 tll
 tll
 euO
 tll
 anU
-ygB
+szK
 jev
 asN
 ygB
@@ -62916,24 +63313,24 @@ fsz
 fsz
 fsz
 fsz
-uRW
-ygB
-ygB
-ygB
-ygB
-ygB
-ygB
+vyC
+nGZ
+nGZ
+nGZ
+nGZ
+nGZ
+szK
 tll
 euO
 amn
 amA
 anV
-ygB
+szK
 gPL
 asK
 ygB
 aCz
-xlD
+glm
 avI
 nJW
 yin
@@ -63173,19 +63570,19 @@ fsz
 gfQ
 gfQ
 gfQ
-yhG
+tRB
 agc
 ghC
 buj
 ags
 ajB
-ygB
+szK
 aow
 tll
 tll
 amC
 anX
-ygB
+szK
 qLq
 xlD
 ygB
@@ -63430,19 +63827,19 @@ fsz
 gfQ
 gfQ
 gfQ
-yhG
+tRB
 agc
-ags
-xlD
-aUK
+hga
+qtb
+tIe
 anf
-ygB
+szK
 aeK
 euO
 dOY
 tll
 nei
-ygB
+szK
 jev
 jbw
 imL
@@ -63686,14 +64083,14 @@ fsz
 fsz
 fsz
 fsz
-yhG
-yhG
-xlD
-xlD
-xlD
-xlD
-xlD
-ygB
+tRB
+tRB
+qtb
+qtb
+qtb
+qtb
+meJ
+szK
 srQ
 srQ
 uiV
@@ -63943,13 +64340,13 @@ gfQ
 fsz
 gfQ
 gfQ
-yhG
-xlD
-xlD
+tRB
+qtb
+qtb
 mRJ
 ahv
 aeI
-jev
+wXD
 ndS
 jev
 jev
@@ -64200,13 +64597,13 @@ gfQ
 fsz
 gfQ
 gfQ
-yhG
-uDr
+tRB
+meJ
 npX
 adV
 sbi
-xlD
-apc
+qtb
+cRO
 oXQ
 xlD
 xlD
@@ -64215,9 +64612,9 @@ xlD
 xlD
 nrR
 jev
-xlD
+uDr
 ewP
-rmy
+qwi
 nti
 iBp
 yin
@@ -64457,12 +64854,12 @@ gfQ
 fsz
 gfQ
 gfQ
-yhG
-xlD
+tRB
+qtb
 agc
 agx
 ahz
-xlD
+qtb
 ajE
 ygB
 qDw
@@ -64474,7 +64871,7 @@ qDw
 jev
 xlD
 ygB
-rmy
+kXw
 rmy
 wYE
 yin
@@ -64714,8 +65111,8 @@ fsz
 fsz
 fsz
 fsz
-yhG
-yhG
+tRB
+tRB
 agd
 lBX
 ahC
@@ -64972,7 +65369,7 @@ fsz
 gfQ
 gfQ
 gfQ
-yhG
+tRB
 agk
 hmt
 iOh
@@ -65229,7 +65626,7 @@ fsz
 gfQ
 gfQ
 gfQ
-yhG
+tRB
 dcp
 diO
 ahD
@@ -65251,14 +65648,14 @@ wUf
 xlD
 ofA
 xlD
-yin
-yin
-yin
-yin
-xke
-xke
-xke
-xke
+vkj
+vkj
+vkj
+vkj
+vkj
+vkj
+vkj
+vkj
 nUR
 fDa
 bcd
@@ -65486,12 +65883,12 @@ fsz
 fsz
 fsz
 fsz
-uRW
-yin
-yin
-ygB
-ygB
-ygB
+uyK
+gtW
+gtW
+eFv
+eFv
+eFv
 ygB
 jbw
 jbw
@@ -65510,12 +65907,12 @@ jbw
 jbw
 ayG
 kDY
-aye
+iKG
 oHK
 mRd
 hmb
 lKO
-xke
+vkj
 bwh
 ugW
 aJq
@@ -65745,7 +66142,7 @@ sHc
 gfQ
 fsz
 gfQ
-yhG
+uFN
 blo
 aja
 jxE
@@ -65765,9 +66162,9 @@ yin
 yin
 yin
 yin
-yin
+vkj
 bbP
-aye
+iKG
 kmC
 eHF
 hmb
@@ -66002,7 +66399,7 @@ sHc
 gfQ
 fsz
 gfQ
-yhG
+uFN
 ahR
 aje
 kBX
@@ -66022,14 +66419,14 @@ caT
 aOm
 aOm
 tHd
-yin
+vkj
 sSG
-aye
+iKG
 iAD
 dEG
 hmb
 wyY
-xke
+vkj
 iYh
 vff
 xIr
@@ -66259,7 +66656,7 @@ sHc
 fsz
 fsz
 gfQ
-uRW
+goy
 fQN
 mok
 rkL
@@ -66279,14 +66676,14 @@ uea
 sWN
 kvd
 vHY
-yin
+vkj
 jhS
-aye
+iKG
 qAw
 llM
 hmb
-ciu
-xke
+iKG
+vkj
 azA
 fDa
 rhI
@@ -66516,15 +66913,15 @@ sHc
 gfQ
 fsz
 fsz
-yin
+mCD
 fQN
 ajg
 rkL
 ygB
-uBy
+fPq
 uce
 qDw
-gbL
+knl
 wVI
 qDw
 cJQ
@@ -66536,14 +66933,14 @@ iYi
 yin
 yin
 yin
-yin
-yin
-yin
-yin
-xke
-xke
-xke
-xke
+vkj
+vkj
+vkj
+vkj
+vkj
+vkj
+vkj
+vkj
 foU
 rtK
 kiu
@@ -66773,7 +67170,7 @@ sHc
 fsz
 fsz
 kWq
-yin
+mCD
 aic
 vNQ
 rkL
@@ -67030,8 +67427,8 @@ sHc
 gfQ
 fsz
 gfQ
-yin
-jxE
+mCD
+nIr
 ajt
 vNQ
 alN
@@ -67287,10 +67684,10 @@ sHc
 gfQ
 fsz
 fsz
-yin
-yin
-yin
-yin
+mCD
+mCD
+mCD
+mCD
 yin
 xlD
 jbw
@@ -68067,7 +68464,7 @@ kYl
 cgp
 qDw
 uBy
-uce
+dCP
 yin
 gfQ
 gfQ
@@ -68134,7 +68531,7 @@ jky
 uOp
 xWP
 uXv
-xFp
+fkV
 fkV
 plT
 ydM
@@ -68579,7 +68976,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+ucs
 gfQ
 gfQ
 gfQ
@@ -68614,7 +69011,7 @@ bhG
 bzj
 rhI
 rhI
-rhI
+xIr
 xIr
 eKb
 eKb
@@ -76607,7 +77004,7 @@ ace
 wWn
 wWn
 wWn
-eki
+exq
 iDE
 ttH
 bdY
@@ -81183,8 +81580,8 @@ ygg
 ygg
 urp
 ygg
-ygg
-ygg
+kVZ
+ifz
 ata
 ygg
 atK
@@ -83240,7 +83637,7 @@ atK
 hmk
 atK
 anb
-atK
+iMO
 agj
 agj
 agj
@@ -84291,7 +84688,7 @@ tGp
 tGp
 cff
 tGp
-dak
+vVA
 bjU
 ybn
 ozS
@@ -85576,7 +85973,7 @@ btD
 aJy
 aJy
 tGp
-qFM
+ybn
 bjU
 aei
 vqN
@@ -85611,7 +86008,7 @@ xvu
 xvu
 xvu
 xvu
-rZB
+oUv
 uVs
 msF
 aKO
@@ -85868,7 +86265,7 @@ shF
 shF
 shF
 hKa
-rZB
+gDm
 uVs
 dAV
 aKO
@@ -86400,7 +86797,7 @@ aSG
 agw
 ncm
 tTH
-cND
+ecW
 qAe
 blU
 tJB
@@ -87375,7 +87772,7 @@ xrI
 xrI
 xrI
 etj
-ybn
+ybV
 dzo
 dWR
 vqN
@@ -87403,7 +87800,7 @@ qnO
 juP
 mvr
 ylr
-ylr
+uQN
 ylr
 mIx
 fjF
@@ -91496,7 +91893,7 @@ aPm
 cnA
 dao
 juY
-ezk
+ciL
 hwL
 mPw
 lli
@@ -92259,7 +92656,7 @@ dPn
 sjT
 kcD
 xAk
-lNt
+fTM
 eaO
 wUU
 wUU
@@ -93311,7 +93708,7 @@ pgy
 pgy
 nZE
 gYJ
-rYC
+jsL
 qvK
 rpt
 vnF
@@ -94073,7 +94470,7 @@ nRR
 pmn
 gbr
 tJp
-seW
+uAk
 txK
 dfS
 dfS
@@ -94330,7 +94727,7 @@ nTr
 fXb
 qey
 tJp
-uAk
+qcW
 tvm
 utq
 vre

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -1184,6 +1184,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/machinery/camera{
+	c_tag = "Science - Nanite Lab";
+	dir = 6;
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "aiQ" = (
@@ -7116,11 +7121,6 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Nanite Lab";
-	dir = 4;
-	network = list("ss13","rd")
-	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "beZ" = (
@@ -9117,6 +9117,10 @@
 "bQv" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/space_heater,
+/obj/machinery/camera{
+	c_tag = "Starboard Maintenance Escape Pod";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bQC" = (
@@ -9433,8 +9437,8 @@
 "caO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
-	c_tag = "Science Hallway - Xeno Entrancce";
-	dir = 4;
+	c_tag = "Science - Aft Hallway";
+	dir = 5;
 	network = list("ss13","rd")
 	},
 /obj/item/radio/intercom{
@@ -10125,7 +10129,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Aft Starboard Corner";
-	dir = 1
+	dir = 1;
+	network = list("ss13","engine")
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -10293,7 +10298,7 @@
 	req_access_txt = "55"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cBq" = (
 /obj/machinery/status_display/ai{
@@ -10798,7 +10803,8 @@
 "cTt" = (
 /obj/structure/chair/sofa/corner,
 /obj/machinery/camera{
-	c_tag = "Medbay - Breakroom"
+	c_tag = "Medbay - Breakroom";
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
@@ -10940,7 +10946,8 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Testing Room";
-	dir = 1
+	dir = 1;
+	network = list("ss13","engine")
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -11966,7 +11973,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Xenobiology Test Chamber";
+	c_tag = "Science - Xenobiology Test Chamber";
 	network = list("xeno","rd")
 	},
 /turf/open/floor/engine,
@@ -13068,13 +13075,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"dYP" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Hallway - Fore Corner";
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "dYS" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/maintenance,
@@ -15746,7 +15746,7 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "fwj" = (
 /obj/machinery/camera{
-	c_tag = "Experimentor Lab";
+	c_tag = "Science - Experimentor Lab";
 	network = list("ss13","rd")
 	},
 /obj/structure/closet/l3closet/scientist,
@@ -16874,7 +16874,7 @@
 /area/service/kitchen)
 "gbY" = (
 /obj/machinery/camera{
-	c_tag = "Robotics Lab";
+	c_tag = "Science - Robotics Lab";
 	dir = 1;
 	network = list("ss13","rd")
 	},
@@ -18831,7 +18831,7 @@
 /area/command/bridge)
 "hhU" = (
 /obj/machinery/camera{
-	c_tag = "Toxins Chamber";
+	c_tag = "Science - Toxins Chamber";
 	dir = 8;
 	network = list("ss13","rd")
 	},
@@ -19030,7 +19030,7 @@
 /area/commons/storage/primary)
 "hnE" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology Central";
+	c_tag = "Science - Xenobiology Central";
 	network = list("ss13","rd")
 	},
 /obj/structure/cable,
@@ -19270,7 +19270,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Aux Chamber";
-	dir = 5
+	dir = 5;
+	network = list("ss13","engine")
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
@@ -21135,7 +21136,7 @@
 "iCT" = (
 /obj/machinery/light/small,
 /obj/machinery/camera{
-	c_tag = "Experimentor Lab Chamber";
+	c_tag = "Science - Experimentor Lab Chamber";
 	dir = 1;
 	network = list("ss13","rd")
 	},
@@ -21852,6 +21853,11 @@
 "iYj" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/machinery/camera{
+	c_tag = "Science - Toxins Storage B";
+	dir = 8;
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron,
 /area/science/mixing)
 "iYk" = (
@@ -22638,6 +22644,11 @@
 "jwG" = (
 /obj/machinery/light/small{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Science - Xenobiology Airlock";
+	dir = 6;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard)
@@ -24314,6 +24325,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
+"kvF" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Science - Xenobiology Pens B";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "kvM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -25153,7 +25174,7 @@
 /area/maintenance/starboard)
 "kRj" = (
 /obj/machinery/camera{
-	c_tag = "Xenobiology - Pens";
+	c_tag = "Science - Xenobiology Pens Hall";
 	dir = 4;
 	network = list("ss13","rd")
 	},
@@ -25927,16 +25948,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"lpi" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/camera{
-	c_tag = "Toxins Storage B";
-	dir = 4;
-	network = list("ss13","rd")
-	},
-/turf/open/floor/iron,
-/area/science/mixing)
 "lpp" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/secure_closet/miner,
@@ -30620,7 +30631,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "R&D Server Room";
+	c_tag = "Science - R&D Server Room";
 	dir = 4;
 	network = list("ss13","rd")
 	},
@@ -32561,6 +32572,11 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
+/obj/machinery/camera{
+	c_tag = "Science - Xenobiology Cold Chamber";
+	dir = 10;
+	network = list("ss13","rd")
+	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "oYC" = (
@@ -32685,8 +32701,8 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
-	c_tag = "Science Access";
-	dir = 4;
+	c_tag = "Science - Airlock";
+	dir = 5;
 	network = list("ss13","rd")
 	},
 /turf/open/floor/iron/white,
@@ -32709,6 +32725,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/science,
+/obj/machinery/camera{
+	c_tag = "Science - Entrance";
+	dir = 8;
+	network = list("ss13","rd")
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "pdg" = (
@@ -32915,7 +32936,7 @@
 "pjD" = (
 /obj/structure/table,
 /obj/machinery/camera{
-	c_tag = "Robotics Lab - Surgery";
+	c_tag = "Science - Robotics Surgical Lab";
 	dir = 1;
 	network = list("ss13","rd")
 	},
@@ -33302,7 +33323,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/camera{
-	c_tag = "Toxins Storage A";
+	c_tag = "Science - Toxins Storage A";
 	dir = 4;
 	network = list("ss13","rd")
 	},
@@ -34283,7 +34304,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Research Director's Office";
+	c_tag = "Command - Research Director's Office";
 	dir = 1;
 	network = list("ss13","rd")
 	},
@@ -34568,7 +34589,7 @@
 "qkf" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/machinery/camera{
-	c_tag = "Genetics Research";
+	c_tag = "Science - Genetics";
 	dir = 1;
 	network = list("ss13","rd")
 	},
@@ -35104,6 +35125,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
+"qAX" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Science - Xenobiology Pens D";
+	dir = 1;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/engine,
+/area/science/xenobiology)
 "qBf" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "Robotics Belt B";
@@ -36081,7 +36113,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Toxins Launch Chamber";
+	c_tag = "Science - Toxins Launch Chamber";
 	dir = 4;
 	network = list("ss13","rd")
 	},
@@ -37358,6 +37390,12 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/library)
+"rXz" = (
+/obj/machinery/camera{
+	c_tag = "Starboard Hallway - Fore Corner"
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "rXA" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/duct,
@@ -37631,7 +37669,7 @@
 /area/commons/vacant_room/office)
 "seW" = (
 /obj/machinery/camera{
-	c_tag = "Science Hallway";
+	c_tag = "Science - Hallway";
 	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38250,7 +38288,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/camera/autoname,
+/obj/machinery/camera{
+	c_tag = "Science - Xenobiology Pens A";
+	network = list("ss13","rd")
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "swL" = (
@@ -40580,7 +40621,7 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/camera{
-	c_tag = "Toxins North";
+	c_tag = "Science - Toxins Airlock";
 	dir = 8;
 	network = list("ss13","rd")
 	},
@@ -41039,8 +41080,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/camera/autoname{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Science - Xenobiology Pens C";
+	dir = 1;
+	network = list("ss13","rd")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -41217,7 +41260,8 @@
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera{
-	c_tag = "Medbay - Storage"
+	c_tag = "Medbay - Storage";
+	network = list("ss13","medbay")
 	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
@@ -42913,7 +42957,8 @@
 "uOL" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Aft Port Corner";
-	dir = 1
+	dir = 1;
+	network = list("ss13","engine")
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -44138,8 +44183,7 @@
 "vvc" = (
 /obj/machinery/camera{
 	c_tag = "Disposals";
-	dir = 8;
-	network = list("ss13","engine")
+	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
@@ -47320,7 +47364,7 @@
 /area/hallway/primary/port)
 "xcz" = (
 /obj/machinery/camera{
-	c_tag = "Mechbay";
+	c_tag = "Science - Mechbay";
 	dir = 8;
 	network = list("ss13","rd")
 	},
@@ -48664,7 +48708,7 @@
 "xLw" = (
 /obj/structure/table,
 /obj/machinery/camera{
-	c_tag = "Research and Development";
+	c_tag = "Science - Research and Development";
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
@@ -89389,7 +89433,7 @@ bmR
 bdj
 ybn
 dBp
-dYP
+ybn
 pnn
 pnn
 pnn
@@ -89901,7 +89945,7 @@ etj
 etj
 etj
 etj
-uWM
+rXz
 dCO
 ydj
 qYW
@@ -93016,7 +93060,7 @@ rpt
 sUF
 vNW
 tmj
-swp
+kvF
 uZT
 uZT
 dmA
@@ -93028,7 +93072,7 @@ kpz
 glU
 uZT
 uZT
-tRr
+qAX
 tmj
 qhx
 yal
@@ -98149,7 +98193,7 @@ vBA
 xEA
 pyP
 sLH
-lpi
+iQM
 rYf
 iQM
 iQM

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -66,7 +66,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "aaH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85,7 +85,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "aaL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/airless,
@@ -138,7 +138,7 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "abb" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
@@ -184,7 +184,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "abB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -821,7 +821,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "afb" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/white/side{
@@ -845,7 +845,6 @@
 	dir = 4;
 	name = "N2O to Pure"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "afp" = (
@@ -1096,7 +1095,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "ahk" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -1159,7 +1158,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "ahR" = (
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
@@ -2074,8 +2073,9 @@
 	},
 /area/maintenance/port/aft)
 "aoh" = (
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "aoj" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -3368,6 +3368,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/commons/dorms)
+"azc" = (
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "azd" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm4";
@@ -3755,7 +3758,7 @@
 	pixel_y = -27
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "aDB" = (
 /obj/machinery/light,
 /turf/open/floor/iron,
@@ -3814,7 +3817,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aEe" = (
@@ -4330,7 +4333,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "aJL" = (
 /obj/structure/cable,
 /obj/structure/cable/layer3,
@@ -4467,8 +4470,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos/upper)
 "aLc" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -4608,7 +4613,7 @@
 	specialfunctions = 4
 	},
 /turf/open/floor/iron/freezer,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "aMA" = (
 /obj/structure/chair{
 	dir = 1
@@ -4621,7 +4626,7 @@
 	name = "Fitness Room Shower"
 	},
 /turf/open/floor/iron/freezer,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "aMQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -4629,13 +4634,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "aMS" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
 	},
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "aMX" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine{
@@ -4648,7 +4653,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "aNd" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -4679,14 +4684,14 @@
 /obj/machinery/power/apc/auto_name/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "aNm" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "aNn" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light/small{
@@ -4745,7 +4750,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "aNG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -4860,11 +4865,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
-"aOG" = (
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/primary/fore)
 "aOK" = (
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -4885,7 +4886,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "aOQ" = (
 /turf/open/floor/wood,
 /area/medical/psychology)
@@ -5086,11 +5087,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "aQm" = (
@@ -5378,7 +5379,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "aSh" = (
 /obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/plating,
@@ -5593,7 +5594,7 @@
 /area/hallway/primary/fore)
 "aTV" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/plating,
 /area/engineering/main)
 "aUa" = (
@@ -5891,7 +5892,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "aWe" = (
 /obj/structure/sink{
 	dir = 8;
@@ -6097,8 +6098,9 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "aXG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6121,6 +6123,19 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"aYa" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aYb" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -6135,7 +6150,7 @@
 "aYg" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "aYn" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -6163,6 +6178,13 @@
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"aYx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aYz" = (
@@ -6351,7 +6373,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "aZk" = (
 /obj/machinery/computer/holodeck{
 	dir = 8
@@ -6360,7 +6382,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "aZl" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -6513,7 +6535,7 @@
 "aZZ" = (
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "baa" = (
 /obj/effect/decal/cleanable/food/egg_smudge,
 /turf/open/floor/plating,
@@ -6637,15 +6659,6 @@
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"bbt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/central)
 "bbw" = (
 /obj/effect/landmark/start/botanist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6660,7 +6673,7 @@
 	dir = 1
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "bbI" = (
@@ -6852,7 +6865,7 @@
 	name = "Fitness"
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/commons/fitness/recreation)
 "bdp" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -6919,7 +6932,7 @@
 "bdP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "bdR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -8074,7 +8087,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "bmr" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -8095,16 +8108,13 @@
 "bmH" = (
 /obj/structure/rack,
 /obj/item/fuel_pellet,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
 "bmR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "bnh" = (
 /obj/structure/window{
 	dir = 4
@@ -8153,7 +8163,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/command)
+/area/command/bridge)
 "bor" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -8381,7 +8391,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "bsv" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm1";
@@ -8525,7 +8535,7 @@
 "buL" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "buN" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "EVA Storage";
@@ -8543,7 +8553,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/command)
+/area/ai_monitored/command/storage/eva)
 "buP" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -8558,6 +8568,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"bvf" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/department/electrical)
 "bvo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
 /turf/open/floor/iron,
@@ -8723,7 +8736,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "bAi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -8810,7 +8823,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "bEP" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -8878,7 +8891,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "bHL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -9174,7 +9187,7 @@
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/iron/freezer,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "bSK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -9346,7 +9359,7 @@
 	},
 /obj/item/assembly/flash,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "bYn" = (
 /obj/structure/table,
 /obj/item/scalpel{
@@ -9445,7 +9458,7 @@
 /obj/structure/window,
 /obj/structure/flora/rock/pile,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "cbo" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -9562,7 +9575,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "cdD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9649,8 +9662,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cfI" = (
@@ -9698,7 +9709,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "cgG" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/disposalpipe/segment{
@@ -9776,14 +9787,14 @@
 "ciA" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "ciF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "ciJ" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
@@ -9796,7 +9807,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "ciT" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -9814,13 +9825,13 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "cjL" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "N2 to Mix"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ckf" = (
@@ -9873,7 +9884,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "cly" = (
 /turf/closed/wall/r_wall,
 /area/security/detectives_office)
@@ -9892,7 +9903,7 @@
 "cma" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "cmd" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
@@ -10067,7 +10078,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "cuF" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -10161,7 +10172,7 @@
 /area/maintenance/starboard/aft)
 "cxf" = (
 /turf/closed/wall,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "cxs" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -10200,7 +10211,7 @@
 /obj/structure/cable,
 /obj/structure/chair/office,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "czP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10439,7 +10450,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "cKG" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner{
@@ -10487,10 +10498,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "cND" = (
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "cNO" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -10543,15 +10554,7 @@
 	location = "Bridge"
 	},
 /turf/open/floor/iron,
-/area/command/heads_quarters/hop)
-"cPb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
+/area/command/corporate_showroom)
 "cPz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
@@ -10709,12 +10712,6 @@
 "cSj" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/medical,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -10906,13 +10903,7 @@
 	pixel_y = 34
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
-"cYZ" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "cZc" = (
 /obj/machinery/light{
 	dir = 1
@@ -11110,10 +11101,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ddR" = (
@@ -11199,7 +11187,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "dfH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -11256,12 +11244,6 @@
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
-"dhi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "dhq" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
@@ -11331,11 +11313,7 @@
 "dka" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
-/area/command)
-"dkt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/area/command/bridge)
 "dld" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
@@ -11403,6 +11381,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
 "dmt" = (
@@ -11484,7 +11463,7 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/item/grenade/chem_grenade/smart_metal_foam,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "dpz" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -11492,6 +11471,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"dpC" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "dpG" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -11517,7 +11500,7 @@
 	},
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "dqT" = (
 /obj/machinery/monkey_recycler,
 /obj/machinery/requests_console{
@@ -11617,7 +11600,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "dtK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
@@ -11708,7 +11691,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "dvV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -11732,7 +11715,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "dwx" = (
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/carbon/human/species/monkey,
@@ -11833,8 +11816,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -11865,7 +11846,7 @@
 "dyS" = (
 /obj/machinery/suit_storage_unit/atmos,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "dyX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -11956,21 +11937,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"dAU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "dAV" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
@@ -12012,7 +11978,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/primary/fore)
 "dBt" = (
 /obj/machinery/button/door{
 	id = "xenobio3";
@@ -12137,6 +12103,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dDP" = (
@@ -12157,7 +12124,7 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "dDZ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /obj/structure/lattice,
@@ -12218,7 +12185,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "dFp" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -12330,7 +12297,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /turf/open/floor/iron/large,
-/area/command)
+/area/command/bridge)
 "dJa" = (
 /obj/structure/closet/emcloset{
 	anchored = 1
@@ -12447,8 +12414,11 @@
 /area/hallway/primary/central)
 "dLn" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "dLz" = (
@@ -12594,7 +12564,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "dNm" = (
 /obj/structure/rack,
 /obj/item/book/manual/wiki/tcomms,
@@ -12655,7 +12625,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "dOQ" = (
@@ -12803,7 +12773,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "dSI" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -12814,15 +12784,15 @@
 	pixel_y = -1
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
+"dSQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "dSR" = (
 /obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"dTm" = (
-/obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
 /turf/open/floor/iron,
@@ -12843,7 +12813,7 @@
 	pixel_y = -30
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "dTw" = (
 /obj/machinery/camera{
 	c_tag = "North Hallway - East";
@@ -12923,7 +12893,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "dVV" = (
 /obj/structure/falsewall,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13031,7 +13001,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/hallway/primary/fore)
 "dYS" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/maintenance,
@@ -13066,7 +13036,7 @@
 /obj/structure/flora/grass/brown,
 /obj/machinery/light,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "eab" = (
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
@@ -13154,7 +13124,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
-/area/command)
+/area/command/bridge)
 "ecm" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 1";
@@ -13165,16 +13135,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"ecN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
-"edc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "edi" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
@@ -13200,12 +13160,6 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "edM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -13213,6 +13167,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eeo" = (
@@ -13227,7 +13182,7 @@
 "eeM" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "eeS" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/effect/decal/cleanable/dirt,
@@ -13378,7 +13333,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "eki" = (
@@ -13388,7 +13345,7 @@
 "eko" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "ekR" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -13399,9 +13356,9 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "elh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "elt" = (
@@ -13493,7 +13450,7 @@
 /area/command/heads_quarters/hop)
 "epn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/brown{
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -13553,7 +13510,7 @@
 /obj/structure/window,
 /obj/structure/flora/rock,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "erh" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -13629,7 +13586,7 @@
 /area/security/courtroom)
 "etj" = (
 /turf/closed/wall,
-/area/hallway/primary/fore)
+/area/commons/fitness/recreation)
 "etw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13640,7 +13597,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "etH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -13761,7 +13718,7 @@
 "evM" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "ewg" = (
 /obj/structure/window{
 	dir = 1
@@ -13771,7 +13728,7 @@
 	},
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "ewu" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/bot,
@@ -13785,6 +13742,7 @@
 	name = "Atmospherics Maintenance";
 	req_access_txt = "24"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "ewP" = (
@@ -13850,7 +13808,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ezE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -13860,7 +13818,7 @@
 	},
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "ezQ" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -14093,7 +14051,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "eHF" = (
 /obj/structure/table,
 /obj/machinery/door/poddoor/shutters{
@@ -14145,7 +14103,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/tank_holder/extinguisher/advanced,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
+"eJQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/engineering/atmos/upper)
 "eJV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -14408,7 +14371,7 @@
 /obj/structure/table,
 /obj/item/paper/fluff/holodeck/disclaimer,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "eQH" = (
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
@@ -14418,7 +14381,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "eQR" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -14442,7 +14405,7 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "eRj" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -14533,7 +14496,7 @@
 	name = "Fore/Port Solar Array"
 	},
 /turf/open/floor/iron/solarpanel,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "eUg" = (
 /obj/item/book/random,
 /obj/item/crowbar,
@@ -14628,7 +14591,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "eWx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/closed/wall/r_wall,
@@ -14643,7 +14606,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "eYd" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -14685,8 +14648,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -14719,7 +14680,6 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "eZw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan{
 	dir = 4
 	},
@@ -14817,6 +14777,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"fcR" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "fcS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -14849,7 +14818,7 @@
 /obj/structure/flora/junglebush/b,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/grass,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "fdq" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/iron/grimy,
@@ -15068,6 +15037,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -15113,7 +15083,7 @@
 	},
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "fii" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
@@ -15153,6 +15123,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"fiL" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "fiU" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -15183,10 +15159,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/bounty_board/directional/north,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "fjt" = (
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "fjy" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -15346,7 +15322,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "fnJ" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/iron/dark/telecomms,
@@ -15503,7 +15479,7 @@
 /obj/structure/table/glass,
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/royalblue,
-/area/command)
+/area/command/bridge)
 "fsH" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/tile/yellow{
@@ -15625,7 +15601,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fvA" = (
@@ -15852,13 +15828,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"fAT" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "fBg" = (
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
@@ -15867,6 +15836,10 @@
 /obj/item/multitool,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
+"fBp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "fBs" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
@@ -16145,7 +16118,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "fMo" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/brown{
@@ -16159,9 +16132,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"fMz" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/aft)
 "fMK" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/light/small{
@@ -16185,12 +16155,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
-"fMY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "fNB" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -16286,7 +16250,7 @@
 "fQn" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "fQu" = (
 /obj/structure/closet/firecloset{
 	anchored = 1
@@ -16626,6 +16590,10 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"fYC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "fYR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -16853,10 +16821,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
-"geF" = (
-/obj/effect/spawner/randomsnackvend,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "geG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -16950,7 +16914,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "ghX" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab";
@@ -17031,6 +16995,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"gkm" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "gks" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17041,10 +17013,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"gla" = (
-/obj/effect/spawner/randomcolavend,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "glU" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio8";
@@ -17065,7 +17033,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "gnk" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -17409,7 +17377,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "gwv" = (
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/engine,
@@ -17489,7 +17457,7 @@
 "gxR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "gxV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -17521,7 +17489,7 @@
 	},
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "gym" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -17529,9 +17497,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gyC" = (
@@ -17629,7 +17597,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "gAY" = (
 /obj/machinery/meter,
 /obj/structure/disposalpipe/segment{
@@ -17722,7 +17690,7 @@
 /obj/structure/window,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "gEO" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -17809,7 +17777,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "gHi" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/cable,
@@ -17828,7 +17796,7 @@
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/light,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "gHt" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -17970,7 +17938,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "gOm" = (
@@ -17987,7 +17955,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "gOB" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -18022,7 +17990,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "gPZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -18041,7 +18009,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "gQh" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -18338,7 +18306,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "gXl" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -18509,7 +18477,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "hci" = (
 /obj/structure/table,
 /obj/machinery/door/window/eastright{
@@ -18542,7 +18510,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "hdE" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -18607,6 +18575,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"hfu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "hfN" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue{
@@ -18630,7 +18605,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "hgr" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18666,7 +18641,7 @@
 	pixel_x = 29
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "hhL" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -18688,7 +18663,7 @@
 /obj/machinery/light,
 /obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "hhU" = (
 /obj/machinery/camera{
 	c_tag = "Toxins Chamber";
@@ -18776,6 +18751,7 @@
 /area/science/storage)
 "hjW" = (
 /obj/item/radio/intercom/directional/west,
+/obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "hkq" = (
@@ -18799,7 +18775,7 @@
 	},
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "hlG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18939,7 +18915,7 @@
 /area/science/nanite)
 "hoU" = (
 /turf/open/floor/plating,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "hpP" = (
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 8;
@@ -18987,7 +18963,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "hqF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -19027,7 +19003,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "hsb" = (
@@ -19057,6 +19032,13 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/cargo/office)
+"htu" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "htz" = (
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
@@ -19237,10 +19219,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hze" = (
-/obj/machinery/bounty_board/directional/south,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "hzP" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
@@ -19386,13 +19364,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "hDu" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "hEh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19509,14 +19488,7 @@
 	},
 /obj/structure/flora/bush,
 /turf/open/floor/grass,
-/area/command)
-"hHr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/area/command/bridge)
 "hHv" = (
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood/large,
@@ -19566,7 +19538,7 @@
 /obj/structure/window,
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "hJH" = (
 /obj/machinery/air_sensor/atmos/mix_tank{
 	id_tag = "mix2_sensor"
@@ -19625,6 +19597,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/security/brig)
+"hKK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/showroomfloor,
+/area/engineering/atmos/upper)
 "hLe" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -19690,7 +19668,7 @@
 	},
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "hNF" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -19701,7 +19679,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "hOO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -19771,7 +19749,7 @@
 "hQU" = (
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall/r_wall,
-/area/command)
+/area/command/bridge)
 "hRi" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -19907,7 +19885,7 @@
 	},
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "hWW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -19960,6 +19938,7 @@
 /obj/machinery/status_display/supply{
 	pixel_y = 30
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "hYH" = (
@@ -20106,10 +20085,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"idF" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "idJ" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole,
@@ -20135,7 +20110,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "ieH" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -20160,7 +20135,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "ieR" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -20289,7 +20264,7 @@
 	pixel_x = -29
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "ihX" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
@@ -20339,7 +20314,7 @@
 	},
 /obj/item/crowbar,
 /turf/open/floor/carpet/royalblue,
-/area/command)
+/area/command/bridge)
 "ilZ" = (
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /obj/effect/decal/cleanable/dirt,
@@ -20412,7 +20387,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "inz" = (
 /obj/structure/window{
 	dir = 1
@@ -20428,7 +20403,7 @@
 	},
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "inV" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow{
@@ -20459,7 +20434,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/command)
+/area/command/bridge)
 "ioL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/docking,
@@ -20561,7 +20536,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "irO" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -20618,6 +20593,12 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"ito" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "itv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -20742,15 +20723,14 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "iwE" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "iwN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20811,7 +20791,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "ixT" = (
 /obj/machinery/door/airlock/research{
 	name = "Experimentation Lab";
@@ -20840,13 +20820,24 @@
 "iyG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
+"iza" = (
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel,
+/area/solars/starboard/aft)
 "izR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
 /obj/machinery/bounty_board/directional/north,
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/stripes/box,
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron,
 /area/engineering/main)
 "izW" = (
@@ -20891,7 +20882,7 @@
 	},
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "iCT" = (
 /obj/machinery/light/small,
 /obj/machinery/camera{
@@ -20944,7 +20935,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/command)
+/area/command/bridge)
 "iDu" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/onion,
@@ -21104,7 +21095,7 @@
 	},
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "iKS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -21138,7 +21129,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "iLO" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Server Room";
@@ -21169,7 +21160,7 @@
 	dir = 8;
 	name = "Air to Pure"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iMP" = (
@@ -21210,9 +21201,7 @@
 /turf/open/space/basic,
 /area/maintenance/disposal/incinerator)
 "iNF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "iNJ" = (
@@ -21302,13 +21291,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
-"iQy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
 /area/engineering/atmos)
 "iQM" = (
 /obj/effect/turf_decal/bot,
@@ -21439,7 +21421,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "iUh" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/freezer,
@@ -21449,6 +21431,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "iUu" = (
@@ -21587,7 +21570,7 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "iYh" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
@@ -21692,7 +21675,7 @@
 /area/engineering/atmos)
 "jaa" = (
 /turf/open/floor/carpet/royalblue,
-/area/command)
+/area/command/bridge)
 "jad" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet{
@@ -21759,7 +21742,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "jcc" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -21937,7 +21920,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/command)
+/area/command/bridge)
 "jjq" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -21966,7 +21949,7 @@
 /obj/structure/flora/grass/brown,
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "jkp" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -22182,7 +22165,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "jsA" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/showroomfloor,
@@ -22197,7 +22180,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "jsN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -22212,7 +22195,7 @@
 	},
 /obj/item/crowbar,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "jtk" = (
 /obj/structure/chair/sofa/left{
 	dir = 1
@@ -22222,7 +22205,7 @@
 "jtt" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "jtB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -22372,7 +22355,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "jwG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -22477,7 +22460,7 @@
 "jzC" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "jAb" = (
 /obj/structure/chair/sofa{
 	dir = 8;
@@ -22552,7 +22535,7 @@
 "jBo" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "jBy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22697,7 +22680,7 @@
 "jGd" = (
 /obj/structure/sign/departments/evac,
 /turf/closed/wall,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "jGk" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -22818,6 +22801,17 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"jLj" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Plasma to Pure";
+	pipe_color = "#FFFF00"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "jLl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22882,7 +22876,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "jMR" = (
 /obj/structure/closet/crate,
 /obj/item/stack/license_plates/empty/fifty,
@@ -23044,7 +23038,7 @@
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "jTo" = (
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -23098,6 +23092,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"jUy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/engineering/main)
 "jUD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -23114,12 +23114,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"jUM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "jUP" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -23249,7 +23243,7 @@
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "jYu" = (
 /obj/machinery/camera/motion{
 	c_tag = "Armory External";
@@ -23317,7 +23311,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
 "kbg" = (
@@ -23404,7 +23398,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "keU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23425,8 +23419,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
 	},
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
@@ -23439,7 +23433,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "kfL" = (
 /turf/open/floor/iron/white/side{
 	dir = 4
@@ -23486,7 +23480,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "khn" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -23527,7 +23521,7 @@
 	},
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "kiu" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -23739,7 +23733,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "kmZ" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/showroomfloor,
@@ -24034,7 +24028,7 @@
 	},
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "kwa" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -24042,7 +24036,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
 "kwf" = (
@@ -24149,7 +24143,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "kyx" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/orange,
@@ -24328,7 +24322,9 @@
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "kEo" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "kEt" = (
@@ -24350,6 +24346,11 @@
 /obj/item/paper_bin,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"kEG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/central/secondary)
 "kEX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -24472,6 +24473,10 @@
 /obj/item/surgical_drapes,
 /turf/open/floor/iron/dark/textured,
 /area/science/robotics/lab)
+"kHG" = (
+/obj/effect/spawner/randomsnackvend,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "kHI" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/landmark/start/hangover,
@@ -24523,9 +24528,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kJf" = (
@@ -24705,7 +24708,7 @@
 	},
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "kML" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
 	dir = 8
@@ -24717,7 +24720,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "kNc" = (
 /obj/machinery/camera{
 	c_tag = "SMES Storage";
@@ -24751,7 +24754,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "kNA" = (
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/structure/closet/crate,
@@ -24909,7 +24912,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "kUd" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -24999,7 +25002,7 @@
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "laE" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -25113,7 +25116,7 @@
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "leP" = (
 /obj/structure/table/wood,
 /obj/structure/window{
@@ -25214,7 +25217,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "lgw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -25383,7 +25386,7 @@
 "lkI" = (
 /obj/machinery/light,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "lkK" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -25399,7 +25402,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "lkS" = (
 /obj/effect/landmark/start/cook,
 /obj/structure/disposalpipe/segment,
@@ -25530,7 +25533,7 @@
 	},
 /area/maintenance/port/aft)
 "loD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "loE" = (
@@ -25599,7 +25602,7 @@
 "lpI" = (
 /obj/structure/chair,
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "lqd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
@@ -25742,7 +25745,7 @@
 "luN" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "luR" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -25872,7 +25875,7 @@
 "lyY" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "lzo" = (
 /obj/structure/chair{
 	dir = 4
@@ -26012,6 +26015,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/range)
+"lFd" = (
+/turf/open/floor/iron/showroomfloor,
+/area/engineering/atmos/upper)
 "lFh" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
@@ -26075,6 +26081,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"lHp" = (
+/obj/machinery/light,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "lHK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
@@ -26217,7 +26227,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "lLy" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -26297,7 +26307,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/command)
+/area/command/bridge)
 "lNp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26517,15 +26527,15 @@
 /turf/open/floor/iron,
 /area/science/storage)
 "lSx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/computer/atmos_control{
 	dir = 8;
 	sensors = list("n2_sensor" = "Nitrogen Tank", "o2_sensor" = "Oxygen Tank", "co2_sensor" = "Carbon Dioxide Tank", "tox_sensor" = "Plasma Tank", "n2o_sensor" = "Nitrous Oxide Tank", "air_sensor" = "Mixed Air Tank", "mix_sensor" = "Mix Tank", "mix2_sensor" = "Mix Tank #2", "distro-loop_meter" = "Distribution Loop", "atmos-waste_loop_meter" = "Atmos Waste Loop", "incinerator_sensor" = "Incinerator Chamber", "toxinslab_sensor" = "Toxins Mixing Chamber")
 	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "lSL" = (
 /obj/structure/table,
 /obj/machinery/door/firedoor,
@@ -26553,7 +26563,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "lUP" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -26875,6 +26885,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"mes" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/showroomfloor,
+/area/engineering/atmos/upper)
 "meB" = (
 /obj/machinery/button/door{
 	id = "stationawaygate";
@@ -26912,7 +26928,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "mfn" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron,
@@ -27055,7 +27071,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "miB" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -27120,7 +27136,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "mjV" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -27157,7 +27173,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mkQ" = (
@@ -27467,7 +27483,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "mtA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27496,7 +27512,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "muF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -27583,7 +27599,7 @@
 	dir = 8
 	},
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "mwO" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -27740,9 +27756,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "mDh" = (
@@ -27830,7 +27844,6 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mFd" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -28170,7 +28183,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "mPw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -28278,7 +28291,7 @@
 "mTd" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "mTe" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/side{
@@ -28323,7 +28336,7 @@
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "mTo" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -28405,7 +28418,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "mVs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -28424,7 +28437,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "mVJ" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -28463,7 +28476,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "mWH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mWM" = (
@@ -28495,7 +28508,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "mWW" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/yellow{
@@ -28610,7 +28623,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "naz" = (
 /obj/machinery/door/airlock/mining{
 	name = "Drone Bay";
@@ -28673,7 +28686,7 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "nbI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron,
@@ -28698,6 +28711,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
+"nck" = (
+/turf/open/floor/carpet/royalblue,
+/area/command/corporate_showroom)
 "ncm" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
@@ -28895,8 +28911,9 @@
 /obj/structure/sign/picture_frame/showroom/four{
 	pixel_y = -32
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "niq" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/bot_white,
@@ -29014,7 +29031,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "noH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/east,
@@ -29056,7 +29073,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblue,
-/area/command)
+/area/command/bridge)
 "npv" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -29274,7 +29291,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "nuO" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
@@ -29374,6 +29391,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"nyO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "nyU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
@@ -29549,6 +29571,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "nDC" = (
@@ -29629,7 +29654,7 @@
 	pixel_x = -29
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "nGg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29995,7 +30020,7 @@
 /obj/effect/mapping_helpers/iannewyear,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "nSz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -30053,8 +30078,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "nTJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
@@ -30200,7 +30225,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "nXD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4
@@ -30387,7 +30412,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "ocu" = (
@@ -30464,8 +30489,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -30478,6 +30503,11 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"ofl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ofn" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -30565,7 +30595,7 @@
 	},
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "oib" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30657,7 +30687,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "olf" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -30774,8 +30804,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -30907,7 +30937,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "orB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
@@ -30920,6 +30950,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"orD" = (
+/turf/closed/wall/r_wall,
+/area/command/bridge)
 "osb" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -30963,6 +30996,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"oub" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "ouc" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -30984,7 +31021,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "ouK" = (
 /obj/structure/reflector/box/anchored{
 	dir = 8
@@ -31132,7 +31169,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "ozi" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
@@ -31330,7 +31367,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "oDV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -31512,12 +31549,6 @@
 /obj/structure/chair,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"oIO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oIW" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod D";
@@ -31541,7 +31572,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "oJq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -31858,10 +31889,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "oSP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green,
-/obj/machinery/atmospherics/pipe/bridge_pipe/brown{
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "oSV" = (
@@ -31890,7 +31921,7 @@
 	pixel_y = 30
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "oTO" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/showroomfloor,
@@ -32268,7 +32299,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/grass,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "php" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -32399,11 +32430,11 @@
 /obj/structure/flora/ausbushes/pointybush,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/grass,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "pkP" = (
 /obj/structure/table/glass,
 /turf/open/floor/carpet/royalblue,
-/area/command)
+/area/command/bridge)
 "pkV" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -32524,7 +32555,7 @@
 	},
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "pnn" = (
 /turf/closed/wall,
 /area/maintenance/central/secondary)
@@ -32556,6 +32587,10 @@
 "poo" = (
 /turf/open/floor/wood/tile,
 /area/service/library)
+"pow" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pox" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -32578,7 +32613,7 @@
 "ppj" = (
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "ppC" = (
 /obj/machinery/computer/rdservercontrol{
 	dir = 8
@@ -32613,14 +32648,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/command)
+/area/command/bridge)
 "prw" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/hop)
 "prx" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "prA" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -32651,7 +32686,7 @@
 /obj/structure/table/glass,
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/carpet/royalblue,
-/area/command)
+/area/command/bridge)
 "ptu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -32690,7 +32725,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "pua" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32973,7 +33008,7 @@
 	dir = 8
 	},
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "pBE" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -33140,9 +33175,7 @@
 /area/hallway/primary/starboard)
 "pIn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "pIs" = (
@@ -33159,7 +33192,7 @@
 	pixel_x = -27
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "pII" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
@@ -33234,9 +33267,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pLf" = (
@@ -33275,7 +33306,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/command)
+/area/command/bridge)
 "pME" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -33326,7 +33357,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "pPb" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -33476,7 +33507,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "pUm" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -33563,7 +33594,7 @@
 	pixel_x = 29
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "pWJ" = (
 /obj/structure/chair,
 /turf/open/floor/iron,
@@ -33608,7 +33639,7 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "pZA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33670,10 +33701,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/brown,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "qaL" = (
@@ -34271,7 +34302,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "qrt" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
@@ -34305,7 +34336,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "qss" = (
 /obj/structure/closet/secure_closet/research_director,
 /obj/item/cartridge/signal/toxins,
@@ -34475,7 +34506,7 @@
 "qxO" = (
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "qyc" = (
 /obj/structure/closet,
 /obj/item/book/random,
@@ -34516,7 +34547,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "qAw" = (
 /obj/structure/chair/plastic,
 /obj/machinery/flasher{
@@ -34528,7 +34559,7 @@
 "qAC" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "qAM" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -34577,7 +34608,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/bounty_board/directional/east,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "qCE" = (
 /obj/structure/grille/broken,
 /obj/machinery/space_heater,
@@ -34588,7 +34619,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "qCP" = (
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/iron,
@@ -34788,7 +34819,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "qKG" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "teleportershutters";
@@ -34810,7 +34841,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "qLq" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -34852,7 +34883,9 @@
 	pixel_y = 11
 	},
 /obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
 /area/command/heads_quarters/ce)
 "qMT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34884,7 +34917,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "qNv" = (
@@ -34904,8 +34937,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/engineering/atmos/upper)
 "qPW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -35292,7 +35326,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "raY" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
@@ -35310,7 +35344,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
 "rbk" = (
@@ -35483,7 +35517,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "rgq" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -35492,6 +35526,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
+"rgD" = (
+/turf/closed/wall/r_wall,
+/area/engineering/atmos/upper)
 "rgW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -35565,6 +35602,10 @@
 	dir = 8
 	},
 /area/security/office)
+"riF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "riG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Maintenance";
@@ -35601,12 +35642,12 @@
 	},
 /obj/item/storage/firstaid/fire,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "rjv" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "rjz" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -35791,8 +35832,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -36039,7 +36078,7 @@
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "rxU" = (
 /turf/closed/wall,
 /area/cargo/office)
@@ -36257,7 +36296,7 @@
 /obj/structure/window,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "rFH" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
@@ -36414,7 +36453,7 @@
 	},
 /obj/structure/flora/rock/pile,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "rKM" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -36547,7 +36586,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "rPv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -36669,7 +36708,7 @@
 "rTW" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "rTZ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -36749,8 +36788,8 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rWe" = (
@@ -36848,10 +36887,10 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "rYi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/violet,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rYp" = (
@@ -36869,7 +36908,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "rYC" = (
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
@@ -36957,7 +36996,7 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "sbi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -37213,7 +37252,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/commons/fitness/recreation)
 "sis" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -37318,7 +37357,7 @@
 	pixel_y = -30
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "slU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37434,7 +37473,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "soQ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -37623,7 +37662,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "suU" = (
 /obj/structure/frame/machine,
 /turf/open/floor/wood{
@@ -37635,7 +37674,7 @@
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "svm" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room";
@@ -37682,6 +37721,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "swp" = (
@@ -37826,8 +37866,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -37918,7 +37956,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "sDv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -37982,7 +38020,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "sGc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance";
@@ -38199,7 +38237,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "sKk" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -38263,7 +38301,7 @@
 "sLV" = (
 /obj/machinery/bounty_board/directional/east,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "sMi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38300,7 +38338,7 @@
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "sNe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -38431,7 +38469,7 @@
 	pixel_x = -29
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "sRw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -38645,13 +38683,10 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "sVI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "CO2 to Pure"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sVQ" = (
@@ -38928,7 +38963,16 @@
 	},
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
+"tdR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "tea" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -39119,7 +39163,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "tjH" = (
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
@@ -39259,19 +39303,6 @@
 "tmj" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
-"tmy" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "tmT" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -39333,7 +39364,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "tpF" = (
@@ -39352,7 +39383,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "tpP" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/bot,
@@ -39488,8 +39519,12 @@
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "tsk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange{
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "CO2 to Pure";
+	pipe_color = "#FFFF00"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -39500,7 +39535,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "tsz" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -39727,7 +39762,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "tyA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39892,7 +39927,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "tCT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -39914,7 +39949,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "tEu" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -39964,7 +39999,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "tFF" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass{
@@ -40113,7 +40148,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblue,
-/area/command)
+/area/command/bridge)
 "tJA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40166,7 +40201,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "tLl" = (
 /obj/structure/table,
 /turf/open/floor/mineral/plastitanium{
@@ -40207,7 +40242,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "tMU" = (
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
@@ -40259,6 +40294,11 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
+"tOi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "tOn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -40308,7 +40348,7 @@
 	dir = 8;
 	name = "Air to Mix"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tPY" = (
@@ -40342,10 +40382,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"tQR" = (
-/obj/effect/spawner/randomsnackvend,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "tRf" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -40359,7 +40395,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "tRl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40414,9 +40450,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tRS" = (
@@ -40440,7 +40476,7 @@
 "tSb" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/starboard/aft)
+/area/solars/starboard/aft)
 "tSh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40498,11 +40534,17 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "tUB" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"tUV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "tVc" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating{
@@ -40703,7 +40745,7 @@
 /area/engineering/atmos)
 "ubH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "ubS" = (
@@ -40867,7 +40909,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "ufi" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
@@ -41037,7 +41079,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "ukm" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
@@ -41063,7 +41105,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/command)
+/area/command/bridge)
 "ukV" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -41081,7 +41123,7 @@
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/grass,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "ulr" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -41116,7 +41158,7 @@
 	},
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "umy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -41333,7 +41375,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "urd" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
@@ -41503,7 +41545,9 @@
 /area/science/mixing/chamber)
 "uwP" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
 /area/command/heads_quarters/ce)
 "uwV" = (
 /turf/closed/wall,
@@ -41558,6 +41602,14 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/service/library)
+"uye" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2 to Pure"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uyn" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
@@ -41571,7 +41623,7 @@
 "uyz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "uyT" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/iron/half,
@@ -41708,7 +41760,7 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "uCf" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Freezers";
@@ -41736,7 +41788,7 @@
 	},
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "uCC" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
@@ -41757,7 +41809,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "uCP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42003,7 +42055,7 @@
 /area/commons/storage/primary)
 "uJv" = (
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "uJy" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
@@ -42077,6 +42129,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
+"uLH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "uMa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -42203,7 +42267,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uOT" = (
@@ -42330,7 +42394,7 @@
 	pixel_y = -30
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "uTh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42451,6 +42515,7 @@
 /area/maintenance/port/aft)
 "uVM" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
+	color = "#0000FF";
 	dir = 4;
 	pipe_color = "#0000FF"
 	},
@@ -42580,9 +42645,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uYE" = (
@@ -42626,7 +42690,7 @@
 /obj/item/aicard,
 /obj/item/multitool,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "uZK" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -42649,9 +42713,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/service/library)
-"vaN" = (
-/turf/closed/wall,
-/area/commons/fitness)
+"vaJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/iron/dark,
+/area/security/execution/education)
 "vbm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -42951,7 +43016,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "vlR" = (
 /obj/machinery/computer/teleporter{
 	dir = 8
@@ -43068,6 +43133,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
 "voM" = (
@@ -43232,7 +43298,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "vsl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -43280,7 +43346,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vsH" = (
@@ -43327,14 +43393,14 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "vtD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "vtY" = (
 /obj/machinery/button/door{
 	desc = "A remote control-switch for the engineering security doors.";
@@ -43506,12 +43572,12 @@
 "vxV" = (
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "vyd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "vye" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
@@ -43614,7 +43680,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "vzP" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -43632,7 +43698,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "vAe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -43827,7 +43893,7 @@
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "vEU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -43919,7 +43985,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "vHn" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -44040,9 +44106,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vJJ" = (
@@ -44062,7 +44128,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "vKu" = (
 /obj/effect/turf_decal/stripes,
 /obj/structure/cable,
@@ -44155,7 +44221,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "vNy" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44175,16 +44241,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"vOu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Plasma to Pure"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "vOD" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -44246,7 +44302,7 @@
 	dir = 8;
 	name = "N2 to Airmix"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vPT" = (
@@ -44262,7 +44318,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "vQo" = (
 /turf/closed/wall,
 /area/security/brig)
@@ -44275,7 +44331,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
-/area/command)
+/area/command/bridge)
 "vRx" = (
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
@@ -44434,7 +44490,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "vWf" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
@@ -44629,9 +44685,6 @@
 /area/engineering/main)
 "wbb" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -44733,9 +44786,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wfm" = (
@@ -44844,7 +44895,7 @@
 	},
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "wix" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood/tile,
@@ -44882,7 +44933,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "wjE" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -44936,11 +44987,10 @@
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "wlb" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "N2 to Pure"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wlQ" = (
@@ -44977,6 +45027,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wmw" = (
+/turf/closed/wall/r_wall,
+/area/command/corporate_showroom)
 "wmC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44992,7 +45045,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/command)
+/area/command/bridge)
 "wmK" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
@@ -45073,7 +45126,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "wqa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -45125,8 +45178,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -45392,12 +45443,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
-"wzY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wAs" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
@@ -45514,7 +45559,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "wCX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45525,7 +45570,7 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "wDi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -45571,7 +45616,7 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
-/area/command)
+/area/command/bridge)
 "wFs" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -45608,6 +45653,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "wGL" = (
@@ -45675,7 +45721,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "wIT" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral,
@@ -45810,7 +45856,7 @@
 	req_access_txt = "57"
 	},
 /turf/open/floor/wood,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "wLQ" = (
 /obj/structure/chair{
 	dir = 1
@@ -45930,6 +45976,12 @@
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
+"wOk" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wOt" = (
 /turf/open/floor/iron/grimy,
 /area/security/prison)
@@ -45945,6 +45997,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "wPl" = (
@@ -46004,7 +46057,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "wQR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -46064,7 +46117,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "wSC" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
@@ -46134,7 +46187,7 @@
 /obj/structure/table/glass,
 /obj/item/pen/fourcolor,
 /turf/open/floor/carpet/royalblue,
-/area/command)
+/area/command/bridge)
 "wTN" = (
 /turf/closed/wall,
 /area/science/server)
@@ -46150,7 +46203,7 @@
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "wUx" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -46166,11 +46219,11 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -46284,7 +46337,7 @@
 	pixel_y = 11
 	},
 /turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "wXQ" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -46295,7 +46348,7 @@
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "wXU" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
@@ -46345,7 +46398,7 @@
 "wZK" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "wZU" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
@@ -46371,8 +46424,8 @@
 	dir = 1;
 	name = "CO2 Outlet Pump"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -46434,6 +46487,10 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"xbI" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engineering/storage/tech)
 "xbN" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
@@ -46468,7 +46525,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "xcl" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
@@ -46510,6 +46567,13 @@
 	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
+"xcD" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "xds" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -46554,7 +46618,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "xee" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46590,7 +46654,7 @@
 	req_access_txt = "19"
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "xfF" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -46634,7 +46698,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/secondary/exit)
 "xhd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -46679,7 +46743,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "xjj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
@@ -46786,7 +46850,7 @@
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+/area/engineering/atmos/upper)
 "xlD" = (
 /turf/open/floor/iron,
 /area/security/prison)
@@ -46800,8 +46864,8 @@
 	dir = 1;
 	name = "Plasma to Mix"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -46852,7 +46916,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "xov" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -46893,7 +46957,7 @@
 	pixel_y = -32
 	},
 /turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hop)
+/area/command/corporate_showroom)
 "xoW" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
@@ -46943,7 +47007,7 @@
 /area/service/bar)
 "xqz" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "xqY" = (
@@ -47108,7 +47172,6 @@
 	dir = 4;
 	name = "N2O to Mix"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xtn" = (
@@ -47472,7 +47535,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "xBZ" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
@@ -47637,7 +47700,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "xFb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/item/banner/science/mundane,
@@ -47673,7 +47736,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "xFu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -48013,7 +48076,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "xSz" = (
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
@@ -48093,7 +48156,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/command)
+/area/command/bridge)
 "xVA" = (
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #1";
@@ -48129,7 +48192,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "xWy" = (
 /obj/structure/curtain,
 /obj/machinery/shower{
@@ -48235,7 +48298,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "xZz" = (
 /obj/structure/cable,
 /obj/structure/table/wood,
@@ -48303,11 +48366,11 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/genericbush,
 /turf/open/floor/grass,
-/area/hallway/secondary/exit)
+/area/hallway/secondary/exit/departure_lounge)
 "yaE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/commons/fitness)
+/area/commons/fitness/recreation)
 "yaR" = (
 /obj/item/wrench,
 /obj/item/stack/sheet/glass{
@@ -48546,9 +48609,7 @@
 /area/security/brig)
 "yfs" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "yfx" = (
@@ -48582,7 +48643,7 @@
 "yfW" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/solars/port/fore)
+/area/solars/port/fore)
 "yfY" = (
 /turf/closed/wall,
 /area/service/bar)
@@ -48730,11 +48791,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
-"yjE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/structure/reagent_dispensers/plumbed,
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "yjI" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -63041,7 +63097,7 @@ ygB
 ygB
 yin
 oFz
-iKe
+hfu
 oKE
 wAs
 lYY
@@ -63298,7 +63354,7 @@ nti
 iBp
 yin
 pLG
-wDc
+vaJ
 oGZ
 cDu
 klu
@@ -63307,7 +63363,7 @@ vyj
 uUm
 mFB
 asr
-xPV
+asr
 kGh
 aIM
 aLT
@@ -64149,14 +64205,14 @@ acs
 fuX
 ffW
 xzY
-sXJ
-xzY
-sXJ
-sXJ
-oIO
-xzY
-xzY
-xzY
+elh
+eIX
+aYx
+aYx
+xrE
+riF
+riF
+rGG
 xzY
 dlD
 iuZ
@@ -64406,14 +64462,14 @@ irn
 waO
 ffW
 xzY
-elh
-eIX
+xzY
+xzY
 xtg
 afo
-xrE
-dkt
-dkt
-rGG
+xzY
+xzY
+xzY
+wOk
 xzY
 xzY
 xzY
@@ -64670,7 +64726,7 @@ hTo
 wGl
 wGl
 fuX
-oIO
+wOk
 rCg
 sCk
 fPo
@@ -64927,7 +64983,7 @@ xyN
 oML
 fBy
 waO
-oIO
+wOk
 xzY
 cES
 vSM
@@ -65139,7 +65195,7 @@ aEk
 ocl
 aEk
 uFr
-fAT
+pLf
 bbx
 wOE
 xRi
@@ -65421,13 +65477,13 @@ wVb
 nsU
 xGp
 wVb
-wVb
-bnA
+rgD
+rgD
 hbZ
 aYg
 aYg
-bnA
-bnA
+rgD
+rgD
 sAA
 xzY
 tVv
@@ -65678,13 +65734,13 @@ gtO
 tPk
 sth
 sdT
-wVb
+rgD
 gXi
 fLG
 dyS
 doY
 xlt
-bnA
+rgD
 foE
 xzY
 xzY
@@ -65935,14 +65991,14 @@ fuD
 tPk
 gft
 btN
-wVb
+rgD
 rjq
 aVW
 tUn
-aoh
+lFd
 aoh
 aXA
-qiF
+tKp
 xzY
 xzY
 xzY
@@ -65950,12 +66006,12 @@ xzY
 qrH
 mWH
 xzY
-mWH
+ofl
 djS
 wZU
 sXJ
 waO
-oIO
+wOk
 xzY
 cES
 vSM
@@ -66192,13 +66248,13 @@ koO
 kwm
 sth
 gxY
-wVb
+rgD
 jtt
-bWb
+eJQ
 keN
 eJJ
 aKR
-bnA
+rgD
 dDI
 xzY
 xzY
@@ -66212,7 +66268,7 @@ djS
 xzY
 sXJ
 waO
-oIO
+wOk
 yfA
 cES
 fsz
@@ -66449,14 +66505,14 @@ koO
 kwm
 sth
 fNB
-wVb
+rgD
 oTN
 bWb
 iUe
 wjt
-bnA
-bnA
-sAA
+rgD
+rgD
+aYa
 xzY
 dbq
 xzY
@@ -66469,7 +66525,7 @@ djS
 jdo
 sXJ
 waO
-oIO
+wOk
 xzY
 cES
 vSM
@@ -66703,17 +66759,17 @@ tEu
 xKV
 wVb
 izR
-biL
-biL
-biL
+jUy
+jUy
+jUy
 qPA
-bWb
-aVW
+hKK
+mes
 lSx
 hDu
-bnA
+rgD
 xtn
-xzY
+pow
 xzY
 xzY
 xzY
@@ -66963,12 +67019,12 @@ cgq
 uOp
 nYz
 fye
-wVb
+rgD
 ghJ
 aYg
 vtD
 aYg
-bnA
+rgD
 tKp
 xzY
 xzY
@@ -66982,8 +67038,8 @@ mWH
 mWH
 vCv
 nYX
-tsk
-vOu
+jLj
+sVI
 mkM
 cES
 iJd
@@ -67479,14 +67535,14 @@ uOp
 biD
 wVb
 wTA
-iQy
+pow
 weO
 idL
 dtK
 epn
 wwK
 srf
-fMY
+elh
 gue
 dGd
 dGd
@@ -67754,7 +67810,7 @@ aYp
 xXh
 xxC
 waO
-oIO
+wOk
 ffT
 mVJ
 lpf
@@ -68003,7 +68059,7 @@ xzY
 elh
 uPB
 wGl
-hTo
+uye
 lfS
 lNY
 lNY
@@ -68011,7 +68067,7 @@ hTo
 rSV
 wGl
 lxn
-oIO
+wOk
 coG
 xzY
 xzY
@@ -68253,12 +68309,12 @@ iub
 lHU
 ips
 dax
-wzY
+loD
 oSP
 loD
 hIz
-hHr
-dkt
+aYx
+riF
 wRu
 wlb
 cjL
@@ -68266,8 +68322,8 @@ vPR
 eZw
 iMJ
 tPW
-dkt
-dkt
+riF
+riF
 qXP
 coG
 xwd
@@ -70043,7 +70099,7 @@ bhU
 bhZ
 siB
 wth
-wth
+xbI
 wWM
 sWg
 sWg
@@ -70301,7 +70357,7 @@ lfZ
 lfZ
 yaj
 icd
-tmy
+gaf
 gaf
 inV
 lJm
@@ -73086,8 +73142,8 @@ xke
 rPv
 rPv
 xke
-cBP
-vYu
+fcR
+ybn
 aaG
 dSu
 wXl
@@ -73343,10 +73399,10 @@ ecm
 bkL
 xMu
 eCf
-aRT
-vYu
+uLH
+ybn
 aaH
-dSR
+aei
 wXl
 ePD
 fTj
@@ -73600,10 +73656,10 @@ xke
 pWR
 bES
 eCf
-cBP
-vYu
+fcR
+ybn
 aby
-hze
+rUC
 wXl
 ePQ
 aQv
@@ -73667,8 +73723,8 @@ uVD
 xjx
 qtY
 vsQ
-vsQ
-vsQ
+ndb
+ndb
 vsQ
 pFC
 xSS
@@ -73859,8 +73915,8 @@ xke
 xke
 sVb
 cYy
-mDM
-dTm
+jUZ
+dWq
 wXl
 wyR
 aQv
@@ -74117,8 +74173,8 @@ cbY
 cEi
 vYu
 kgY
-vYu
-fSS
+ybn
+hBV
 rkx
 aQv
 ufR
@@ -74181,8 +74237,8 @@ jls
 cvJ
 vqR
 vqR
-vqR
-vqR
+jQl
+jQl
 vsQ
 vsQ
 vsQ
@@ -74371,11 +74427,11 @@ wyf
 wyf
 wyf
 ccl
-vYu
-vYu
+ybn
+ybn
 afa
-pGN
-pGN
+fiL
+fiL
 nfu
 jOj
 jYf
@@ -74628,11 +74684,11 @@ ykS
 xAw
 vUW
 hsp
+ybn
 vYu
-vYu
-mDM
-vYu
-fSS
+jUZ
+ybn
+hBV
 rkx
 aQv
 aQv
@@ -74885,9 +74941,9 @@ wKA
 nRK
 nRK
 eLv
-dCo
-dCo
-mDM
+oSV
+oSV
+jUZ
 dTp
 wXl
 wyR
@@ -75142,9 +75198,9 @@ vUW
 agP
 vUW
 ako
-vYu
-vYu
-mDM
+ybn
+ybn
+jUZ
 ahh
 wXl
 aDL
@@ -75399,9 +75455,9 @@ ykS
 agP
 vUW
 hsp
-vYu
-vYu
-mDM
+ybn
+ybn
+jUZ
 aDA
 wXl
 uyd
@@ -75656,10 +75712,10 @@ acU
 ims
 sYz
 cdc
-pLL
-pLL
+bdO
+bdO
 tyx
-aDB
+lHp
 wXl
 wyR
 pcs
@@ -75913,11 +75969,11 @@ wyf
 wyf
 wyf
 bEZ
-vYu
-vYu
-mDM
-vYu
-geF
+ybn
+ybn
+jUZ
+ybn
+xbT
 wXl
 wXl
 wXl
@@ -76171,9 +76227,9 @@ jcE
 aZO
 ced
 cMa
-vYu
-mDM
-vYu
+ybn
+jUZ
+ybn
 evM
 xtO
 fVP
@@ -76428,10 +76484,10 @@ sVb
 sVb
 sVb
 sVb
-cYZ
+bjJ
 mDM
-vYu
-gla
+ybn
+hPr
 xtO
 fVV
 sgN
@@ -76686,9 +76742,9 @@ uJa
 adN
 vwr
 xBN
-mDM
-bhe
-bhe
+jUZ
+oub
+oub
 eRj
 uMp
 sgN
@@ -76704,7 +76760,7 @@ tdq
 tdq
 tdq
 tdq
-bbt
+idf
 wWn
 xdE
 yar
@@ -76942,9 +76998,9 @@ hyd
 uJa
 hqh
 xyp
-vYu
-mDM
-vYu
+ybn
+jUZ
+ybn
 xvt
 xvt
 xvt
@@ -79581,9 +79637,9 @@ cxf
 wSA
 wSA
 qsm
-qde
+ito
 tLj
-qde
+ito
 nuD
 sRr
 jBo
@@ -79835,15 +79891,15 @@ meS
 otG
 tuj
 cxf
-gPg
-ulu
-ulu
+kHG
+azc
+azc
 gmz
 gmz
 gmz
 gmz
-ulu
-ulu
+azc
+azc
 ciA
 fjt
 eko
@@ -80093,14 +80149,14 @@ qBL
 tuj
 cxf
 xWs
-ulu
-ulu
+azc
+azc
 lLq
 kis
 hlE
 hIB
-ulu
-ulu
+azc
+azc
 ciA
 eko
 eko
@@ -80351,14 +80407,14 @@ lsi
 cxf
 tCO
 kMP
-ulu
+azc
 jTb
 rKn
 dqR
 rFE
-ulu
+azc
 kMP
-ulu
+azc
 uCO
 hoU
 kfI
@@ -80607,14 +80663,14 @@ otG
 aof
 cxf
 dDQ
-ssG
-ulu
+fBp
+azc
 vKo
 iwr
 vKo
 vKo
-ulu
-ssG
+azc
+fBp
 ciA
 eko
 eko
@@ -80864,14 +80920,14 @@ taP
 vZs
 jGd
 vtt
-ssG
-ulu
+fBp
+azc
 bsp
 bsp
 bsp
 bsp
-ulu
-ssG
+azc
+fBp
 ciA
 uBY
 eeM
@@ -81093,7 +81149,7 @@ vii
 xEd
 xEd
 xEd
-eWh
+gkm
 eAn
 gSu
 kGs
@@ -81109,26 +81165,26 @@ nGa
 mPj
 xgP
 wXQ
-tQR
+gPg
 cma
 muw
 wpS
 ihU
 ixO
 gOn
-cfI
-hEB
-bqm
+ulu
+stt
 mku
-ulu
-ssG
-ulu
+dpC
+azc
+fBp
+azc
 gmz
 gmz
 clu
 gmz
-ulu
-ssG
+azc
+fBp
 ciA
 tdN
 rTW
@@ -81282,7 +81338,7 @@ gfQ
 gfQ
 aig
 wYX
-cPb
+fWh
 ald
 qUs
 amh
@@ -81354,30 +81410,30 @@ pzd
 hEB
 kal
 fTC
-oMD
-hEB
-eHx
-eHx
-eHx
-hEB
-hEB
-hEB
-hEB
-hEB
-hEB
-fTC
-hEB
-hEB
-hEB
-hEB
-hEB
-hEB
-hEB
-sFT
-hEB
-oMD
 pty
 stt
+eHx
+eHx
+eHx
+stt
+stt
+stt
+stt
+stt
+stt
+htu
+stt
+stt
+stt
+stt
+stt
+stt
+stt
+sFT
+stt
+pty
+xcD
+dSQ
 qrr
 bHK
 inz
@@ -81611,38 +81667,38 @@ oOA
 cEJ
 kLj
 cfI
-bqm
-cfI
-cfI
-aSi
-ecN
-cfI
+mku
+ulu
+ulu
+sCG
+bXe
+ulu
 dNk
 gPP
 wCT
-cfI
-hEB
-jUM
-jUM
-cfI
-cfI
-cfI
-gPP
-gPP
-cfI
-cfI
-edc
-qCo
-mku
 ulu
+stt
+qde
+qde
+ulu
+ulu
+ulu
+gPP
+gPP
+ulu
+ulu
+ssG
+qCo
+dpC
+azc
 vPZ
-sCG
+tOi
 soK
 oDP
 soK
 nau
-sCG
-sCG
+tOi
+tOi
 tMS
 wUo
 rjv
@@ -81898,8 +81954,8 @@ bsp
 bsp
 uCA
 bsp
-ulu
-ulu
+azc
+azc
 tMS
 jjB
 fQn
@@ -82149,14 +82205,14 @@ kiF
 eUg
 cxf
 yaC
-ssG
+fBp
 mTd
 gmz
 gmz
 gmz
 gmz
-ulu
-ulu
+azc
+azc
 vHl
 eko
 eko
@@ -82406,15 +82462,15 @@ iXJ
 sis
 cxf
 vAa
-bXe
+tUV
 mTd
 nbb
 leO
 pZr
 cbm
-ulu
+azc
 gxR
-sCG
+tOi
 uCO
 hoU
 kfI
@@ -82637,7 +82693,7 @@ xcl
 aKN
 xcl
 hJP
-rJK
+rLe
 uio
 puT
 ezQ
@@ -82663,14 +82719,14 @@ vmQ
 vmQ
 cxf
 kvM
-ulu
+azc
 mTd
 ewg
 pnk
 fig
 gEA
-ulu
-ulu
+azc
+azc
 vHl
 eko
 eko
@@ -82894,22 +82950,22 @@ xcl
 kot
 xcl
 cfI
-rJK
+tdR
 pII
 anY
-dZA
-dZA
+puT
+puT
 buN
-dZA
-dZA
-dZA
-dZA
-dZA
-dZA
-dZA
-dZA
-dZA
-dZA
+puT
+puT
+puT
+puT
+puT
+qKN
+qKN
+qKN
+qKN
+qKN
 jFo
 qKN
 kNA
@@ -82920,14 +82976,14 @@ vmQ
 xrb
 cxf
 lyY
-ulu
+azc
 mTd
 vKo
 vKo
 vKo
 vKo
-ulu
-ulu
+azc
+azc
 vHl
 suB
 lpI
@@ -83151,7 +83207,7 @@ bQg
 brO
 xcl
 cfI
-rJK
+rLe
 daW
 anZ
 nXA
@@ -83166,7 +83222,7 @@ ciJ
 tEs
 mVv
 rYy
-dZA
+qKN
 jFo
 qKN
 sXR
@@ -83177,14 +83233,14 @@ xsM
 vmQ
 cxf
 jzC
-ulu
+azc
 dFh
 oyQ
 pWI
 lkO
 xFq
-ulu
-ulu
+azc
+azc
 vHl
 suB
 lpI
@@ -83930,8 +83986,8 @@ qYB
 qYB
 qYB
 qYB
-dZA
-dZA
+orD
+orD
 pBz
 mwH
 cND
@@ -84438,9 +84494,9 @@ pnn
 aiS
 rLe
 uio
-prw
+wmw
 cOX
-prw
+wmw
 tvz
 naM
 tTH
@@ -84695,11 +84751,11 @@ pnn
 wNb
 rJK
 nNO
-prw
+wmw
 rfU
-prw
-prw
-prw
+wmw
+wmw
+wmw
 tTH
 lcB
 bpf
@@ -85212,7 +85268,7 @@ uio
 fdc
 etA
 ppj
-unF
+nck
 xoP
 tTH
 aSF
@@ -85467,8 +85523,8 @@ rau
 rLe
 uio
 uln
-unF
-unF
+nck
+nck
 wXz
 tRi
 tTH
@@ -85668,10 +85724,10 @@ xNm
 xNm
 xNm
 mbr
-vaN
-vaN
-vaN
-vaN
+etj
+etj
+etj
+etj
 aMS
 yaE
 yaE
@@ -85723,10 +85779,10 @@ pnn
 cfI
 rLe
 dqJ
-prw
+wmw
 phe
 pko
-prw
+wmw
 wLK
 tTH
 tTH
@@ -85925,7 +85981,7 @@ rML
 pxw
 uvI
 uvI
-vaN
+etj
 xrI
 xrI
 xrI
@@ -85936,7 +85992,7 @@ xrI
 xrI
 xrI
 xrI
-eRs
+fYC
 ybn
 bjU
 lNJ
@@ -86182,7 +86238,7 @@ hIq
 kbg
 yiQ
 yiQ
-vaN
+etj
 xrI
 xrI
 xrI
@@ -86193,7 +86249,7 @@ xrI
 xrI
 xrI
 xrI
-eRs
+fYC
 ybn
 bjU
 sRL
@@ -86439,7 +86495,7 @@ hEh
 wrE
 yiQ
 aLr
-vaN
+etj
 xrI
 xrI
 xrI
@@ -86515,7 +86571,7 @@ tJB
 tJB
 tJB
 tJB
-dZA
+orD
 eQR
 xrZ
 pMJ
@@ -86696,7 +86752,7 @@ hEh
 wrE
 kbg
 aLr
-vaN
+etj
 xrI
 xrI
 xrI
@@ -86764,7 +86820,7 @@ dka
 cND
 qAe
 cND
-dZA
+orD
 pIs
 xch
 eWo
@@ -86772,7 +86828,7 @@ olc
 uqS
 idW
 xUU
-dZA
+orD
 nVl
 vmQ
 pMJ
@@ -86953,7 +87009,7 @@ uYE
 kbg
 wrE
 aLs
-vaN
+etj
 xrI
 xrI
 xrI
@@ -87021,7 +87077,7 @@ qxO
 cND
 qAe
 tpK
-dZA
+orD
 qCG
 qCG
 qCG
@@ -87030,7 +87086,7 @@ qCG
 qCG
 qCG
 hQU
-dZA
+orD
 vmQ
 pMJ
 tYw
@@ -87210,7 +87266,7 @@ hIq
 yiQ
 yiQ
 rsd
-vaN
+etj
 xrI
 xrI
 xrI
@@ -87235,8 +87291,8 @@ knV
 tRt
 rmB
 nCs
-yjE
-awt
+wVB
+evf
 qUD
 rWP
 tqR
@@ -87287,7 +87343,7 @@ cND
 cND
 cND
 uTe
-dZA
+orD
 vmQ
 pMJ
 tYw
@@ -87467,7 +87523,7 @@ hIq
 yiQ
 wrE
 aGM
-vaN
+etj
 xrI
 xrI
 xrI
@@ -87479,9 +87535,9 @@ xrI
 xrI
 xrI
 cQk
-uWM
-dAU
-uWM
+ybn
+bjU
+ybn
 vqN
 frP
 loU
@@ -87491,9 +87547,9 @@ jlf
 kor
 fnK
 evf
-evf
-wVB
-wVB
+awt
+nyO
+nyO
 dLn
 rWP
 trH
@@ -87522,9 +87578,9 @@ pay
 bqm
 wxp
 pDo
-fMz
-dZA
-dZA
+prw
+prw
+prw
 prw
 prw
 prw
@@ -87544,7 +87600,7 @@ nog
 gGT
 czj
 iKA
-dZA
+orD
 vmQ
 pMJ
 tYw
@@ -87724,7 +87780,7 @@ hIq
 kbg
 wrE
 wEK
-vaN
+etj
 xrI
 xrI
 xrI
@@ -87736,9 +87792,9 @@ xrI
 xrI
 xrI
 rnj
-uWM
-dAU
-uWM
+ybn
+bjU
+ybn
 vqN
 ftQ
 gjF
@@ -87801,7 +87857,7 @@ jaa
 kyk
 qAC
 hhS
-dZA
+orD
 sis
 pPE
 yam
@@ -87981,7 +88037,7 @@ hIq
 cuO
 yiQ
 yiQ
-vaN
+etj
 xrI
 xrI
 xrI
@@ -87993,9 +88049,9 @@ xrI
 xrI
 xrI
 rnj
-dgp
-dAU
-aOG
+dak
+bjU
+lHp
 vqN
 bff
 bff
@@ -88058,7 +88114,7 @@ hWE
 kyk
 qAC
 hcN
-dZA
+orD
 iHs
 lXm
 dZA
@@ -88238,10 +88294,10 @@ aLF
 rhH
 yiQ
 yiQ
-vaN
-vaN
-vaN
-vaN
+etj
+etj
+etj
+etj
 aNm
 yaE
 yaE
@@ -88250,16 +88306,16 @@ yaE
 yaE
 yaE
 cQk
-uWM
+ybn
 aOA
-idF
+bdO
 eCi
 wec
 wec
 wec
 wec
 wec
-wec
+kEG
 wec
 wec
 wec
@@ -88495,7 +88551,7 @@ ayE
 fVR
 aBz
 vhx
-vaN
+etj
 bSw
 aMz
 aMJ
@@ -88507,7 +88563,7 @@ bdP
 bmR
 bmR
 cQB
-dhi
+fiL
 dBp
 dYP
 pnn
@@ -88551,16 +88607,16 @@ uWM
 iMZ
 dld
 fkU
+qYB
+qYB
+qYB
+bvf
+bvf
+bvf
+bvf
 dZA
-dZA
-dZA
-dZA
-dZA
-dZA
-dZA
-dZA
-dZA
-dZA
+bvf
+orD
 hDh
 cND
 ume
@@ -88572,7 +88628,7 @@ jYl
 gAL
 qAC
 pOS
-dZA
+orD
 pHi
 rei
 ooP
@@ -88752,10 +88808,10 @@ ybK
 ybK
 kjj
 aLU
-vaN
-vaN
-vaN
-vaN
+etj
+etj
+etj
+etj
 aNa
 ahP
 aZZ
@@ -88817,7 +88873,7 @@ pKs
 qhd
 jyS
 cyB
-dZA
+orD
 bAf
 cND
 hHa
@@ -88829,7 +88885,7 @@ jaa
 gAL
 qAC
 gHq
-dZA
+orD
 pHi
 oUM
 eRN
@@ -89012,14 +89068,14 @@ wsd
 ybK
 wrE
 aVK
-vaN
-vaN
-vaN
-vaN
-vaN
-vaN
-vaN
-vaN
+etj
+etj
+etj
+etj
+etj
+etj
+etj
+etj
 cQk
 uWM
 dCO
@@ -89074,7 +89130,7 @@ ibR
 ulr
 pVR
 gqf
-dZA
+orD
 fjm
 uyz
 vyd
@@ -89086,7 +89142,7 @@ cgE
 mtq
 qAC
 aOP
-dZA
+orD
 rKi
 nIk
 oFA
@@ -89331,7 +89387,7 @@ tWI
 xjX
 pVR
 gAp
-dZA
+orD
 prx
 cND
 wZK
@@ -89343,7 +89399,7 @@ cND
 cND
 cND
 bXY
-dZA
+orD
 ryV
 nIk
 tZR
@@ -89588,7 +89644,7 @@ pbX
 jyS
 pVR
 gqf
-dZA
+orD
 iLN
 hhu
 iDr
@@ -89600,7 +89656,7 @@ bEN
 bEN
 uZE
 iDr
-dZA
+orD
 qZr
 nIk
 hXV
@@ -89845,9 +89901,9 @@ pVR
 mkm
 qVf
 hzU
-dZA
-dZA
-dZA
+orD
+orD
+orD
 wmJ
 wmJ
 irM
@@ -99340,21 +99396,21 @@ fsz
 fsz
 fsz
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 tSb
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 rpu
 fsz
 gfQ
@@ -99854,21 +99910,21 @@ gfQ
 gfQ
 fsz
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 tSb
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 fsz
 gfQ
@@ -100368,21 +100424,21 @@ gfQ
 gfQ
 fsz
 rpu
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 tSb
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 fsz
 gfQ
@@ -100882,21 +100938,21 @@ gfQ
 gfQ
 fsz
 rpu
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 tSb
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 rpu
 fsz
 fsz
@@ -101396,21 +101452,21 @@ gfQ
 fsz
 fsz
 rpu
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 tSb
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 fsz
 gfQ
@@ -101910,21 +101966,21 @@ gfQ
 gfQ
 fsz
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 tSb
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 rpu
 fsz
 fsz
@@ -102424,21 +102480,21 @@ fsz
 fsz
 fsz
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 tSb
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 rpu
 fsz
 fsz
@@ -102938,21 +102994,21 @@ gfQ
 gfQ
 fsz
 rpu
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 tSb
 gfQ
 qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
 rpu
 fsz
 fsz
@@ -103452,21 +103508,21 @@ fsz
 fsz
 fsz
 rpu
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 tSb
 gfQ
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 rpu
 fsz
 gfQ
@@ -103966,21 +104022,21 @@ gfQ
 gfQ
 fsz
 rpu
-qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
+iza
+iza
+iza
+iza
 gfQ
 tSb
 gfQ
+iza
+iza
+iza
 qms
-qms
-qms
-qms
-qms
-qms
+iza
+iza
 rpu
 fsz
 fsz

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -30,8 +30,6 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aao" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
@@ -53,12 +51,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -66,6 +58,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aaH" = (
@@ -76,12 +71,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -89,6 +78,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aaL" = (
@@ -148,7 +139,7 @@
 "aba" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
-/turf/open/floor/iron/airless/solarpanel,
+/turf/open/floor/iron/solarpanel,
 /area/maintenance/solars/port/fore)
 "abb" = (
 /turf/open/floor/plating,
@@ -191,13 +182,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "abB" = (
@@ -225,23 +212,14 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "abR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "abS" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "abT" = (
@@ -255,8 +233,8 @@
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "abV" = (
@@ -294,12 +272,8 @@
 /area/medical/virology)
 "abY" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "acb" = (
@@ -325,12 +299,16 @@
 	req_access_txt = "46"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/theater)
 "acf" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/clown,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/theater)
 "ach" = (
@@ -353,10 +331,15 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"acl" = (
+/obj/effect/spawner/scatter/grime,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aco" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "acp" = (
@@ -365,12 +348,17 @@
 	},
 /turf/closed/wall,
 /area/cargo/sorting)
+"acs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "act" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Cargo Bay Maintenance";
 	req_access_txt = "31"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "acw" = (
@@ -393,6 +381,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "acy" = (
@@ -418,6 +407,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "acC" = (
@@ -516,11 +506,8 @@
 /area/hallway/secondary/entry)
 "adr" = (
 /obj/structure/chair,
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 2581;
-	name = "Confessional Intercom";
-	pixel_x = 29
+/obj/item/radio/intercom/chapel{
+	pixel_x = 28
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
@@ -559,7 +546,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/east,
-/turf/open/floor/iron,
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "adD" = (
 /obj/structure/sign/directions/science{
@@ -588,8 +575,6 @@
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
@@ -617,9 +602,12 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"adN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "adP" = (
 /obj/item/trash/candy,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "adU" = (
@@ -629,8 +617,8 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "adV" = (
@@ -646,8 +634,8 @@
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "aec" = (
@@ -661,7 +649,8 @@
 /turf/open/floor/iron/airless,
 /area/space/nearstation)
 "aeh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -702,13 +691,6 @@
 	dir = 5
 	},
 /area/hallway/secondary/entry)
-"aev" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible,
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "aew" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -718,15 +700,10 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"aex" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "aey" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/airless,
@@ -762,8 +739,8 @@
 /area/space/nearstation)
 "aeI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "aeJ" = (
@@ -800,19 +777,9 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "aeO" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/rnd_secure,
-/obj/machinery/camera{
-	c_tag = "Secure Tech Storage"
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/storage/tech)
-"aeR" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
+/area/engineering/gravity_generator)
 "aeS" = (
 /obj/machinery/door/airlock/external{
 	name = "External Docking Port"
@@ -853,13 +820,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "afb" = (
@@ -881,11 +847,11 @@
 	},
 /area/hallway/secondary/entry)
 "afo" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
 	name = "N2O to Pure"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "afp" = (
@@ -995,12 +961,13 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "agj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "agk" = (
@@ -1009,8 +976,8 @@
 /area/security/prison)
 "agn" = (
 /obj/effect/landmark/start/assistant,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "ago" = (
@@ -1024,9 +991,7 @@
 /turf/open/space/basic,
 /area/space)
 "agq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "ags" = (
@@ -1039,12 +1004,8 @@
 	name = "Isolation B";
 	req_access_txt = "39"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "agw" = (
@@ -1072,10 +1033,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "agA" = (
@@ -1084,6 +1044,7 @@
 	pixel_y = 25
 	},
 /obj/item/storage/box/prisoner,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "agI" = (
@@ -1097,8 +1058,13 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "agN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
+"agP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/red,
+/area/service/chapel/main)
 "agQ" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -1155,18 +1121,20 @@
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "ahz" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "ahC" = (
 /obj/machinery/door/window/westleft{
 	name = "Kitchen"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "ahD" = (
@@ -1191,6 +1159,9 @@
 	c_tag = "Holodeck";
 	dir = 8;
 	network = list("ss13","rd")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/commons/fitness)
@@ -1237,35 +1208,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"ail" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"ais" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "aiu" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythree_twentythree,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
 "aix" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
 "aiA" = (
@@ -1293,7 +1242,7 @@
 /area/service/hydroponics/garden)
 "aiS" = (
 /obj/structure/table,
-/obj/item/trash/plate,
+/obj/item/plate,
 /obj/item/trash/chips,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -1315,30 +1264,16 @@
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "aje" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "ajg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/freezer,
-/area/security/prison)
-"ajo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "ajp" = (
@@ -1349,13 +1284,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "aju" = (
@@ -1365,8 +1297,8 @@
 /area/hallway/secondary/entry)
 "ajv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
 "ajA" = (
@@ -1394,6 +1326,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "ajO" = (
@@ -1439,16 +1372,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"ake" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "akf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1458,22 +1381,11 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"akg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "akh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "akj" = (
@@ -1498,60 +1410,18 @@
 /area/service/chapel/main)
 "akp" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "akq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
-/area/hallway/secondary/entry)
-"akw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"akx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"aky" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "akz" = (
 /obj/machinery/computer/prisoner/management{
@@ -1592,9 +1462,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Recreation"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "akR" = (
@@ -1611,13 +1481,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "akX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "alb" = (
@@ -1632,10 +1498,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ale" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
 "alf" = (
@@ -1648,10 +1514,14 @@
 	},
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"alh" = (
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "ali" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "alm" = (
@@ -1663,6 +1533,9 @@
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -1708,9 +1581,9 @@
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "alH" = (
@@ -1720,8 +1593,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "alJ" = (
-/obj/structure/cable,
-/obj/machinery/power/smes/engineering,
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "alL" = (
@@ -1739,17 +1613,17 @@
 /area/maintenance/solars/port/fore)
 "alN" = (
 /obj/structure/curtain,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "alO" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "alQ" = (
@@ -1765,41 +1639,8 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"alS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
-"alU" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"alY" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "amd" = (
@@ -1808,8 +1649,8 @@
 /area/hallway/secondary/entry)
 "ame" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "amg" = (
@@ -1930,9 +1771,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "amz" = (
@@ -1968,12 +1809,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "amL" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "amM" = (
@@ -1987,8 +1826,8 @@
 	name = "Evidence Storage";
 	req_access_txt = "63"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "amP" = (
@@ -2014,18 +1853,14 @@
 /area/security/checkpoint/auxiliary)
 "amT" = (
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
 "amU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
 "amV" = (
@@ -2044,21 +1879,17 @@
 	c_tag = "Arrivals Hallway - Sec Checkpoint";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
 "anb" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "anc" = (
@@ -2083,11 +1914,14 @@
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/item/kitchen/knife/plastic,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "ank" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "anq" = (
@@ -2206,9 +2040,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "aoa" = (
@@ -2253,15 +2087,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
 /area/security/prison)
-"aoC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "aoE" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -2270,12 +2095,6 @@
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
-"aoH" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "aoI" = (
 /obj/structure/grille/broken,
 /obj/machinery/light/small{
@@ -2292,6 +2111,17 @@
 	},
 /turf/open/floor/grass,
 /area/security/prison)
+"aoP" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/grass/jungle/b,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/service/library)
 "aoU" = (
 /obj/machinery/space_heater,
 /obj/structure/cable,
@@ -2341,17 +2171,7 @@
 /turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
 "apc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
-"apf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "apm" = (
@@ -2396,22 +2216,18 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
 "apA" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydrophonics"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "apC" = (
@@ -2440,13 +2256,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"apJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "apR" = (
 /obj/machinery/light{
 	dir = 8
@@ -2462,8 +2271,8 @@
 /area/security/prison)
 "apU" = (
 /obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "aqg" = (
@@ -2471,15 +2280,10 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/shaft_miner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"aqh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "aqs" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral{
@@ -2511,14 +2315,20 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
+"arc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "ark" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
 	req_access_txt = "1"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
 "arl" = (
@@ -2527,57 +2337,19 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"arm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
-"arp" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "arq" = (
 /obj/machinery/door/airlock/security{
 	name = "Perma Brig"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "arv" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
-"arw" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
-"arx" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "arz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -2611,8 +2383,8 @@
 /turf/open/floor/plating,
 /area/service/chapel/office)
 "arN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "arP" = (
@@ -2716,12 +2488,8 @@
 /turf/open/floor/plating,
 /area/service/chapel/main)
 "asl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "asm" = (
@@ -2742,12 +2510,8 @@
 /area/engineering/atmos)
 "asr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "ass" = (
@@ -2767,9 +2531,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "asD" = (
@@ -2890,6 +2654,7 @@
 /area/maintenance/starboard)
 "atn" = (
 /obj/effect/landmark/blobstart,
+/obj/effect/landmark/start/chaplain,
 /turf/open/floor/carpet/red,
 /area/service/chapel/main)
 "ato" = (
@@ -2912,16 +2677,9 @@
 	c_tag = "Chapel Crematorium";
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"att" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "atw" = (
 /obj/machinery/door/airlock/maintenance/glass{
 	name = "Mass Driver Airlock";
@@ -2931,45 +2689,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aty" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"atB" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "atC" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "atE" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "atK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "atL" = (
@@ -2977,21 +2712,9 @@
 	codes_txt = "patrol;next_patrol=3";
 	location = "2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
-"atN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "atQ" = (
@@ -3020,12 +2743,14 @@
 	pixel_x = -8;
 	pixel_y = 30
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "atX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "auf" = (
@@ -3033,12 +2758,14 @@
 	name = "Crematorium";
 	req_access_txt = "27"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "aug" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "auj" = (
@@ -3075,6 +2802,7 @@
 	pixel_y = -20
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "aun" = (
@@ -3082,6 +2810,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "aup" = (
@@ -3100,6 +2829,7 @@
 /area/medical/medbay/central)
 "auA" = (
 /obj/structure/table/wood,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "auH" = (
@@ -3107,11 +2837,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "auJ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/old,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "auR" = (
@@ -3135,10 +2867,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "avd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "avf" = (
@@ -3161,32 +2893,12 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
-"avl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
-"avp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
 "avq" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Viewing Room";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
-"avr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "avw" = (
@@ -3208,13 +2920,6 @@
 	},
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
-/turf/open/floor/iron/sepia,
-/area/service/chapel/office)
-"avy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "avz" = (
@@ -3291,16 +2996,9 @@
 /obj/item/food/grown/harebell,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
-"awb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
 "awc" = (
 /obj/structure/closet/crate/coffin,
-/turf/open/floor/iron/sepia,
+/turf/open/floor/carpet/black,
 /area/service/chapel/main)
 "awf" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3325,28 +3023,23 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/main)
-"awl" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Room";
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "awm" = (
 /obj/machinery/camera{
 	c_tag = "Fore Port Solar Access"
 	},
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aws" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "awu" = (
@@ -3390,6 +3083,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "awR" = (
@@ -3424,14 +3118,18 @@
 	},
 /turf/open/floor/plating,
 /area/service/chapel/main)
+"awZ" = (
+/obj/effect/landmark/start/librarian,
+/turf/open/floor/carpet/green,
+/area/service/library)
 "axb" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin/empty,
 /turf/open/floor/iron,
 /area/security/prison)
 "axd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "axk" = (
@@ -3442,26 +3140,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/theater)
-"axl" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "axn" = (
 /obj/structure/window{
 	dir = 1
@@ -3480,6 +3162,14 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
+"axv" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/service/hydroponics)
 "axz" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -3521,9 +3211,7 @@
 /area/service/chapel/office)
 "axO" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "axU" = (
@@ -3545,6 +3233,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "axZ" = (
@@ -3579,23 +3268,17 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "ayo" = (
 /obj/machinery/light/small,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/obj/structure/table,
+/obj/item/clothing/suit/armor/vest,
+/obj/item/restraints/handcuffs,
+/turf/open/floor/plating,
 /area/security/brig)
-"ayq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
 "ayr" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
@@ -3604,13 +3287,13 @@
 /obj/structure/chair/sofa/right{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "ayu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "ayA" = (
@@ -3629,9 +3312,8 @@
 "ayD" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "ayE" = (
@@ -3656,8 +3338,8 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Visiting Room"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "ayK" = (
@@ -3665,26 +3347,18 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/iron/sepia,
+/turf/open/floor/carpet/black,
 /area/service/chapel/main)
 "ayQ" = (
 /turf/open/floor/carpet/red,
 /area/service/chapel/office)
-"ayT" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
 "ayX" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm3";
 	name = "Dorm 3"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "azd" = (
@@ -3692,16 +3366,10 @@
 	id_tag = "Dorm4";
 	name = "Dorm 4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"aze" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "azg" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -3714,12 +3382,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "azD" = (
@@ -3733,12 +3397,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "azF" = (
@@ -3754,12 +3414,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "azJ" = (
@@ -3773,16 +3429,12 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Brig Prison Hallway North East";
 	network = list("ss13","prison")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "azM" = (
@@ -3799,12 +3451,9 @@
 	pixel_y = 30
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "azS" = (
@@ -3813,9 +3462,8 @@
 	dir = 1
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "azZ" = (
@@ -3841,36 +3489,14 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aAi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"aAm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"aAn" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel Viewing Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
 "aAr" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel Office";
 	req_access_txt = "22"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "aAs" = (
@@ -3880,16 +3506,6 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
-"aAw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "aAD" = (
 /obj/item/reagent_containers/spray/plantbgone,
 /obj/item/reagent_containers/spray/pestspray{
@@ -3932,12 +3548,10 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "aAM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "aAN" = (
@@ -3945,26 +3559,8 @@
 	id_tag = "Dorm2";
 	name = "Dorm 2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
-"aAO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
-"aAP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aAS" = (
@@ -3977,12 +3573,8 @@
 /obj/machinery/camera{
 	c_tag = "Dormitory North"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aAZ" = (
@@ -4001,21 +3593,8 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
-"aBf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aBn" = (
@@ -4043,9 +3622,7 @@
 /area/commons/dorms)
 "aBp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aBx" = (
@@ -4065,11 +3642,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/fore)
-"aBA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "aBF" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -4098,12 +3670,6 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/grass,
 /area/service/chapel/main)
-"aBU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
 "aBX" = (
 /obj/structure/chair{
 	dir = 8
@@ -4115,28 +3681,14 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aBZ" = (
 /turf/open/floor/plating,
 /area/service/chapel/main)
-"aCe" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "aCs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "aCz" = (
@@ -4161,20 +3713,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron,
 /area/security/brig)
-"aCC" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure Bypass"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "aCL" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aCP" = (
@@ -4213,10 +3757,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aDx" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "aDA" = (
 /obj/structure/noticeboard{
 	dir = 1;
@@ -4234,7 +3774,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aDL" = (
-/obj/structure/bookcase/random/reference,
+/obj/structure/table/wood/fancy/royalblue,
+/obj/machinery/door/window{
+	name = "Secure Art Exhibition";
+	req_access_txt = "37"
+	},
+/obj/structure/sign/painting/library_secure{
+	pixel_y = 32
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/service/library)
 "aDT" = (
@@ -4250,9 +3800,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aDZ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -4269,6 +3816,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aEe" = (
@@ -4324,10 +3872,8 @@
 	name = "Chapel Maintenance";
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aFh" = (
@@ -4351,13 +3897,9 @@
 /obj/machinery/door/airlock/vault{
 	req_access_txt = "53"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ai_monitored/command/nuke_storage)
 "aFv" = (
@@ -4370,19 +3912,15 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aFE" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "aFQ" = (
@@ -4394,17 +3932,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aFY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/door/airlock{
 	name = "Law Office";
 	req_access_txt = "38"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "aGa" = (
@@ -4421,13 +3955,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "aGg" = (
@@ -4474,8 +4004,8 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aGy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aGA" = (
@@ -4502,6 +4032,7 @@
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "aGM" = (
@@ -4510,12 +4041,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aGO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "aGP" = (
@@ -4523,9 +4051,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "aGY" = (
@@ -4556,15 +4082,6 @@
 /area/cargo/sorting)
 "aHo" = (
 /obj/structure/chair/office{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/sorting)
-"aHt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -4608,11 +4125,8 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	broadcasting = 1;
-	frequency = 2581;
-	name = "Confessional Intercom";
-	pixel_x = 29
+/obj/item/radio/intercom/chapel{
+	pixel_x = 28
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/main)
@@ -4642,15 +4156,16 @@
 /area/commons/storage/primary)
 "aIg" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aIp" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "aIr" = (
@@ -4710,8 +4225,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "aIN" = (
@@ -4758,12 +4273,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
-"aJk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
 "aJm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -4784,13 +4293,14 @@
 	icon_state = "right";
 	name = "Brig Infirmary"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "aJt" = (
@@ -4818,13 +4328,9 @@
 /area/commons/fitness)
 "aJL" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aJQ" = (
@@ -4834,9 +4340,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aJR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aJU" = (
@@ -4918,10 +4422,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "aKw" = (
@@ -4935,18 +4437,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "aKN" = (
 /turf/open/space/basic,
 /area/medical/virology)
 "aKO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "aKP" = (
@@ -4982,7 +4480,7 @@
 /area/commons/dorms)
 "aLn" = (
 /obj/machinery/bookbinder,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/service/library)
 "aLr" = (
 /obj/machinery/space_heater,
@@ -5022,16 +4520,14 @@
 /area/commons/dorms)
 "aLT" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "aLU" = (
@@ -5097,7 +4593,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aMS" = (
@@ -5146,8 +4642,8 @@
 "aNj" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aNm" = (
@@ -5209,19 +4705,17 @@
 "aNC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aNG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aNJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aNM" = (
@@ -5238,11 +4732,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"aNW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "aNY" = (
 /obj/structure/table,
 /obj/item/hatchet,
@@ -5266,6 +4755,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/range)
 "aOi" = (
@@ -5284,6 +4774,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "aOk" = (
@@ -5307,47 +4798,9 @@
 /area/security/prison)
 "aOo" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
-"aOw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
-"aOx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aOz" = (
@@ -5365,13 +4818,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "aOG" = (
@@ -5410,21 +4859,27 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
+"aOX" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engineering/atmos)
 "aOZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "aPd" = (
-/obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
@@ -5544,8 +4999,25 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/iron/white,
 /area/security/brig)
+"aPZ" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "aQa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -5623,16 +5095,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aQu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "aQv" = (
@@ -5716,11 +5186,6 @@
 	name = "black plastitanium floor"
 	},
 /area/service/bar)
-"aQW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/medical/virology)
 "aQX" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -5759,12 +5224,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"aRi" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/service/bar)
 "aRn" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -5822,6 +5281,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aRG" = (
@@ -5855,10 +5315,8 @@
 /area/security/detectives_office)
 "aRL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "aRW" = (
@@ -5872,39 +5330,28 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "aSi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "aSv" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "aSx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "aSz" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/four,
 /obj/item/stack/cable_coil,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "aSD" = (
@@ -5968,21 +5415,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aTf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/sepia,
+/turf/open/floor/carpet/red,
 /area/service/chapel/main)
 "aTl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "aTn" = (
@@ -6004,26 +5447,17 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aTv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"aTx" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Tech Storage";
-	req_access_txt = "19;23"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "aTy" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
@@ -6065,17 +5499,11 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"aTL" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
 "aTM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aTR" = (
@@ -6084,12 +5512,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aTT" = (
@@ -6097,41 +5521,15 @@
 	name = "Garden"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aTV" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
 /turf/open/floor/plating,
 /area/engineering/main)
-"aTY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
-"aTZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "aUa" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -6158,11 +5556,6 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
-"aUf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/turf/open/floor/engine,
-/area/engineering/main)
 "aUg" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
@@ -6173,12 +5566,6 @@
 /obj/item/paicard,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
-"aUi" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/turf/open/floor/engine,
-/area/engineering/main)
 "aUj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -6210,15 +5597,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/fore)
-"aUv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "aUx" = (
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/structure/closet/crate,
@@ -6268,7 +5646,7 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "aUI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers,
 /turf/open/floor/iron,
 /area/engineering/main)
 "aUK" = (
@@ -6317,18 +5695,13 @@
 /turf/open/floor/carpet/red,
 /area/service/chapel/main)
 "aVc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/sepia,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/red,
 /area/service/chapel/main)
 "aVe" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -6348,21 +5721,20 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "aVq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aVr" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+/obj/machinery/atmospherics/components/binary/thermomachine/heater{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -6372,7 +5744,7 @@
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "aVw" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -6441,20 +5813,9 @@
 "aVQ" = (
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
-"aVU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "aVW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "aWe" = (
@@ -6477,24 +5838,20 @@
 	dir = 1;
 	network = list("ss13","engine")
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aWg" = (
-/obj/machinery/atmospherics/components/trinary/filter/critical{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4;
+	filter_type = "n2"
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "aWk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aWq" = (
@@ -6502,16 +5859,13 @@
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "aWt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "aWu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "aWv" = (
@@ -6521,6 +5875,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/service/chapel/main)
 "aWw" = (
@@ -6531,10 +5887,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "aWJ" = (
@@ -6548,7 +5902,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -6568,6 +5922,7 @@
 	pixel_y = 11
 	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aWP" = (
@@ -6634,13 +5989,19 @@
 /area/maintenance/starboard/fore)
 "aXk" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
+	dir = 4;
 	name = "Cold Loop Bypass"
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "aXp" = (
 /obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"aXr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aXs" = (
@@ -6651,14 +6012,14 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "aXG" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "aXM" = (
@@ -6673,32 +6034,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"aXN" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
-"aXQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
-"aXT" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "aXZ" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -6713,17 +6048,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"aYc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "aYe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
@@ -6753,35 +6077,18 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aYs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"aYt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aYz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aYB" = (
@@ -6812,12 +6119,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aYH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "aYI" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/carpet/black,
@@ -6864,6 +6165,7 @@
 /area/maintenance/starboard/fore)
 "aYO" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/range)
 "aYP" = (
@@ -6882,6 +6184,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "aYQ" = (
@@ -6896,12 +6199,10 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "aYU" = (
@@ -6944,44 +6245,21 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"aZc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "aZe" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/dorms)
-"aZf" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aZh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aZi" = (
@@ -7001,7 +6279,7 @@
 	pixel_y = 11
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aZk" = (
@@ -7026,6 +6304,7 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aZp" = (
@@ -7141,11 +6420,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aZT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aZV" = (
@@ -7161,10 +6438,6 @@
 /obj/structure/closet/wardrobe/grey,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"aZY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "aZZ" = (
 /obj/structure/closet/boxinggloves,
 /turf/open/floor/iron,
@@ -7173,13 +6446,10 @@
 /obj/effect/decal/cleanable/food/egg_smudge,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"bab" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "bai" = (
 /obj/machinery/rnd/production/techfab/department/service,
-/turf/open/floor/iron,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "bak" = (
 /obj/effect/turf_decal/tile/green{
@@ -7238,6 +6508,7 @@
 /area/ai_monitored/command/nuke_storage)
 "baE" = (
 /obj/structure/closet/secure_closet/hos,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "baK" = (
@@ -7266,20 +6537,13 @@
 	dir = 6
 	},
 /area/hallway/secondary/entry)
-"bbe" = (
-/obj/structure/rack,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/spawner/lootdrop/techstorage/tcomms,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "bbf" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "bbj" = (
@@ -7301,43 +6565,38 @@
 /area/security/office)
 "bbt" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/central)
 "bbw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/botanist,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "bbx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/turf/open/floor/iron/smooth_half,
+/area/engineering/gravity_generator)
 "bbB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
 /turf/open/floor/engine,
 /area/engineering/main)
 "bbI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "bbP" = (
@@ -7349,6 +6608,7 @@
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
 "bbR" = (
@@ -7386,13 +6646,9 @@
 	name = "ce sorting disposal pipe";
 	sortType = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bcd" = (
@@ -7417,7 +6673,6 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/item/storage/firstaid/regular,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -7469,9 +6724,9 @@
 /area/ai_monitored/security/armory)
 "bcB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "bcE" = (
@@ -7481,12 +6736,6 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
 /area/service/chapel/main)
-"bcH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "bcN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7513,15 +6762,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "bcX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"bcZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/office)
 "bda" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -7555,11 +6798,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
-"bdC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
 "bdG" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/cable,
@@ -7587,23 +6825,17 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"bdM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/commons/storage/primary)
 "bdO" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bdP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "bdR" = (
@@ -7618,6 +6850,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "bdX" = (
@@ -7633,6 +6866,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"bdY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/cafeteria,
+/area/maintenance/central)
 "bdZ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
@@ -7649,21 +6886,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"beg" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/item/stock_parts/cell/high/plus,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "bel" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -7671,6 +6898,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "beo" = (
@@ -7689,6 +6918,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "bet" = (
@@ -7697,18 +6927,31 @@
 /area/service/kitchen)
 "beu" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"bex" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator";
+	req_access_txt = "11"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "bez" = (
 /turf/open/floor/iron,
 /area/security/brig)
+"beC" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/cyan,
+/area/hallway/primary/port)
 "beE" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -7720,11 +6963,12 @@
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "beI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "beJ" = (
 /obj/effect/decal/cleanable/food/plant_smudge,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/fore)
 "beK" = (
@@ -7740,20 +6984,20 @@
 /area/maintenance/fore)
 "beN" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "beO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "beP" = (
@@ -7763,6 +7007,7 @@
 	name = "Psychology RC";
 	pixel_y = -30
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "beV" = (
@@ -7774,10 +7019,6 @@
 	dir = 4;
 	network = list("ss13","rd")
 	},
-/turf/open/floor/iron/dark,
-/area/science/nanite)
-"beX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "beZ" = (
@@ -7813,8 +7054,14 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
+"bfu" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bfv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -7850,34 +7097,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"bfM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "bfQ" = (
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/iron,
 /area/maintenance/fore)
-"bfR" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "bfS" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Surgical Suite";
 	req_access_txt = "5"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "bfT" = (
@@ -7903,11 +7134,10 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "bgb" = (
-/obj/structure/table,
-/obj/item/electronics/apc,
-/obj/item/electronics/airlock,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
+/area/engineering/gravity_generator)
 "bge" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -7928,9 +7158,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bgn" = (
@@ -7963,22 +7193,6 @@
 "bgt" = (
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"bgz" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "bgD" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -7996,38 +7210,11 @@
 /area/engineering/main)
 "bgK" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"bgL" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
-"bgN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/medical/virology)
 "bgQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -8038,24 +7225,25 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bgV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"bgX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/engineering/storage/tech)
+/obj/machinery/camera{
+	c_tag = "Gravity Generator Room";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "bgY" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "bhd" = (
@@ -8088,9 +7276,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "bhk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "bhm" = (
@@ -8098,7 +7286,7 @@
 /area/service/hydroponics)
 "bhq" = (
 /obj/structure/sign/warning/electricshock,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/hallway/primary/port)
 "bhr" = (
 /obj/structure/closet/emcloset,
@@ -8131,13 +7319,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "bhD" = (
@@ -8147,9 +7332,6 @@
 "bhF" = (
 /obj/structure/cable,
 /obj/effect/loot_site_spawner,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bhG" = (
@@ -8161,6 +7343,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bhL" = (
@@ -8168,9 +7351,9 @@
 	name = "Engineering Foyer";
 	req_one_access_txt = "10;24"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "bhR" = (
@@ -8206,9 +7389,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "bhX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/bar)
 "bhZ" = (
@@ -8225,11 +7407,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
-"bii" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/layer1,
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/main)
 "bim" = (
 /obj/machinery/light{
 	dir = 8
@@ -8238,33 +7415,38 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bio" = (
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
-"bir" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
-"bix" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = -1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
-"biy" = (
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/multitool,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
+"bir" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
+"biy" = (
+/obj/structure/table,
+/obj/item/electronics/apc,
+/obj/item/electronics/apc,
+/obj/item/electronics/apc,
+/obj/item/aicard,
+/obj/item/assembly/flash/handheld,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "biz" = (
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "biD" = (
@@ -8272,16 +7454,13 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "biF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "biL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "biM" = (
@@ -8291,13 +7470,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "biP" = (
@@ -8320,6 +7495,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
+"biV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/tcommsat/computer)
 "biW" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/iron,
@@ -8438,13 +7620,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bjS" = (
@@ -8480,13 +7658,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bjV" = (
@@ -8505,13 +7679,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bjW" = (
@@ -8528,74 +7698,19 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bjZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
-"bka" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
-"bkb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/cafeteria,
-/area/service/kitchen)
-"bkc" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
 /area/service/kitchen)
 "bkd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
-"bkf" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bkg" = (
@@ -8637,14 +7752,16 @@
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bkk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/holosign_creator/robot_seat/restaurant,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "bko" = (
@@ -8667,13 +7784,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "bku" = (
@@ -8715,24 +7828,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"bkS" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "bkU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -8785,8 +7883,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "blg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "bll" = (
@@ -8833,12 +7931,12 @@
 /area/security/courtroom)
 "blG" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "blU" = (
@@ -8865,8 +7963,8 @@
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "bmR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "bnh" = (
@@ -8881,7 +7979,7 @@
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/supermatter)
 "bny" = (
@@ -8899,7 +7997,7 @@
 "bnV" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "boc" = (
@@ -8928,12 +8026,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "boH" = (
@@ -8950,6 +8042,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "bpf" = (
@@ -8961,24 +8054,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/brig)
-"bpR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "bqb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bqm" = (
@@ -8995,10 +8074,10 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "bqU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "bqY" = (
@@ -9074,6 +8153,7 @@
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "brE" = (
@@ -9085,16 +8165,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"brG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "brH" = (
 /obj/machinery/door/airlock{
 	name = "Unit 1"
@@ -9118,9 +8188,8 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/airless,
 /area/medical/virology)
 "brU" = (
@@ -9176,25 +8245,17 @@
 	id_tag = "Dorm1";
 	name = "Dorm 1"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "bsy" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "bsI" = (
@@ -9202,17 +8263,14 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bsK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "bsU" = (
 /obj/structure/table_frame,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/fore)
 "btl" = (
@@ -9236,6 +8294,7 @@
 /area/maintenance/starboard/fore)
 "btv" = (
 /obj/structure/table/wood,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "btz" = (
@@ -9260,19 +8319,17 @@
 /area/commons/toilet)
 "btH" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "btK" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/ai,
+/obj/structure/cable,
+/obj/machinery/power/terminal,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/engineering/storage/tech)
+/area/engineering/gravity_generator)
 "btN" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility,
@@ -9312,8 +8369,8 @@
 	name = "Custodial Closet";
 	req_access_txt = "26"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "buJ" = (
@@ -9356,6 +8413,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"bvo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "bvu" = (
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
@@ -9366,14 +8427,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
+"bwc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "bwh" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Brig Prison Hallway North West";
 	network = list("ss13","prison")
@@ -9384,6 +8444,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "bwn" = (
@@ -9403,21 +8465,18 @@
 "bxg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "bxj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "bxt" = (
@@ -9450,11 +8509,19 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
+"byj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium{
+	name = "black plastitanium floor"
+	},
+/area/service/bar)
 "bzj" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -9465,12 +8532,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bzt" = (
@@ -9495,16 +8558,16 @@
 	name = "Prisoner Processing";
 	req_access_txt = "2"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "bAf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "bAi" = (
@@ -9517,19 +8580,17 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "bAz" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "bAE" = (
@@ -9555,9 +8616,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "bAP" = (
@@ -9579,6 +8638,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
 "bCa" = (
@@ -9648,32 +8709,12 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter)
 "bFZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"bGE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
 "bGI" = (
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
-"bGQ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/service/chapel/main)
 "bHK" = (
 /obj/machinery/camera{
 	c_tag = "Escape North";
@@ -9697,25 +8738,15 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"bIg" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/carpet/red,
-/area/service/chapel/main)
+"bIf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "bIx" = (
 /obj/structure/table,
 /obj/item/storage/crayons{
@@ -9729,22 +8760,15 @@
 /turf/open/floor/iron,
 /area/commons/storage/art)
 "bIZ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bJr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bJu" = (
@@ -9793,12 +8817,12 @@
 /area/commons/toilet)
 "bKm" = (
 /obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "bKt" = (
@@ -9816,6 +8840,7 @@
 	dir = 8;
 	pixel_x = 11
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "bLd" = (
@@ -9823,15 +8848,16 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"bLy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"bMB" = (
-/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+"bMD" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/grass,
+/area/service/library)
 "bMN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9853,13 +8879,13 @@
 	id = "atmos";
 	name = "Atmospherics Blast Door"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNd" = (
@@ -9880,16 +8906,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/biohazard,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/medical/virology)
-"bQh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bQv" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/space_heater,
@@ -9909,15 +8929,10 @@
 	network = list("ss13","prison")
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "bQF" = (
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/range)
 "bRe" = (
@@ -9935,8 +8950,15 @@
 	id = "briglockdown";
 	name = "brig shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/warden)
+"bRN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "bSh" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -9986,14 +9008,12 @@
 "bTh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/security/brig)
 "bTm" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bTw" = (
@@ -10009,9 +9029,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"bTW" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "bUm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -10022,25 +9047,23 @@
 /obj/machinery/light,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"bUR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "bUU" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
 	req_one_access_txt = "22;25;26;28;35;37;38;46"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "bVm" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/carpet/black,
 /area/service/bar)
+"bVO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/warden)
 "bVR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
 	dir = 1
@@ -10051,6 +9074,29 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
+"bWC" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/engine_smes)
+"bWS" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "bXe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -10059,11 +9105,17 @@
 /area/hallway/secondary/exit)
 "bXi" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"bXN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "bXO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -10118,6 +9170,15 @@
 "bYN" = (
 /turf/closed/wall,
 /area/cargo/warehouse)
+"bZn" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Bar"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/service/bar)
 "bZD" = (
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/iron,
@@ -10129,13 +9190,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"caq" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "caO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
@@ -10200,15 +9254,6 @@
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/grass,
 /area/service/chapel/main)
-"ccb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/command)
 "ccc" = (
 /obj/machinery/camera{
 	c_tag = "Firing Range";
@@ -10227,6 +9272,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "ccg" = (
@@ -10238,7 +9284,8 @@
 /area/ai_monitored/turret_protected/ai)
 "cch" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "ccl" = (
 /obj/structure/window{
@@ -10252,9 +9299,7 @@
 /turf/open/floor/grass,
 /area/service/chapel/main)
 "cco" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "ccQ" = (
@@ -10263,15 +9308,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"ccY" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/public/glass{
-	name = "Chapel"
-	},
-/turf/open/floor/iron,
-/area/service/chapel/main)
 "cdc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -10293,13 +9329,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
+"cdD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "cdG" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -10312,6 +9351,12 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"cdK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cdQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/atmos/air_output{
 	dir = 8
@@ -10332,6 +9377,13 @@
 /obj/item/multitool,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"ceP" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/cyan,
+/area/hallway/primary/port)
 "ceQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -10345,9 +9397,7 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "cff" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "cfz" = (
@@ -10363,24 +9413,21 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "cfC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cfI" = (
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cfZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
 	},
@@ -10390,12 +9437,8 @@
 	c_tag = "Dormitory Toilets";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "cgp" = (
@@ -10408,12 +9451,8 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -10424,6 +9463,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "cgG" = (
@@ -10432,6 +9472,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cgH" = (
@@ -10440,11 +9482,20 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
+"cgJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/execution/transfer)
 "cgN" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
 "cgS" = (
@@ -10454,14 +9505,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"cgW" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "chj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -10471,10 +9514,9 @@
 /area/command/gateway)
 "chl" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "cir" = (
 /obj/structure/table,
@@ -10493,22 +9535,22 @@
 /area/hallway/secondary/exit)
 "ciF" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "ciJ" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "ciT" = (
@@ -10517,12 +9559,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"cjv" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/command)
 "cjL" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "N2 to Mix"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ckf" = (
@@ -10530,24 +9584,10 @@
 	dir = 5
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
-"cki" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/exam_room)
 "ckn" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -10561,6 +9601,16 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"ckw" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "cln" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -30
@@ -10609,14 +9659,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "cmf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "cmm" = (
@@ -10626,6 +9674,8 @@
 	name = "disposals sorting disposal pipe";
 	sortType = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -10650,30 +9700,14 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/iron,
 /area/medical/exam_room)
-"cnX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "cof" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"cos" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/command)
 "coG" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/violet{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -10691,21 +9725,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"cqB" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
-"cqL" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+"cro" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "crC" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
@@ -10728,21 +9752,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "csT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "csU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/engine,
 /area/engineering/main)
 "cti" = (
@@ -10758,12 +9776,8 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "ctG" = (
@@ -10780,14 +9794,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"ctV" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/prison)
 "cuq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -10802,6 +9808,7 @@
 	c_tag = "Hydrophonics Backroom";
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "cuz" = (
@@ -10817,20 +9824,25 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"cuJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+"cuO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/command)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "cuY" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"cvJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cvX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10842,10 +9854,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cwc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "cwg" = (
@@ -10853,6 +9863,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cwr" = (
@@ -10878,18 +9889,26 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"cwS" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "cwX" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/security/execution/transfer)
+"cwY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet/black,
+/area/maintenance/starboard/aft)
 "cxf" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit)
@@ -10901,12 +9920,6 @@
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
 	req_access_txt = "20"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
@@ -10922,7 +9935,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "cyz" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -10958,10 +9971,10 @@
 /area/engineering/main)
 "czQ" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/space/basic,
 /area/space/nearstation)
 "czY" = (
@@ -10970,6 +9983,8 @@
 	req_one_access_txt = "22;25;26;28;35;37;38;46"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "cAB" = (
@@ -11003,18 +10018,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/maintenance/starboard/aft)
-"cAV" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cBq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "cBO" = (
@@ -11056,20 +10065,16 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "cDF" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Cell 3"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "cDT" = (
@@ -11078,6 +10083,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cEi" = (
@@ -11134,33 +10141,19 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
-"cIK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+"cIR" = (
+/obj/structure/chair/pew/left{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/red,
+/area/service/chapel/main)
 "cJh" = (
 /obj/machinery/light,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
@@ -11174,8 +10167,9 @@
 /area/science/xenobiology)
 "cKk" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command)
 "cKG" = (
@@ -11193,11 +10187,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
+"cKZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/aft)
 "cLV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cMa" = (
@@ -11215,9 +10216,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Storage"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/storage/art)
 "cMM" = (
@@ -11235,22 +10236,6 @@
 "cNO" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
-"cOb" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cOe" = (
 /obj/machinery/button/door/incinerator_vent_atmos_aux{
 	pixel_x = 6;
@@ -11260,11 +10245,11 @@
 	pixel_x = -6;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cOf" = (
@@ -11301,14 +10286,22 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
+"cPb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "cPz" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "cPT" = (
@@ -11332,26 +10325,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 22
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "cQB" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Fitness"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "cQC" = (
@@ -11364,6 +10353,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
+"cQM" = (
+/obj/machinery/light/directional/south,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/wood/tile,
+/area/service/library)
 "cQP" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Fitness"
@@ -11391,7 +10385,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on,
+/obj/machinery/atmospherics/components/binary/thermomachine/heater/on,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cRb" = (
@@ -11409,29 +10403,26 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cRp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"cRt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "cRA" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "cSc" = (
@@ -11445,12 +10436,19 @@
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
-"cSr" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 8
+"cSj" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/medical,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "cTa" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger{
@@ -11461,6 +10459,12 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"cTf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "cTt" = (
 /obj/structure/chair/sofa/corner,
 /obj/machinery/camera{
@@ -11482,13 +10486,20 @@
 "cTD" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
+"cTJ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "cTO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
@@ -11500,8 +10511,6 @@
 /area/engineering/main)
 "cUu" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -11509,37 +10518,31 @@
 	dir = 1
 	},
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cUC" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
-"cUY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "cVt" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/landmark/start/janitor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
+"cVL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cVR" = (
 /obj/item/banner/command/mundane,
 /turf/open/floor/plating,
@@ -11551,19 +10554,16 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "cWu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "cWP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/commons/vacant_room/office)
 "cWV" = (
@@ -11578,6 +10578,8 @@
 "cWY" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "cXi" = (
@@ -11590,13 +10592,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "cXp" = (
@@ -11613,10 +10611,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"cXu" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/medical/virology)
 "cXz" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -11627,15 +10621,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"cYs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/cargo/office)
 "cYy" = (
 /obj/machinery/light{
 	dir = 1
@@ -11659,35 +10644,21 @@
 /obj/item/phone,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"cZu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "cZR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
-"daf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
 "dak" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dam" = (
 /obj/effect/landmark/observer_start,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dao" = (
@@ -11702,13 +10673,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "dax" = (
 /obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/machinery/meter{
@@ -11716,6 +10685,9 @@
 	},
 /obj/item/radio/intercom{
 	pixel_x = 29
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -11749,11 +10721,18 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"dbl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "dbq" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
@@ -11772,11 +10751,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dbX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/item/paper/guides/jobs/engi/gravity_gen,
+/obj/item/pen/blue,
 /turf/open/floor/iron,
-/area/engineering/storage/tech)
+/area/engineering/gravity_generator)
 "dcp" = (
 /obj/machinery/processor,
 /obj/effect/turf_decal/stripes/box,
@@ -11815,49 +10798,30 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain)
-"dcN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "dcP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "ddh" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
 "ddA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -11867,6 +10831,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ddR" = (
@@ -11900,8 +10868,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/camera{
 	c_tag = "Security Central";
 	dir = 8;
@@ -11911,8 +10877,16 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"dfb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "dfj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -11921,12 +10895,8 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "dfr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "dfs" = (
@@ -11936,9 +10906,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "dfA" = (
@@ -11964,11 +10934,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "dfT" = (
@@ -12010,8 +10978,8 @@
 /area/engineering/atmos)
 "dhi" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "dhq" = (
@@ -12026,6 +10994,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/lab)
+"dhI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "diO" = (
 /obj/structure/sink{
 	dir = 8;
@@ -12037,24 +11009,15 @@
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "djH" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
-"djN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "djP" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -12074,15 +11037,9 @@
 /turf/open/floor/iron,
 /area/command)
 "dkt" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"dla" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "dld" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
@@ -12108,6 +11065,29 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"dlD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"dlE" = (
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/capacitor,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "dmp" = (
 /obj/machinery/door/airlock/security{
 	name = "Armory";
@@ -12149,29 +11129,26 @@
 /obj/item/paper/pamphlet/gateway,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"dmW" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "dnN" = (
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
 /turf/open/floor/iron,
 /area/security/prison)
-"dnU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/aft)
 "doi" = (
-/obj/machinery/computer/atmos_control/toxinsmix{
-	dir = 1
-	},
 /obj/machinery/light,
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/gas,
+/obj/item/wrench,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "doj" = (
@@ -12199,10 +11176,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "dpz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "dpG" = (
@@ -12236,25 +11213,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"dqN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "dqR" = (
 /obj/structure/window{
 	dir = 4
@@ -12274,9 +11232,9 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "dqX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "drd" = (
@@ -12289,12 +11247,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12305,6 +11257,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "drj" = (
@@ -12319,12 +11273,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12335,6 +11283,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "dse" = (
@@ -12353,39 +11304,23 @@
 	name = "Chief Engineer";
 	req_access_txt = "56"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "dsI" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"dtd" = (
-/obj/structure/disposalpipe/segment{
+"dsX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/command)
 "dtK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dud" = (
@@ -12402,15 +11337,17 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"dug" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "duk" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -12425,18 +11362,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"dux" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "duS" = (
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
@@ -12453,13 +11381,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "duY" = (
@@ -12469,32 +11393,22 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"dvy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "dvT" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Telecomms and AI";
 	req_access_txt = "19"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command)
+"dvV" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "dwf" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
@@ -12542,6 +11456,11 @@
 /obj/structure/chair/stool,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
+"dwP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "dwV" = (
 /obj/machinery/telecomms/server/presets/science,
 /obj/effect/turf_decal/tile/purple{
@@ -12554,26 +11473,9 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "dxa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
-"dxe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "dxo" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/rack,
@@ -12623,15 +11525,12 @@
 	c_tag = "Atmos Entry";
 	network = list("ss13","engine")
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dxP" = (
@@ -12653,13 +11552,9 @@
 	name = "medical sorting disposal pipe";
 	sortType = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dyS" = (
@@ -12704,16 +11599,12 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dzX" = (
@@ -12723,12 +11614,23 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "dzZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/item/beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"dAl" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig)
 "dAn" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -12748,15 +11650,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"dAE" = (
-/obj/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/multilayer/connected,
-/turf/open/floor/engine,
-/area/engineering/supermatter)
 "dAU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12767,13 +11660,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "dAV" = (
@@ -12814,8 +11703,8 @@
 	name = "bar sorting disposal pipe";
 	sortType = 19
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "dBt" = (
@@ -12831,9 +11720,8 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "dCo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "dCK" = (
@@ -12847,16 +11735,12 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "dCO" = (
@@ -12874,12 +11758,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "dCS" = (
@@ -12892,9 +11772,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "dDc" = (
@@ -12946,20 +11825,23 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dDP" = (
+/obj/effect/landmark/start/botanist,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/service/hydroponics)
 "dDQ" = (
 /obj/structure/window{
 	dir = 4
@@ -12978,15 +11860,36 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "dEa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "dEk" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/engineering/main)
+"dEF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/execution/transfer)
 "dEG" = (
 /obj/structure/table,
 /obj/machinery/door/poddoor/shutters{
@@ -13019,27 +11922,10 @@
 	pixel_x = -3;
 	pixel_y = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
-"dFM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "dFO" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -13063,7 +11949,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "dGd" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dGn" = (
@@ -13073,6 +11959,7 @@
 	pixel_y = 22
 	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/tank_holder/extinguisher,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "dGI" = (
@@ -13106,6 +11993,10 @@
 	},
 /turf/closed/wall,
 /area/science/xenobiology)
+"dIg" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engineering/storage/tech)
 "dIv" = (
 /obj/structure/window{
 	dir = 8
@@ -13140,6 +12031,15 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
+"dJc" = (
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Atmospherics Testing Room";
+	req_access_txt = "24"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "dJf" = (
 /turf/closed/wall/r_wall,
 /area/science/nanite)
@@ -13215,12 +12115,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"dKQ" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "dLd" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -13232,12 +12126,19 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"dLn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+"dLi" = (
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
+"dLn" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "dLz" = (
@@ -13308,12 +12209,16 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "dMq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -13325,18 +12230,14 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "dME" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "dML" = (
@@ -13370,6 +12271,10 @@
 /area/ai_monitored/security/armory)
 "dNe" = (
 /obj/structure/reagent_dispensers/watertank,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dNk" = (
@@ -13392,16 +12297,14 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"dOl" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
+"dNR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
+/area/maintenance/central)
 "dOH" = (
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
@@ -13443,9 +12346,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "dOQ" = (
@@ -13480,12 +12381,13 @@
 /area/security/detectives_office)
 "dPn" = (
 /obj/effect/decal/cleanable/generic,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/fore)
 "dPw" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -13520,7 +12422,8 @@
 	sortType = 7
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "dQJ" = (
@@ -13560,20 +12463,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"dRj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "dRA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/service,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "dRO" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
 	dir = 4
@@ -13584,12 +12479,8 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Cell 1"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "dSu" = (
@@ -13618,16 +12509,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"dSW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "dTm" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -13639,6 +12520,7 @@
 	dir = 4;
 	name = "Air to Distro"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dTp" = (
@@ -13689,6 +12571,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"dVq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "dVr" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -13699,6 +12589,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"dVA" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "dVG" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
@@ -13712,14 +12606,9 @@
 /area/hallway/secondary/exit)
 "dVV" = (
 /obj/structure/falsewall,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"dWp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/bar)
 "dWq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
@@ -13759,22 +12648,12 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"dXm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "dXn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/aft)
-"dXE" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "dYg" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -13819,18 +12698,18 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "dZb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "dZv" = (
 /obj/structure/flora/junglebush/b,
 /obj/item/toy/plush/snakeplushie,
+/obj/structure/sign/warning/biohazard{
+	pixel_x = 32
+	},
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "dZA" = (
@@ -13888,16 +12767,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"eaE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "eaJ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/purple{
@@ -13906,6 +12775,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "eaK" = (
@@ -13924,8 +12794,15 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
+"ecf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore)
 "ecl" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -13938,8 +12815,8 @@
 	name = "Cell 1"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "ecN" = (
@@ -13949,13 +12826,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "edc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "edi" = (
@@ -13966,8 +12837,8 @@
 	},
 /area/maintenance/aft)
 "edn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "edI" = (
@@ -13977,16 +12848,15 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "edM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -14015,15 +12885,6 @@
 /obj/item/relic,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"efs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hop)
 "egL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/start/security_officer,
@@ -14032,12 +12893,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"egP" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/aft)
 "egQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "hosspace";
 	name = "space shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
 "eha" = (
@@ -14057,12 +12925,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -14072,15 +12934,15 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "ehQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
 /obj/machinery/meter,
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "ehU" = (
@@ -14108,6 +12970,7 @@
 /area/engineering/atmos)
 "eiw" = (
 /obj/structure/grille/broken,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -14116,11 +12979,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "eiQ" = (
@@ -14135,14 +12996,15 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "ejv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ejW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/engine,
 /area/engineering/main)
 "ekh" = (
@@ -14153,11 +13015,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/unary/cryo_cell{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"eki" = (
+/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "eko" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14168,12 +13032,13 @@
 /area/maintenance/aft)
 "elb" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
 "elh" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "elt" = (
@@ -14191,37 +13056,18 @@
 /obj/structure/chair,
 /turf/open/floor/iron/grimy,
 /area/security/brig)
-"elJ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"emy" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "emM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "enk" = (
@@ -14237,16 +13083,14 @@
 	c_tag = "Captains Office";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "ent" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "enS" = (
@@ -14258,12 +13102,6 @@
 /obj/machinery/door/airlock/security/glass,
 /turf/open/floor/iron,
 /area/security/brig)
-"enY" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "eoe" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
@@ -14290,12 +13128,17 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "epn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "epF" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "eqt" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
@@ -14337,6 +13180,10 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
+"erb" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/black,
+/area/service/bar)
 "erg" = (
 /obj/structure/window,
 /obj/structure/flora/rock,
@@ -14374,7 +13221,6 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "esC" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -14385,6 +13231,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "esO" = (
@@ -14392,6 +13239,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "ete" = (
@@ -14417,6 +13265,17 @@
 "etj" = (
 /turf/closed/wall,
 /area/hallway/primary/fore)
+"etw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"etA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hop)
 "eui" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass{
@@ -14521,6 +13380,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "evw" = (
@@ -14529,6 +13389,8 @@
 	req_access_txt = "31"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "evM" = (
@@ -14550,6 +13412,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ewM" = (
@@ -14596,39 +13459,33 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ezc" = (
 /obj/item/target/syndicate,
 /obj/structure/training_machine,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/range)
-"ezh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "ezk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "ezy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ezE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
 /turf/open/floor/engine,
 /area/engineering/main)
 "ezH" = (
@@ -14675,6 +13532,14 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"eAo" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/cyan,
+/area/hallway/primary/starboard)
+"eAq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "eAy" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -14740,8 +13605,21 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/cargo_technician,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
+"eCe" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "eCf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -14783,12 +13661,11 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
-"eCP" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
+"eCZ" = (
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/hallway/primary/central)
 "eDb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -14827,24 +13704,16 @@
 	},
 /turf/open/floor/iron,
 /area/science/nanite)
-"eGB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port/aft)
 "eHp" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "eHx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "eHF" = (
@@ -14859,6 +13728,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"eId" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/bar)
+"eIV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/bar)
 "eIX" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -14880,12 +13762,11 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "eJJ" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/tank_holder/extinguisher/advanced,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "eJV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "eJX" = (
@@ -14916,6 +13797,7 @@
 	req_access_txt = "11"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "eKF" = (
@@ -14929,18 +13811,23 @@
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "eLb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"eLv" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/service/chapel/main)
 "eLC" = (
 /obj/structure/sign/warning/docking{
 	pixel_y = -32
@@ -14965,10 +13852,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "eLP" = (
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "eLR" = (
@@ -14984,16 +13872,12 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "eLX" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /mob/living/simple_animal/bot/secbot{
 	arrest_type = 1;
 	health = 45;
@@ -15002,6 +13886,8 @@
 	name = "Sergeant-at-Armsky";
 	weaponscheck = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "eMq" = (
@@ -15080,27 +13966,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/theater)
-"eOb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/courtroom)
-"eOD" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "eOU" = (
 /obj/effect/decal/remains/human,
 /obj/item/clothing/under/dress/redeveninggown,
@@ -15108,12 +13973,6 @@
 /obj/item/stack/spacecash/c100,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ePz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "ePA" = (
 /obj/machinery/camera{
 	c_tag = "Courtroom North";
@@ -15182,6 +14041,7 @@
 /obj/machinery/light/built{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
 "eQX" = (
@@ -15213,9 +14073,7 @@
 	uses = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "eRN" = (
@@ -15227,6 +14085,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/command)
+"eSn" = (
+/obj/effect/spawner/bundle/hobo_squat,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "eSp" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -15279,7 +14141,7 @@
 	id = "foreportsolar";
 	name = "Fore/Port Solar Array"
 	},
-/turf/open/floor/iron/airless/solarpanel,
+/turf/open/floor/iron/solarpanel,
 /area/maintenance/solars/port/fore)
 "eUg" = (
 /obj/item/book/random,
@@ -15296,10 +14158,10 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "eUn" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/violet,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eUz" = (
@@ -15309,16 +14171,10 @@
 	pixel_y = 11
 	},
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/tank_holder/oxygen,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
-"eUB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "eVc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
@@ -15381,6 +14237,14 @@
 	},
 /turf/open/floor/iron,
 /area/command)
+"eWx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
+"eXn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "eXs" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -15395,10 +14259,8 @@
 	location = "Tool Storage"
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "eYe" = (
@@ -15425,28 +14287,18 @@
 /turf/open/floor/grass,
 /area/hallway/primary/aft)
 "eYL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eYM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -15456,6 +14308,8 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
 /obj/item/clothing/suit/hazardvest,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eYX" = (
@@ -15469,19 +14323,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "eZw" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"eZB" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "eZL" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
@@ -15491,35 +14342,14 @@
 /obj/item/broken_bottle,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"fal" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/carpet/royalblue,
-/area/command/heads_quarters/hop)
 "fav" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24
 	},
 /turf/open/floor/wood,
 /area/medical/psychology)
-"faD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/cargo/office)
 "fbm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -15527,13 +14357,11 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"fby" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+"fbo" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/service/library)
 "fbI" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -15547,22 +14375,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
-"fch" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"fcm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "fco" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -15602,7 +14414,8 @@
 "fcJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fcS" = (
@@ -15655,6 +14468,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"fdQ" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "fey" = (
 /obj/structure/table,
 /obj/item/storage/box/syringes,
@@ -15666,6 +14484,8 @@
 	dir = 4
 	},
 /obj/item/stack/cable_coil,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "feE" = (
@@ -15705,15 +14525,12 @@
 "feI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "ffN" = (
@@ -15722,15 +14539,15 @@
 /turf/open/floor/carpet/orange,
 /area/commons/vacant_room/office)
 "ffT" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/smart/simple/violet{
 	dir = 4
 	},
-/obj/machinery/light,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ffW" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -15793,9 +14610,6 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/security/execution/education)
 "fhB" = (
@@ -15808,13 +14622,9 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "fib" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -15844,6 +14654,14 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
+"fii" = (
+/obj/machinery/door/poddoor{
+	id = "Secure Storage";
+	name = "secure storage"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/engineering/main)
 "fij" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -15889,15 +14707,24 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "fjt" = (
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
+"fjy" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fjF" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -15917,21 +14744,10 @@
 /turf/open/floor/plating,
 /area/hallway/primary/port)
 "fjO" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engineering/storage/tech)
 "fjP" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -15952,17 +14768,16 @@
 /obj/item/toy/plush/beeplushie,
 /turf/open/floor/carpet,
 /area/medical/psychology)
+"fkL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fkU" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/starboard)
 "fkV" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/smooth,
 /area/engineering/main)
 "flp" = (
 /obj/structure/table,
@@ -15988,7 +14803,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "flQ" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "flS" = (
@@ -16010,6 +14825,22 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"fme" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"fmp" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator";
+	req_access_txt = "11"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "fmE" = (
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
@@ -16068,24 +14899,22 @@
 	network = list("ss13","engine");
 	view_range = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "foP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fpc" = (
@@ -16123,8 +14952,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "fqj" = (
@@ -16135,46 +14964,24 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"frf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "fri" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "frl" = (
 /obj/structure/closet/l3closet,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"frF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/command/teleporter)
 "frN" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -16208,7 +15015,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
 "ftA" = (
@@ -16259,10 +15068,12 @@
 /obj/item/stack/sheet/plasteel{
 	amount = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "fuF" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/science/nanite)
 "fuO" = (
@@ -16276,27 +15087,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
-"fuQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "fuX" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 5
 	},
 /turf/open/floor/iron,
@@ -16312,9 +15109,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fvA" = (
@@ -16345,13 +15140,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/storage)
 "fwR" = (
@@ -16360,6 +15151,11 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"fwW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "fxb" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -16400,6 +15196,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/explab)
+"fxC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore)
 "fxF" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -16423,12 +15226,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "fxZ" = (
@@ -16455,6 +15254,8 @@
 "fyr" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "fyx" = (
@@ -16464,6 +15265,11 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
+/turf/open/floor/iron/showroomfloor,
+/area/cargo/office)
+"fyC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "fyK" = (
@@ -16476,6 +15282,7 @@
 /area/science/explab)
 "fzu" = (
 /obj/effect/decal/remains/robot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "fzx" = (
@@ -16491,41 +15298,39 @@
 "fzM" = (
 /turf/open/floor/engine,
 /area/science/explab)
-"fzU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "fAy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "fAC" = (
-/obj/machinery/gravity_generator/main/station,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/security,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/engineering/gravity_generator)
+/area/engineering/storage/tech)
 "fAE" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"fAO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "fAP" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/violet{
 	dir = 10
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"fAT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "fBg" = (
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
@@ -16538,19 +15343,15 @@
 /turf/closed/wall,
 /area/construction/mining/aux_base)
 "fBy" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 5
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fBA" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "fBE" = (
@@ -16652,13 +15453,14 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/service/bar)
-"fFl" = (
-/obj/structure/closet/toolcloset,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
+"fFC" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "fFL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
@@ -16738,17 +15540,16 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "fJZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "fKe" = (
 /obj/effect/landmark/start/scientist,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "fKk" = (
@@ -16758,10 +15559,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "fKs" = (
@@ -16819,13 +15620,8 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "fMN" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
@@ -16840,7 +15636,7 @@
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "fMY" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
 	},
 /turf/open/floor/iron,
@@ -16850,13 +15646,14 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
 /area/engineering/main)
 "fOx" = (
 /obj/structure/sign/painting/library{
 	pixel_x = -32
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/tile,
 /area/service/library)
 "fOQ" = (
 /turf/open/floor/engine/n2o,
@@ -16866,8 +15663,8 @@
 	name = "Courtroom";
 	req_access_txt = "42"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "fPj" = (
@@ -16897,13 +15694,8 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "fPw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "fPC" = (
@@ -16915,13 +15707,10 @@
 /area/engineering/storage/tech)
 "fPF" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "fPI" = (
 /obj/structure/cable,
@@ -16977,15 +15766,15 @@
 /obj/item/canvas/nineteen_nineteen,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"fRU" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
+"fRK" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "fSe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "fSf" = (
@@ -16993,9 +15782,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "fSg" = (
@@ -17003,11 +15790,14 @@
 /obj/machinery/restaurant_portal/restaurant,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"fSl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/security/courtroom)
+"fSo" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/aft)
 "fSK" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -17016,19 +15806,19 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "fSL" = (
-/obj/structure/cable,
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = -22
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/command,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/gravity_generator)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/storage/tech)
 "fSP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/mixing)
 "fSS" = (
@@ -17050,34 +15840,15 @@
 /area/medical/exam_room)
 "fTC" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "fTD" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/engineering/main)
-"fTH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/service/library)
-"fTQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/service/library)
 "fUf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
@@ -17099,37 +15870,21 @@
 	name = "Telecommunications";
 	req_access_txt = "61"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
-"fVb" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/library)
-"fVp" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "fVr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "fVD" = (
@@ -17154,26 +15909,24 @@
 	},
 /area/maintenance/central)
 "fWh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"fWj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "fWk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/storage)
 "fWw" = (
@@ -17191,12 +15944,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "fWF" = (
@@ -17206,12 +15953,9 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "fWR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "fWV" = (
@@ -17231,9 +15975,6 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "fXb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "fXf" = (
@@ -17241,9 +15982,10 @@
 	codes_txt = "patrol;next_patrol=0";
 	location = "9"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "fXp" = (
@@ -17254,13 +15996,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "fXy" = (
@@ -17280,19 +16018,29 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "fYi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
+"fYt" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/item/plant_analyzer,
+/obj/item/analyzer,
+/obj/structure/table,
+/obj/item/healthanalyzer,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "fYR" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/teleporter)
 "fZc" = (
@@ -17308,18 +16056,11 @@
 	dir = 9
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "fZq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "fZM" = (
@@ -17332,19 +16073,22 @@
 /area/commons/vacant_room/office)
 "fZN" = (
 /obj/item/banner/cargo/mundane,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fZQ" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/tank_dispenser,
+/obj/machinery/light_switch{
+	pixel_x = 22;
+	pixel_y = -22
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "fZW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "gac" = (
@@ -17360,10 +16104,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "gas" = (
@@ -17371,12 +16112,8 @@
 	name = "Kitchen cold room";
 	req_access_txt = "28"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "gay" = (
@@ -17385,12 +16122,6 @@
 	req_access_txt = "65;13"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -17424,21 +16155,15 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "gbO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "gbY" = (
@@ -17459,10 +16184,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "gcu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "gcC" = (
@@ -17482,13 +16205,9 @@
 /area/medical/pharmacy)
 "gdx" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "gdV" = (
@@ -17504,23 +16223,20 @@
 /area/science/xenobiology)
 "gdX" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "gej" = (
 /obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "get" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "geD" = (
@@ -17532,13 +16248,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "geF" = (
@@ -17599,6 +16312,25 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/cargo/qm)
+"ggx" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"ggF" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ghC" = (
 /obj/structure/table,
 /obj/item/kitchen/spoon/plastic,
@@ -17629,12 +16361,6 @@
 	name = "Atmos RC";
 	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -17642,6 +16368,8 @@
 	dir = 8
 	},
 /obj/structure/rack,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ghX" = (
@@ -17649,13 +16377,10 @@
 	name = "Chemistry Lab";
 	req_access_txt = "5; 33"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
 "giB" = (
@@ -17673,9 +16398,8 @@
 "gjj" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "gjo" = (
@@ -17709,9 +16433,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "gjL" = (
@@ -17724,8 +16446,8 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "gkd" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/violet,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -17734,9 +16456,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "gla" = (
@@ -17765,15 +16488,11 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
 "gnk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/orange,
 /area/commons/vacant_room/office)
 "gnl" = (
@@ -17788,16 +16507,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"gnu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "gny" = (
 /obj/machinery/door/airlock/external{
-	name = "Escape Pod Two"
+	name = "Escape Pod Two";
+	req_one_access_txt = "1;2;13"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/security/brig)
 "gnC" = (
@@ -17815,13 +16530,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/storage)
 "god" = (
@@ -17853,12 +16564,8 @@
 	name = "Gateway Chamber";
 	req_access_txt = "62"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "goG" = (
@@ -17874,6 +16581,7 @@
 /area/science/lab)
 "gpl" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/command/storage/eva)
 "gpP" = (
@@ -17897,7 +16605,6 @@
 "gqN" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/lab)
@@ -17917,10 +16624,11 @@
 	req_access_txt = "4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "gqX" = (
@@ -17945,13 +16653,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/engineering/main)
-"grJ" = (
-/turf/open/floor/iron/dark,
 /area/engineering/main)
 "grK" = (
 /obj/effect/turf_decal/bot,
@@ -17976,13 +16681,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "gtr" = (
@@ -18001,10 +16702,8 @@
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "gtJ" = (
@@ -18014,13 +16713,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "gtO" = (
@@ -18079,9 +16774,7 @@
 "gug" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/explab)
 "guN" = (
@@ -18093,18 +16786,14 @@
 	req_access_txt = "47"
 	},
 /obj/effect/landmark/start/scientist,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "guT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "gvd" = (
@@ -18116,6 +16805,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
+"gvi" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/bar)
 "gvk" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/brown{
@@ -18148,6 +16841,7 @@
 	},
 /obj/effect/landmark/start/clown,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/theater)
 "gxg" = (
@@ -18171,11 +16865,8 @@
 /area/maintenance/fore)
 "gxp" = (
 /obj/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "gxw" = (
@@ -18186,6 +16877,7 @@
 "gxD" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "gxF" = (
@@ -18199,17 +16891,17 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"gxR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "gxV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "gxY" = (
@@ -18224,7 +16916,7 @@
 	name = "Engineering RC";
 	pixel_y = -30
 	},
-/obj/structure/closet/crate/solarpanel_small,
+/obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
 /area/engineering/main)
 "gyl" = (
@@ -18239,16 +16931,26 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gyC" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"gzf" = (
+/obj/structure/table,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/mineral/plastitanium{
+	name = "black plastitanium floor"
+	},
+/area/service/bar)
 "gzl" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/gas/sechailer{
@@ -18278,6 +16980,13 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"gzz" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4;
+	name = "Waste Release"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gAm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
 	dir = 4
@@ -18295,13 +17004,37 @@
 "gAr" = (
 /turf/closed/wall,
 /area/maintenance/solars/starboard/aft)
+"gAC" = (
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/item/stock_parts/cell/high/plus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stock_parts/cell/high/plus{
+	pixel_y = -4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
+"gAL" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/command)
 "gAY" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/violet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "gBo" = (
@@ -18336,15 +17069,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"gBO" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "gCc" = (
 /obj/machinery/flasher{
 	pixel_x = 30
@@ -18358,12 +17082,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "gCI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "gDq" = (
@@ -18436,17 +17156,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
 "gGb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "gGt" = (
@@ -18486,6 +17202,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command)
 "gHi" = (
@@ -18511,12 +17229,6 @@
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"gHW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "gIl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18536,12 +17248,15 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
+"gID" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "gJv" = (
 /obj/machinery/ore_silo,
 /turf/open/floor/vault,
@@ -18568,38 +17283,19 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "gKI" = (
-/obj/structure/rack,
-/obj/item/ai_module/reset,
-/obj/item/aicard,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 30
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"gKM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+/turf/open/floor/plating,
+/area/engineering/gravity_generator)
 "gLf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
 	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "gLp" = (
@@ -18621,14 +17317,11 @@
 /area/commons/storage/art)
 "gLx" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "gLT" = (
@@ -18646,16 +17339,17 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gMI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "gMW" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/item/beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "gNl" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
@@ -18672,20 +17366,8 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"gNZ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/courtroom)
 "gOk" = (
 /obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/dark/visible{
 	dir = 4
 	},
 /obj/machinery/airalarm/server{
@@ -18719,24 +17401,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
-"gPA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/service/library)
 "gPL" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "gPP" = (
@@ -18745,6 +17416,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"gPZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "gQg" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -18753,8 +17430,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command)
 "gQh" = (
@@ -18769,12 +17447,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "gQq" = (
@@ -18782,12 +17458,6 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"gQP" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/supermatter)
 "gQW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -18820,9 +17490,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "gRN" = (
@@ -18836,6 +17503,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"gSq" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/engineering/atmos)
 "gSu" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9";
@@ -18848,13 +17522,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "gSA" = (
@@ -18885,6 +17555,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "gTc" = (
@@ -18915,6 +17586,7 @@
 	name = "Atmospherics Testing Room";
 	req_access_txt = "24"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "gTE" = (
@@ -18943,10 +17615,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "gTP" = (
@@ -18972,12 +17644,6 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "gUz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -19007,37 +17673,35 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "gVQ" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
+"gVT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"gVY" = (
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "port to mix"
+	},
+/obj/structure/sign/warning/fire{
+	pixel_y = 32
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/mixing/chamber)
 "gWb" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"gWK" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/space/basic,
-/area/space)
-"gXd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "gXi" = (
 /obj/machinery/light{
 	dir = 8
@@ -19073,6 +17737,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"gYL" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/tcommsat/computer)
+"gZh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gZk" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -19083,6 +17758,9 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "gZr" = (
@@ -19091,6 +17769,7 @@
 	id = "kanyewest";
 	name = "privacy shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/detectives_office)
 "gZy" = (
@@ -19116,10 +17795,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/cargo/office)
 "gZV" = (
@@ -19170,7 +17846,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
 /area/engineering/main)
 "haO" = (
 /obj/machinery/door/airlock/maintenance{
@@ -19205,9 +17884,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -19239,6 +17915,14 @@
 	},
 /turf/open/floor/iron,
 /area/command)
+"hdE" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hdJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -19274,16 +17958,13 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "hev" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/landmark/start/psychologist,
 /turf/open/floor/wood,
 /area/medical/psychology)
@@ -19294,12 +17975,8 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "hfr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "hfJ" = (
@@ -19325,8 +18002,16 @@
 	dir = 1
 	},
 /obj/item/beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command)
+"hgr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "hgw" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -19343,12 +18028,10 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "hhu" = (
@@ -19385,12 +18068,9 @@
 	dir = 8;
 	network = list("ss13","rd")
 	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"hhY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/command)
 "hid" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -19400,13 +18080,19 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "hiv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
 "hiA" = (
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
+"hiU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/library)
 "hja" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -19441,13 +18127,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "hjS" = (
@@ -19460,6 +18142,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/storage)
+"hjW" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "hkq" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white,
@@ -19482,6 +18168,17 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
+"hlG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"hlN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/command/heads_quarters/captain)
 "hlP" = (
 /obj/structure/table,
 /obj/item/dest_tagger,
@@ -19522,12 +18219,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"hmf" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
+"hmk" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/hallway/secondary/entry)
+"hmt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "hmI" = (
 /obj/structure/table,
 /obj/item/reagent_containers/dropper,
@@ -19553,13 +18255,11 @@
 	c_tag = "Xenobiology Central";
 	network = list("ss13","rd")
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/sink{
 	pixel_y = 20
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "hnF" = (
@@ -19584,13 +18284,10 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "hou" = (
@@ -19604,13 +18301,11 @@
 	},
 /area/engineering/main)
 "hoy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/sign/poster/contraband/ambrosia_vulgaris{
 	pixel_y = 32
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "hoB" = (
@@ -19622,11 +18317,6 @@
 "hoU" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"hpf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/medical/virology)
 "hpP" = (
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 8;
@@ -19642,10 +18332,17 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/fore)
+"hqh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "hql" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -19667,9 +18364,8 @@
 /area/hallway/secondary/exit)
 "hqF" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/nanite)
 "hqR" = (
@@ -19680,6 +18376,9 @@
 	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
@@ -19693,11 +18392,18 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
+"hrU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "hsb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
@@ -19764,10 +18470,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "huI" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/violet{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -19782,6 +18488,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/brig)
+"hvm" = (
+/obj/structure/sign/warning/enginesafety,
+/turf/closed/wall/r_wall,
+/area/engineering/main)
 "hvp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -19821,17 +18531,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"hwA" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood/large,
+/area/service/library)
 "hwC" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"hwE" = (
-/obj/structure/cable/layer1,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "hwL" = (
 /turf/closed/wall/r_wall,
 /area/science/research)
@@ -19858,33 +18567,30 @@
 /turf/open/floor/engine,
 /area/science/explab)
 "hxA" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/multitool,
-/obj/item/multitool,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "hxQ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
 "hyg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "hym" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "hyo" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hzP" = (
@@ -19913,18 +18619,15 @@
 "hAJ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "hAK" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hAR" = (
@@ -19933,6 +18636,7 @@
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hAX" = (
@@ -19956,22 +18660,18 @@
 	name = "det sorting disposal pipe";
 	sortType = 30
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
-"hBg" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "hBP" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hBV" = (
@@ -19990,6 +18690,7 @@
 	pixel_y = 9
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hCx" = (
@@ -20031,25 +18732,21 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "hDu" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hEx" = (
@@ -20064,13 +18761,9 @@
 /turf/open/space/basic,
 /area/space)
 "hEB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "hEE" = (
@@ -20080,21 +18773,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"hEI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/office)
 "hEK" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hEP" = (
@@ -20120,13 +18804,13 @@
 "hFs" = (
 /turf/closed/wall/r_wall,
 /area/security/range)
-"hFT" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
+"hFX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/engineering/gravity_generator)
 "hGr" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/requests_console{
@@ -20136,6 +18820,16 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"hGI" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "hGX" = (
 /obj/item/food/donut/chaos,
 /turf/open/floor/plating,
@@ -20144,13 +18838,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "hHa" = (
@@ -20164,23 +18855,21 @@
 /obj/structure/flora/bush,
 /turf/open/floor/grass,
 /area/command)
+"hHr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hHv" = (
 /obj/structure/cable,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/service/library)
 "hHw" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"hHx" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "hHQ" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -20196,13 +18885,18 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "hHX" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Pure to Pure"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"hIq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hIz" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 1
@@ -20229,6 +18923,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"hKa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "hKj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -20236,13 +18937,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
-"hKq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/service/hydroponics)
 "hKA" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph{
 	pixel_x = -32
@@ -20251,6 +18949,7 @@
 /area/science/xenobiology)
 "hKE" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -20260,6 +18959,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/wood,
 /area/service/bar)
+"hKJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/security/brig)
 "hLe" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -20274,11 +18979,8 @@
 /obj/structure/window/plasma/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
 /obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "hLt" = (
@@ -20290,16 +18992,13 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hLU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "hMw" = (
@@ -20313,21 +19012,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
-"hMM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/command)
 "hMX" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/secure_closet/miner,
@@ -20346,6 +19035,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"hNS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hop)
 "hOO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -20353,28 +19047,23 @@
 	req_access_txt = "3"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"hOS" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+"hOX" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "hOZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -20391,6 +19080,9 @@
 "hPS" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "hQc" = (
@@ -20398,12 +19090,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/head_of_personnel,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "hQl" = (
@@ -20412,14 +19099,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
-"hQq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/command/gateway)
 "hQP" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -20449,27 +19128,24 @@
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
 "hSL" = (
-/obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
 "hTo" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hTx" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "hTE" = (
@@ -20516,16 +19192,25 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "hVa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"hVA" = (
+/obj/effect/landmark/start/cook,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "hWd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/range)
@@ -20562,13 +19247,13 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/service/library)
 "hXK" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/paicard,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/service/library)
 "hXV" = (
 /obj/structure/transit_tube/horizontal,
@@ -20579,6 +19264,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "hYd" = (
@@ -20593,13 +19279,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"hZo" = (
+/obj/structure/lattice,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space/basic,
+/area/space/nearstation)
 "hZE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
@@ -20607,7 +19292,7 @@
 	pixel_x = -10;
 	pixel_y = -22
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/service/library)
 "hZL" = (
 /obj/machinery/air_sensor/atmos/nitrogen_tank,
@@ -20646,25 +19331,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"iam" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/science/xenobiology)
 "ibb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -20711,6 +19377,8 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ibM" = (
@@ -20729,28 +19397,24 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"ick" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
-"icF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "idc" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/satellite)
+"idf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/central)
+"ids" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "idF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -20759,13 +19423,14 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/library)
 "idL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
 	},
-/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "idW" = (
@@ -20800,11 +19465,18 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
+"ieR" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "ifc" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
@@ -20815,6 +19487,12 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
+"ife" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "iff" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -20842,16 +19520,11 @@
 /obj/effect/landmark/start/quartermaster,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"ifY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/iron/dark,
-/area/engineering/atmos)
 "igd" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -20878,23 +19551,22 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "ihj" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "ihq" = (
@@ -20905,26 +19577,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
-"ihs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/gravity_generator)
 "ihD" = (
 /obj/structure/table/wood,
 /obj/item/gavelblock,
@@ -20979,9 +19634,10 @@
 "ikU" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "ilJ" = (
@@ -21007,6 +19663,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
+"ims" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/service/chapel/main)
 "imv" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/glass/fifty,
@@ -21022,8 +19685,8 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Laundry"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "imN" = (
@@ -21031,24 +19694,14 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
-"imS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "inj" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -21080,15 +19733,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"iof" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig)
 "ioj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21109,11 +19756,13 @@
 "iow" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command)
 "ioL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/docking,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "ipn" = (
@@ -21123,20 +19772,16 @@
 	dir = 8;
 	network = list("ss13","medbay")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "ipo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Medbay South Hallway";
 	network = list("ss13","medbay")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ips" = (
@@ -21146,7 +19791,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -21182,6 +19827,12 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/security/detectives_office)
+"irn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "irD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21203,6 +19854,13 @@
 	},
 /turf/open/floor/iron,
 /area/command)
+"irO" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/commons/dorms)
 "irX" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -21210,39 +19868,26 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "isb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
 "isl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/range)
-"isG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/command)
 "isQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/service/bar)
@@ -21256,19 +19901,25 @@
 	},
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/paper/guides/jobs/hydroponics,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "itf" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"itv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/fore)
 "itC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "itI" = (
@@ -21302,6 +19953,14 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"iuu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iuC" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/brown{
@@ -21316,12 +19975,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"iuN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "iuU" = (
 /obj/machinery/camera{
 	c_tag = "South Hallway - East";
@@ -21337,6 +19990,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"iuZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ivy" = (
 /turf/open/floor/iron,
 /area/commons/dorms)
@@ -21372,19 +20029,23 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "iwq" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet,
 /turf/open/floor/iron,
 /area/engineering/main)
-"iwE" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+"iwr" = (
+/obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit)
+"iwE" = (
+/obj/effect/landmark/event_spawn,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "iwN" = (
@@ -21398,13 +20059,9 @@
 	name = "Engineering";
 	req_one_access_txt = "10;24"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "iwW" = (
@@ -21422,13 +20079,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ixo" = (
@@ -21460,9 +20113,9 @@
 	name = "Experimentation Lab";
 	req_access_txt = "47"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "iyn" = (
@@ -21477,6 +20130,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "iyG" = (
@@ -21490,12 +20144,8 @@
 	pixel_y = 24;
 	req_access_txt = "11"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -21567,6 +20217,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"iDj" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium{
+	name = "black plastitanium floor"
+	},
+/area/service/bar)
 "iDr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -21578,6 +20236,13 @@
 /obj/machinery/light,
 /turf/open/floor/grass,
 /area/security/prison)
+"iDE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "iDW" = (
 /obj/machinery/computer/slot_machine,
 /obj/item/coin/silver,
@@ -21591,18 +20256,11 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"iEb" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "iEr" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -21610,17 +20268,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"iFa" = (
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/iron,
+/area/engineering/main)
 "iFd" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"iGt" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iHs" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
@@ -21632,7 +20287,9 @@
 /area/maintenance/starboard)
 "iIJ" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth,
 /area/engineering/main)
 "iJd" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -21670,6 +20327,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -21760,11 +20420,11 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "iMJ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Air to Pure"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iMP" = (
@@ -21784,18 +20444,27 @@
 	},
 /turf/open/floor/iron,
 /area/service/janitor)
-"iNx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
+"iMZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
+"iNn" = (
+/obj/structure/sign/painting/library{
+	pixel_x = 32
+	},
+/turf/open/floor/wood/tile,
+/area/service/library)
+"iNx" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/maintenance/disposal/incinerator)
 "iNF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
 	},
 /turf/open/floor/iron,
@@ -21806,8 +20475,13 @@
 	id = "rabbitcontainment";
 	name = "privacy shutter"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
+"iOh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "iOj" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -21853,14 +20527,6 @@
 /obj/item/book/manual/wiki/tcomms,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
-"iPX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/office)
 "iQl" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/aisat/exterior)
@@ -21868,7 +20534,15 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark,
+/area/engineering/atmos)
+"iQy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "iQM" = (
 /obj/effect/turf_decal/bot,
@@ -21891,9 +20565,8 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "iQR" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/bot{
-	dir = 1
+/obj/machinery/atmospherics/components/trinary/filter/flipped{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -21901,8 +20574,12 @@
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
 /obj/item/pen,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/service/library)
+"iRr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "iRR" = (
 /obj/machinery/teleport/station,
 /obj/machinery/status_display/ai{
@@ -21914,14 +20591,14 @@
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iSn" = (
@@ -21934,14 +20611,26 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iSD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engineering/storage/tech)
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "iSJ" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/library)
+"iTj" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "iTt" = (
 /obj/machinery/camera{
 	c_tag = "West Hallway - South";
@@ -21983,6 +20672,13 @@
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
+"iUq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "iUu" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -21994,9 +20690,7 @@
 /area/engineering/atmos)
 "iUB" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "iUI" = (
@@ -22045,13 +20739,6 @@
 /obj/effect/spawner/lootdrop/aimodule_neutral,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"iVe" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Waste to Space"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iVw" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -22061,31 +20748,26 @@
 /turf/open/floor/grass,
 /area/security/courtroom)
 "iVV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"iWb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "iWs" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "iXz" = (
@@ -22108,6 +20790,14 @@
 /obj/structure/table_frame/wood,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
+"iXJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/aft)
 "iXW" = (
 /obj/structure/window{
 	dir = 4
@@ -22128,18 +20818,14 @@
 /area/command)
 "iYh" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "iYi" = (
@@ -22148,12 +20834,8 @@
 	name = "Isolation Cell";
 	req_access_txt = "2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "iYj" = (
@@ -22180,7 +20862,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "iYB" = (
@@ -22198,12 +20880,8 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "iZa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "iZm" = (
@@ -22248,9 +20926,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "jaR" = (
@@ -22261,6 +20939,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/storage)
 "jbu" = (
@@ -22270,8 +20950,8 @@
 	},
 /area/service/bar)
 "jbw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "jbF" = (
@@ -22293,22 +20973,9 @@
 /area/security/office)
 "jbR" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"jbU" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "jcc" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -22333,6 +21000,10 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/service/chapel/main)
+"jcZ" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/space/basic,
+/area/engineering/gravity_generator)
 "jdd" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/machinery/door/window/eastright,
@@ -22351,10 +21022,8 @@
 "jdu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "jdA" = (
@@ -22378,19 +21047,16 @@
 	name = "Psychologist's Office";
 	req_access_txt = "70"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "jes" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"jeu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "jey" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -22409,6 +21075,8 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jgR" = (
@@ -22441,7 +21109,6 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "jhE" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
 	name = "Freezer Bypass"
 	},
 /turf/open/floor/engine,
@@ -22449,8 +21116,9 @@
 "jhM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "jhS" = (
@@ -22470,9 +21138,9 @@
 /obj/machinery/door/airlock/medical{
 	name = "Medical Breakroom"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
 "jjd" = (
@@ -22496,8 +21164,6 @@
 "jjA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/camera{
 	c_tag = "Security Armory Exterior";
 	dir = 8;
@@ -22507,6 +21173,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "jjB" = (
@@ -22517,39 +21185,12 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
-"jjR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "jkp" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"jkr" = (
-/obj/structure/rack,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/capacitor,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
 "jkt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -22561,11 +21202,22 @@
 /turf/open/floor/iron,
 /area/science/storage)
 "jku" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"jky" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/iron,
+/area/engineering/main)
 "jkP" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -22593,43 +21245,31 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
-"jmh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "jmn" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"jms" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
+/area/engineering/main)
 "jmU" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
 	name = "science sorting disposal pipe";
 	sortType = 12
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "jna" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Security Cells East";
 	network = list("ss13","prison")
@@ -22640,15 +21280,10 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
-"jnm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
 "jnC" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
@@ -22658,16 +21293,12 @@
 /turf/open/floor/iron/dark,
 /area/cargo/qm)
 "jnT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "joO" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "joR" = (
@@ -22742,27 +21373,15 @@
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Bridge Entry East";
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
-"jse" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/service/janitor)
 "jsA" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/showroomfloor,
@@ -22773,17 +21392,17 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
-"jsH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/research)
 "jsM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command)
+"jsN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engineering/main)
 "jtc" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/brute,
@@ -22825,6 +21444,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "jtJ" = (
@@ -22844,31 +21465,34 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "jtX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
+"jur" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "juA" = (
 /obj/machinery/door/airlock/command{
 	name = "Teleport Access";
 	req_access_txt = "17"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "juJ" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -22897,16 +21521,22 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "jvy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/camera{
 	c_tag = "Engineering North";
 	dir = 8;
 	network = list("ss13","engine")
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/power/apc{
+	areastring = /area/engineering/engine_smes;
+	dir = 4;
+	name = "Engine SMES APC";
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/smooth,
 /area/engineering/main)
 "jvA" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -22915,6 +21545,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "jwA" = (
@@ -22944,22 +21576,22 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/medical/virology)
 "jyy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "jyG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "jyK" = (
@@ -22972,13 +21604,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "jyS" = (
@@ -23000,13 +21628,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "jzy" = (
@@ -23024,6 +21648,17 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"jAb" = (
+/obj/structure/chair/sofa{
+	dir = 8;
+	name = "plush sofa"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/bar)
 "jAq" = (
 /obj/structure/table,
 /obj/item/clothing/shoes/sneakers/orange{
@@ -23055,8 +21690,8 @@
 	name = "warehouse shutters"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "jAG" = (
@@ -23066,13 +21701,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "jAI" = (
@@ -23082,22 +21713,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"jAR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/research)
 "jAT" = (
 /obj/structure/window{
 	dir = 4
@@ -23117,11 +21732,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "jBI" = (
@@ -23145,6 +21758,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"jBN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/mineral/plastitanium{
+	name = "black plastitanium floor"
+	},
+/area/service/bar)
 "jCe" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/security/sec,
@@ -23163,7 +21783,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "jCt" = (
@@ -23180,12 +21801,7 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "jDr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "jDY" = (
@@ -23201,6 +21817,15 @@
 /obj/machinery/computer/telecomms/monitor,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
+"jEN" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "jEP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23241,13 +21866,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "jFS" = (
@@ -23263,26 +21884,27 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
+"jGz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "jGM" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "jHh" = (
@@ -23293,17 +21915,15 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "jHw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/engine,
 /area/engineering/main)
 "jHD" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/sepia,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/red,
 /area/service/chapel/main)
 "jHE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23333,13 +21953,8 @@
 /turf/closed/wall,
 /area/science/robotics/lab)
 "jIV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "jJn" = (
@@ -23365,9 +21980,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "jKs" = (
@@ -23381,12 +21994,10 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "jLl" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/engineering/storage/tech)
+/area/engineering/gravity_generator)
 "jLJ" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -23400,7 +22011,6 @@
 /area/security/courtroom)
 "jMb" = (
 /obj/structure/closet/secure_closet/captains,
-/obj/item/gun/energy/e_gun/mini,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "jMo" = (
@@ -23414,12 +22024,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "jMr" = (
@@ -23435,9 +22041,6 @@
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "jMy" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 5
-	},
 /obj/machinery/computer/atmos_control/tank/mix_tank{
 	dir = 4;
 	input_tag = "mix2_in";
@@ -23465,17 +22068,11 @@
 "jNn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
-"jNr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/command/heads_quarters/rd)
 "jNu" = (
 /obj/structure/chair{
 	dir = 8;
@@ -23512,30 +22109,32 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/wood,
 /area/service/library)
-"jOj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+"jOf" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"jOj" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/library)
 "jOm" = (
 /obj/structure/falsewall,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"jPM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/service/library)
 "jQi" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray{
 	pixel_y = 5
 	},
 /obj/effect/spawner/lootdrop/donkpockets,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "jQE" = (
@@ -23558,6 +22157,12 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"jRu" = (
+/obj/structure/cable,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "jRI" = (
 /obj/structure/sink{
 	dir = 4;
@@ -23644,10 +22249,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "jTX" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
 /turf/open/floor/engine,
 /area/engineering/main)
 "jUf" = (
@@ -23663,9 +22266,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "jUG" = (
@@ -23709,13 +22310,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "jVk" = (
@@ -23746,10 +22343,8 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
 "jWx" = (
@@ -23772,9 +22367,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "jXT" = (
@@ -23785,17 +22381,10 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"jXV" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jYf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/library)
 "jYl" = (
@@ -23841,28 +22430,41 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"jZg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+"jZO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/tcommsat/computer)
 "kal" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"kam" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/red,
+/area/service/chapel/main)
 "kaC" = (
-/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
 "kbg" = (
@@ -23922,18 +22524,20 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"kdY" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/security/prison)
 "kei" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/cargo/office)
 "keN" = (
@@ -23951,23 +22555,19 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"kfl" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kfC" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green{
+	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
@@ -24001,27 +22601,33 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/engineering/main)
-"khe" = (
+"kgY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "khn" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -24029,12 +22635,8 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "khC" = (
@@ -24044,27 +22646,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/warehouse)
-"khO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "khQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "khZ" = (
@@ -24088,8 +22675,13 @@
 	req_one_access_txt = "1;4"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/office)
+"kiF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "kiL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24097,6 +22689,8 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "kjf" = (
@@ -24108,12 +22702,8 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
 "kji" = (
@@ -24159,15 +22749,17 @@
 	c_tag = "Medbay North Hallway";
 	network = list("ss13","medbay")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "kjT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "kjZ" = (
@@ -24177,13 +22769,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "kkt" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/engine,
 /area/engineering/main)
 "kkz" = (
@@ -24191,7 +22783,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "klb" = (
@@ -24204,6 +22796,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "klr" = (
@@ -24226,12 +22820,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "klu" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "klF" = (
@@ -24256,7 +22851,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "kmC" = (
@@ -24274,13 +22869,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "kmH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "kmZ" = (
@@ -24288,21 +22878,15 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "knB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "knV" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"koj" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/science/xenobiology)
 "kor" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -24337,16 +22921,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/medical/virology)
+"koB" = (
+/obj/structure/tank_holder/extinguisher/advanced,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "koC" = (
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "koO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/structure/cable,
+/obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/iron,
 /area/engineering/main)
 "kpz" = (
@@ -24365,31 +22949,27 @@
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "kqd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/item/beacon,
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
-"kqj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/commons/fitness)
 "kqr" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/range)
 "kre" = (
-/obj/machinery/atmospherics/components/trinary/filter/critical{
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "krh" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "krj" = (
@@ -24416,13 +22996,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "krR" = (
@@ -24444,8 +23020,8 @@
 	req_access_txt = "12"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "ksc" = (
@@ -24453,10 +23029,11 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/engineering/main)
 "ksd" = (
 /obj/effect/turf_decal/tile/purple{
@@ -24482,8 +23059,6 @@
 	req_access_txt = "5; 33"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -24494,8 +23069,15 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"ksw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/sepia,
+/area/service/chapel/main)
 "ksz" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -24506,31 +23088,29 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"ksE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"ksI" = (
+/obj/effect/landmark/start/chaplain,
+/turf/open/floor/carpet/red,
+/area/service/chapel/main)
 "ksS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "ktb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "ktq" = (
 /obj/machinery/light,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
-"ktR" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "kub" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
@@ -24550,13 +23130,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"kva" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Process to Waste"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kvd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -24566,16 +23139,12 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "kvt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
 	name = "Vacant Office"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "kvM" = (
@@ -24586,15 +23155,13 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "kwa" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
 "kwf" = (
@@ -24605,9 +23172,8 @@
 	pixel_y = -30;
 	receive_ore_updates = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "kws" = (
@@ -24627,9 +23193,8 @@
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "kwF" = (
@@ -24637,9 +23202,8 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "kxP" = (
@@ -24650,9 +23214,8 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "kxW" = (
@@ -24666,11 +23229,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "kxZ" = (
@@ -24689,6 +23251,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command)
 "kyx" = (
@@ -24712,9 +23276,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "kzh" = (
@@ -24742,13 +23306,10 @@
 /obj/structure/window{
 	dir = 8
 	},
-/turf/open/floor/iron/sepia,
+/turf/open/floor/carpet/black,
 /area/service/chapel/main)
 "kAI" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "kAZ" = (
@@ -24764,9 +23325,6 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "kBA" = (
@@ -24779,9 +23337,7 @@
 /area/science/research)
 "kBM" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "kBX" = (
@@ -24796,8 +23352,20 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
+"kCk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "kCx" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "kCB" = (
@@ -24822,13 +23390,14 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "kDD" = (
-/turf/open/floor/iron,
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "kDK" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kDO" = (
@@ -24839,7 +23408,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "kDS" = (
@@ -24855,15 +23424,15 @@
 	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"kEo" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "kEt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow{
@@ -24872,6 +23441,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "kEw" = (
@@ -24880,18 +23451,6 @@
 /obj/item/paper_bin,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"kEB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/construction/mining/aux_base)
-"kEW" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kEX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -24913,16 +23472,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/sink{
 	pixel_y = 20
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "kFX" = (
@@ -24930,22 +23485,23 @@
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "kGh" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "kGn" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -24961,6 +23517,8 @@
 	req_one_access_txt = "32;19"
 	},
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "kGs" = (
@@ -24976,6 +23534,14 @@
 "kGJ" = (
 /turf/closed/wall/r_wall,
 /area/science/genetics)
+"kGL" = (
+/obj/structure/chair/sofa{
+	dir = 1;
+	name = "plush sofa"
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/bar)
 "kHn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Genetics Maintenance";
@@ -24990,6 +23556,11 @@
 /obj/item/surgical_drapes,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"kHI" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/commons/dorms)
 "kHK" = (
 /obj/structure/filingcabinet{
 	name = "Secure Documents Cabinet"
@@ -25035,13 +23606,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kJf" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "kJn" = (
@@ -25050,7 +23621,8 @@
 /area/command/teleporter)
 "kJH" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "kJU" = (
@@ -25164,13 +23736,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "kLm" = (
@@ -25198,8 +23766,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "kMo" = (
@@ -25232,15 +23800,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "kNc" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "SMES Storage";
 	dir = 1;
 	network = list("ss13","engine")
 	},
-/obj/structure/cable,
+/obj/machinery/suit_storage_unit/engine,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "kNf" = (
@@ -25298,14 +23863,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
-"kOc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "kPn" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -25354,21 +23911,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"kRe" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "kRj" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Pens";
@@ -25400,6 +23942,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"kSV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "kTf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/flasher{
@@ -25434,6 +23981,8 @@
 	name = "Holding Area";
 	req_access_txt = "2"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "kUd" = (
@@ -25445,18 +23994,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
 	req_access_txt = "31"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "kVx" = (
@@ -25469,13 +24014,13 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Foyer";
 	req_one_access_txt = "32;19"
 	},
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "kVM" = (
@@ -25492,6 +24037,9 @@
 /area/hallway/primary/port)
 "kWL" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -25521,7 +24069,7 @@
 "kYD" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
-/turf/open/floor/iron/airless/solarpanel,
+/turf/open/floor/iron/solarpanel,
 /area/maintenance/solars/starboard/aft)
 "laE" = (
 /obj/machinery/airalarm{
@@ -25535,10 +24083,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "laI" = (
@@ -25572,33 +24118,24 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"lbU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/medical/virology)
+"lbL" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/service/bar)
 "lca" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/landmark/start/station_engineer,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "lcn" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/grimy,
 /area/security/brig)
-"lcu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/service/bar)
 "lcB" = (
 /obj/machinery/computer/upload/borg,
 /obj/structure/window/reinforced{
@@ -25630,20 +24167,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"ldw" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
-"leo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+"ldL" = (
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/security/prison)
 "leO" = (
 /obj/structure/window{
 	dir = 8
@@ -25662,7 +24194,7 @@
 	},
 /obj/item/paper_bin/bundlenatural,
 /obj/item/pen/fourcolor,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/blue,
 /area/service/library)
 "leT" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
@@ -25670,10 +24202,26 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"lff" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "lfu" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/commons/storage/art)
+"lfI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/security/brig)
 "lfK" = (
 /obj/structure/table/wood,
 /obj/machinery/door/window/northright{
@@ -25681,7 +24229,9 @@
 	req_access_txt = "37"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/carpet/blue,
 /area/service/library)
 "lfS" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
@@ -25690,6 +24240,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"lfZ" = (
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/engineering/break_room)
 "lgb" = (
 /obj/structure/window{
 	dir = 1
@@ -25698,7 +24252,7 @@
 	dir = 4
 	},
 /obj/machinery/libraryscanner,
-/turf/open/floor/wood,
+/turf/open/floor/carpet/blue,
 /area/service/library)
 "lge" = (
 /obj/effect/turf_decal/tile/green{
@@ -25725,11 +24279,17 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
+"lgw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "lgz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -25743,13 +24303,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "lgW" = (
@@ -25869,9 +24426,9 @@
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "lkE" = (
@@ -25883,10 +24440,10 @@
 /turf/open/floor/iron,
 /area/command)
 "lkK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "lkO" = (
@@ -25910,10 +24467,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "lly" = (
@@ -25936,7 +24491,7 @@
 /area/hallway/primary/port)
 "llI" = (
 /obj/effect/landmark/start/paramedic,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "llM" = (
@@ -25948,16 +24503,6 @@
 /obj/machinery/door/window/southleft,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"lmk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "lmt" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
@@ -25965,6 +24510,8 @@
 	sortType = 3
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "lmy" = (
@@ -25974,29 +24521,15 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lmz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"lmA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "lnf" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -26013,12 +24546,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "lnE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "lnP" = (
@@ -26029,12 +24558,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "lnY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/requests_console{
 	department = "Medical";
@@ -26052,18 +24575,23 @@
 /obj/item/stack/sheet/glass,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"lou" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "low" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port/aft)
 "loD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "loE" = (
@@ -26080,12 +24608,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/machinery/vending/wallmed{
 	pixel_y = -32
@@ -26094,6 +24616,7 @@
 	dir = 8;
 	pixel_x = 12
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "lpf" = (
@@ -26139,36 +24662,23 @@
 "lqD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "lqV" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "lqY" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
-"lrw" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/multilayer/connected,
-/turf/open/floor/engine,
-/area/engineering/supermatter)
 "lrE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -26202,17 +24712,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"lsb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "lsi" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -26225,12 +24724,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "lsN" = (
@@ -26239,9 +24734,9 @@
 	name = "toxins sorting disposal pipe";
 	sortType = 25
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "lsU" = (
@@ -26280,11 +24775,15 @@
 	},
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
+"lui" = (
+/obj/effect/spawner/xmastree,
+/turf/open/floor/wood,
+/area/service/bar)
 "lur" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -26315,6 +24814,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/disposal)
+"lvC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "lvL" = (
 /obj/machinery/power/smes{
 	capacity = 9e+006;
@@ -26348,11 +24851,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "lws" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "lwu" = (
@@ -26362,18 +24864,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"lwC" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/command)
 "lwL" = (
 /obj/machinery/door/airlock/research{
 	name = "Kill Chamber";
@@ -26406,7 +24896,7 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
 "lxn" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
 	},
 /turf/open/floor/iron,
@@ -26419,15 +24909,24 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"lyK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/turf/open/floor/iron,
+/area/science/mixing)
 "lyY" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "lzo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
 "lzG" = (
@@ -26466,11 +24965,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "lAs" = (
@@ -26508,11 +25005,15 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"lDs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/cargo/office)
 "lDO" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "lDV" = (
@@ -26536,12 +25037,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"lEN" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "lEQ" = (
 /obj/machinery/vending/engivend,
 /turf/open/floor/iron,
@@ -26550,12 +25045,23 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/range)
 "lFh" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
 /area/security/execution/education)
+"lFi" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lFk" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -26624,9 +25130,8 @@
 /obj/machinery/meter{
 	name = "Distro Gas Meter"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lJm" = (
@@ -26634,22 +25139,20 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lJu" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 5
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lJx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lJW" = (
@@ -26657,9 +25160,9 @@
 	name = "Courtroom";
 	req_access_txt = null
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "lKc" = (
@@ -26669,6 +25172,8 @@
 	req_access_txt = "48"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "lKx" = (
@@ -26682,12 +25187,11 @@
 /turf/open/space/basic,
 /area/engineering/atmos)
 "lKL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "lKO" = (
 /obj/machinery/button/door{
 	id = "visitation";
@@ -26742,16 +25246,9 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/structure/cable,
-/obj/machinery/power/smes/engineering,
+/obj/structure/tank_dispenser,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
-"lLR" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "lLY" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -26759,6 +25256,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"lMh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "lMp" = (
 /obj/structure/table,
 /obj/item/wrench/medical,
@@ -26775,19 +25276,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"lME" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "lMI" = (
 /obj/structure/chair{
 	dir = 8
@@ -26809,9 +25297,9 @@
 	c_tag = "Cargo Office";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
 "lMX" = (
@@ -26839,7 +25327,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "lND" = (
 /obj/structure/chair/office{
@@ -26851,6 +25339,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "lNJ" = (
@@ -26860,10 +25349,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "lNY" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lOx" = (
@@ -26879,7 +25368,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "lOE" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/structure/table,
+/obj/item/hfr_box/body/fuel_input,
+/obj/item/hfr_box/body/interface,
+/obj/item/hfr_box/body/moderator_input,
+/obj/item/hfr_box/body/waste_output,
+/obj/item/hfr_box/core,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
+/obj/item/hfr_box/corner,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "lPk" = (
@@ -26892,9 +25390,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "lPE" = (
@@ -26907,20 +25405,8 @@
 	pixel_x = 4;
 	pixel_y = 2
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/service/library)
-"lPX" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "lQn" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/effect/turf_decal/stripes/line{
@@ -26946,11 +25432,10 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/warning/pods{
+	pixel_y = 30
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -27000,16 +25485,12 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "lRW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "lRX" = (
@@ -27043,17 +25524,28 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"lSL" = (
+/obj/structure/table,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/service/kitchen)
 "lTt" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -27066,6 +25558,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
+"lUD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit)
 "lUP" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -27091,28 +25588,12 @@
 /obj/item/grenade/chem_grenade/glitter,
 /turf/open/floor/iron,
 /area/security/brig)
-"lVx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
-"lVz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "lVC" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "lVG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "lVI" = (
@@ -27137,6 +25618,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/range)
 "lWt" = (
@@ -27150,13 +25632,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "lWC" = (
@@ -27178,25 +25657,22 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "lWT" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "lXm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "Telecomms and AI";
 	req_access_txt = "19"
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/command)
 "lYe" = (
@@ -27262,6 +25738,11 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port)
+"lZH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/edge,
+/area/engineering/main)
 "lZW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -27308,6 +25789,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "mcB" = (
@@ -27316,14 +25799,19 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/engineering/main)
 "mcT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
+"mcU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "mdd" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -27353,9 +25841,7 @@
 	uses = 10
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "meB" = (
@@ -27366,13 +25852,9 @@
 	pixel_y = -24;
 	req_access_txt = "31"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
 "meM" = (
@@ -27396,7 +25878,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "mfn" = (
@@ -27432,12 +25914,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "mfS" = (
@@ -27470,6 +25946,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -27494,6 +25972,13 @@
 /obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/plating,
 /area/security/prison/safe)
+"mht" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
 "mhN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -27523,6 +26008,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "mio" = (
@@ -27549,6 +26035,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/port)
 "miZ" = (
@@ -27558,6 +26045,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "mjq" = (
@@ -27572,6 +26060,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/port)
 "mjw" = (
@@ -27633,9 +26122,7 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mkQ" = (
@@ -27687,6 +26174,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "mne" = (
@@ -27708,8 +26196,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "mnw" = (
@@ -27734,14 +26222,14 @@
 "mnA" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
 	name = "Chamber Bypass"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "mnE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "mnR" = (
@@ -27755,6 +26243,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "mnV" = (
@@ -27765,31 +26254,36 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
 "mnZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "moj" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
 /area/engineering/main)
 "mor" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/courtroom)
+"moO" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "moX" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -27832,8 +26326,8 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "mpM" = (
@@ -27844,18 +26338,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "mqe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "mqm" = (
@@ -27893,11 +26385,18 @@
 /area/science/xenobiology)
 "mqz" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
+"mqL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "mqQ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -27907,6 +26406,9 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"mrq" = (
+/turf/closed/wall/r_wall,
+/area/maintenance/starboard/fore)
 "msF" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -27920,24 +26422,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /turf/open/floor/iron,
 /area/science/nanite)
 "mtq" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "mtA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "mtJ" = (
@@ -27959,9 +26455,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "mup" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "muw" = (
@@ -27975,12 +26469,13 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "muR" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet,
 /turf/open/floor/iron,
 /area/engineering/main)
 "muZ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -28025,16 +26520,12 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mvt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "mwm" = (
@@ -28060,9 +26551,6 @@
 	},
 /turf/open/floor/grass,
 /area/command)
-"mwJ" = (
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/main)
 "mwO" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -28070,31 +26558,20 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "mwP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/morgue{
 	name = "Private Study";
 	req_access_txt = "37"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/library)
-"mwV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/service/hydroponics)
-"mxc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "mxm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -28118,15 +26595,13 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "myw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "myx" = (
@@ -28138,7 +26613,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "myQ" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -28149,12 +26624,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"mze" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "mzq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/conveyor_switch/oneway{
@@ -28181,14 +26650,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "mAb" = (
@@ -28201,6 +26666,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "mAK" = (
@@ -28209,34 +26675,21 @@
 	pixel_x = 8;
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "mAP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/chair/office{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/librarian,
+/turf/open/floor/carpet/blue,
 /area/service/library)
-"mBt" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "mBV" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -28250,6 +26703,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "mDp" = (
@@ -28260,9 +26716,35 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"mDy" = (
+/obj/machinery/space_heater,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"mDM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "mDX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -28275,12 +26757,8 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Cell 2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "mEb" = (
@@ -28290,9 +26768,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "mEq" = (
@@ -28317,35 +26795,33 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mFd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "mFo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "mFy" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "mFB" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "mFL" = (
@@ -28369,6 +26845,12 @@
 /obj/item/analyzer,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
+"mGD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mGG" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -28392,13 +26874,8 @@
 /turf/open/floor/plating,
 /area/service/kitchen)
 "mHQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "mHZ" = (
@@ -28406,7 +26883,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
 	name = "Cold Loop to Gas"
 	},
 /turf/open/floor/engine,
@@ -28416,13 +26892,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "mIx" = (
@@ -28435,12 +26907,20 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"mIL" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel Viewing Room"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/service/chapel/main)
 "mJh" = (
 /obj/machinery/camera{
 	c_tag = "Bar Storage";
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
@@ -28508,11 +26988,9 @@
 /turf/open/floor/carpet/orange,
 /area/security/detectives_office)
 "mKV" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
 "mLm" = (
@@ -28533,10 +27011,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
+"mLA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "mLC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "mLP" = (
@@ -28546,11 +27029,10 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "mLZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command)
 "mML" = (
@@ -28585,12 +27067,8 @@
 	name = "Isolation A";
 	req_access_txt = "39"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "mOB" = (
@@ -28611,10 +27089,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "mPj" = (
@@ -28641,17 +27119,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
-"mQs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "mQu" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron/showroomfloor,
@@ -28703,6 +27173,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/color_adapter,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "mRJ" = (
@@ -28714,26 +27185,6 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
-"mSn" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
-"mSS" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = -7;
-	pixel_y = 1
-	},
-/obj/item/wrench/medical,
-/obj/item/storage/pill_bottle/mannitol,
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "mSU" = (
 /obj/structure/sign/poster/official/obey,
 /turf/closed/wall,
@@ -28758,13 +27209,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "mTk" = (
@@ -28772,6 +27219,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "mTn" = (
@@ -28791,8 +27239,6 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
 "mTo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -28800,6 +27246,8 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mTy" = (
@@ -28807,15 +27255,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"mTz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/grimy,
-/area/security/prison/safe)
 "mTA" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
@@ -28823,6 +27262,8 @@
 	sortType = 2
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "mTW" = (
@@ -28847,12 +27288,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"mUb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "mUl" = (
 /obj/structure/moisture_trap,
 /turf/open/floor/plating,
@@ -28870,17 +27305,11 @@
 /area/science/research)
 "mUD" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
-"mUO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "mVn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -28897,19 +27326,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "mVv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "mVJ" = (
@@ -28937,6 +27363,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "mWA" = (
@@ -28947,8 +27374,11 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"mWH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mWM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
@@ -28987,12 +27417,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/office)
@@ -29033,8 +27457,8 @@
 /area/command/heads_quarters/rd)
 "mYg" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/plating,
 /area/science/server)
 "mYo" = (
@@ -29049,18 +27473,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
-"mZF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "nab" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Server Room";
 	req_access_txt = "30"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron/dark,
 /area/science/server)
 "nam" = (
@@ -29095,6 +27514,15 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"nau" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit)
 "naz" = (
 /obj/structure/moisture_trap,
 /turf/open/floor/plating,
@@ -29171,7 +27599,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/main)
 "ncm" = (
@@ -29187,17 +27615,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"ndz" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "ndN" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
@@ -29206,13 +27623,13 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Cafeteria"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "ndT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -29259,16 +27676,19 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "nfu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/library)
 "nfy" = (
@@ -29285,21 +27705,27 @@
 /area/space/nearstation)
 "nfD" = (
 /obj/structure/closet/emcloset/anchored,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command)
 "ngr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"ngx" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "ngD" = (
 /obj/machinery/computer/security/mining{
 	dir = 1
@@ -29320,28 +27746,18 @@
 /area/security/execution/education)
 "ngV" = (
 /obj/structure/table,
-/obj/item/circuitboard/machine/HFR_core,
-/obj/item/circuitboard/machine/HFR_fuel_input,
-/obj/item/circuitboard/machine/HFR_interface,
-/obj/item/circuitboard/machine/HFR_moderator_input,
-/obj/item/circuitboard/machine/HFR_waste_output,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
+/obj/item/stack/sheet/plasteel/fifty,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"ngZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+"nhh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
+/area/maintenance/port)
 "nhm" = (
 /obj/effect/turf_decal,
 /obj/effect/landmark/start/atmospheric_technician,
@@ -29354,12 +27770,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "nhE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "nhU" = (
@@ -29376,9 +27794,7 @@
 	c_tag = "Ian's Room";
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "niq" = (
@@ -29398,6 +27814,9 @@
 "niR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -29424,6 +27843,10 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/cargo/storage)
+"nkh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/fore)
 "nkv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -29438,15 +27861,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
-"nlv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/science/storage)
 "nlX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29473,18 +27887,29 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"nnD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "nog" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command)
 "noH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "noK" = (
@@ -29498,6 +27923,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/port)
 "noX" = (
@@ -29560,6 +27986,7 @@
 /area/science/lab)
 "nqh" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
 "nqn" = (
@@ -29567,15 +27994,20 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "nqF" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/education)
+"nqN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "nqS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29586,14 +28018,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "nqV" = (
@@ -29658,9 +28086,9 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "nsS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/multilayer/connected,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "nsU" = (
@@ -29669,13 +28097,9 @@
 	req_access_txt = "10"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "nti" = (
@@ -29694,19 +28118,12 @@
 /obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/plating,
 /area/security/prison/safe)
-"ntr" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 10
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ntJ" = (
 /obj/item/ectoplasm,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "ntV" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -29775,12 +28192,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
-"nvW" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/main)
 "nwA" = (
 /obj/machinery/smartfridge,
 /turf/open/floor/iron,
@@ -29793,12 +28204,19 @@
 	name = "Hydroponics Desk";
 	req_access_txt = "35"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "nwX" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engineering/gravity_generator)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/rnd_secure,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/storage/tech)
 "nxk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29819,12 +28237,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/service/kitchen)
-"nxK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "nxS" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -29860,16 +28272,14 @@
 	},
 /area/maintenance/starboard/aft)
 "nzd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "nzo" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "nzD" = (
@@ -29878,6 +28288,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/fore)
+"nAl" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "nAA" = (
 /turf/closed/wall,
 /area/commons/storage/primary)
@@ -29894,13 +28310,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
+"nBp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "nBq" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "nBH" = (
@@ -29924,20 +28344,33 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"nBW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
+"nCc" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/mineral/plastitanium{
+	name = "black plastitanium floor"
+	},
+/area/service/bar)
 "nCk" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "nCm" = (
@@ -29954,28 +28387,27 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "nCq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "nCs" = (
-/obj/structure/table,
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
-"nCM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/medical/virology)
 "nCU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
@@ -30004,13 +28436,9 @@
 	name = "rd sorting disposal pipe";
 	sortType = 13
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "nDS" = (
@@ -30018,22 +28446,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nDV" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/violet,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
-"nEB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "nEJ" = (
 /obj/machinery/computer/bank_machine,
 /obj/machinery/light{
@@ -30043,11 +28462,9 @@
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "nFu" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "nFy" = (
@@ -30071,23 +28488,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "nGh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Distro to Waste"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -30102,12 +28515,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/research)
 "nGv" = (
@@ -30132,10 +28541,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "nHg" = (
@@ -30148,15 +28555,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"nHp" = (
+/obj/structure/cable,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "nHO" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "nIf" = (
@@ -30165,16 +28577,18 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"nIk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/command)
 "nIB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "nIT" = (
@@ -30184,8 +28598,9 @@
 /turf/open/floor/iron,
 /area/service/library)
 "nJg" = (
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Ports to Process"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -30194,13 +28609,9 @@
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "nJO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "nJW" = (
@@ -30271,16 +28682,6 @@
 	},
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
-"nMT" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "nNy" = (
 /obj/machinery/camera{
 	c_tag = "West Hallway - Robotics";
@@ -30308,12 +28709,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "nOq" = (
@@ -30323,9 +28720,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "nOr" = (
@@ -30361,33 +28756,13 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"nPs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"nPx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/science/research)
 "nPX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "nQc" = (
@@ -30404,9 +28779,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "nQs" = (
@@ -30422,28 +28797,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"nQQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/lab)
 "nRg" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
-"nRl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "nRK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/service/chapel/main)
 "nRR" = (
@@ -30457,6 +28818,7 @@
 	pixel_y = 5
 	},
 /obj/item/stamp/rd,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "nRT" = (
@@ -30468,7 +28830,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/iannewyear,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "nSz" = (
@@ -30486,7 +28848,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "nTr" = (
@@ -30494,7 +28856,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/research_director,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "nTw" = (
@@ -30510,8 +28872,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"nTG" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "nTJ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -30551,18 +28921,14 @@
 	name = "Security RC";
 	pixel_y = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "nVl" = (
@@ -30574,9 +28940,6 @@
 "nVw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 5
 	},
 /obj/machinery/camera{
 	c_tag = "R&D Server Room";
@@ -30591,16 +28954,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/science/server)
 "nWg" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "nWs" = (
@@ -30618,15 +28976,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"nWy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plastic,
+/area/hallway/secondary/service)
 "nWH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "nWX" = (
@@ -30636,13 +28998,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
 "nXh" = (
@@ -30666,9 +29024,9 @@
 	req_access_txt = "19"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "nXD" = (
@@ -30704,18 +29062,12 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
 "nYf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -30723,6 +29075,8 @@
 	dir = 1
 	},
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "nYk" = (
@@ -30762,9 +29116,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nZh" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nZE" = (
@@ -30782,29 +29135,30 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 9
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
 	},
 /obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/science/server)
-"oaO" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "oaP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
+"obt" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/cafeteria,
+/area/security/prison)
 "obW" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -30831,22 +29185,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
-"obY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "ocj" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Cell 5"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "ocl" = (
@@ -30874,9 +29218,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "ocu" = (
@@ -30896,6 +29238,7 @@
 "ocz" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/brig)
 "ocJ" = (
@@ -30904,6 +29247,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"odN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/mixing)
 "odO" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -30913,8 +29262,8 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "odS" = (
@@ -30927,23 +29276,19 @@
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "oee" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/bar)
 "oeh" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green{
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -30958,18 +29303,14 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "ofq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "ofA" = (
@@ -31024,15 +29365,6 @@
 /obj/item/multitool,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
-"ogY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/security/execution/transfer)
 "ohu" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -31052,10 +29384,9 @@
 /turf/open/floor/grass,
 /area/command)
 "oib" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "oiD" = (
@@ -31100,17 +29431,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"ojV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "okk" = (
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
@@ -31119,6 +29439,7 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "olc" = (
@@ -31159,8 +29480,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "olN" = (
@@ -31182,8 +29503,11 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "olV" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable/multilayer/connected,
+/obj/machinery/computer/security/telescreen/engine{
+	dir = 8;
+	pixel_x = 24;
+	pixel_y = -4
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "olZ" = (
@@ -31193,16 +29517,12 @@
 	sortType = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "omc" = (
@@ -31222,14 +29542,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/service/hydroponics)
-"omh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "omu" = (
 /obj/machinery/light/small,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "omx" = (
@@ -31245,9 +29561,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "omJ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -31258,6 +29571,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/simple/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "omL" = (
@@ -31284,15 +29600,15 @@
 /turf/open/floor/plating,
 /area/hallway/primary/starboard)
 "ooH" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/turf/open/floor/iron/smooth_half{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
 /area/engineering/main)
 "ooP" = (
 /obj/machinery/light,
@@ -31301,37 +29617,26 @@
 	dir = 1;
 	network = list("minisat")
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command)
 "ooZ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "opa" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"opp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "opY" = (
 /turf/open/floor/iron,
 /area/security/execution/transfer)
@@ -31340,16 +29645,6 @@
 /obj/item/gun/energy/e_gun/mini,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"oqj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oql" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -31364,7 +29659,7 @@
 /area/cargo/sorting)
 "oqm" = (
 /obj/structure/table,
-/turf/open/floor/iron,
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "oqE" = (
 /obj/effect/turf_decal/loading_area{
@@ -31372,15 +29667,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"oqG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
 "oqT" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -31417,10 +29703,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "orB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -31428,6 +29710,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "osb" = (
@@ -31439,14 +29723,13 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "osr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/gravity_generator)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/ai,
+/turf/open/floor/iron,
+/area/engineering/storage/tech)
 "osN" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -31456,32 +29739,19 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/port)
-"osV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/cargo/office)
 "osZ" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "otG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ouc" = (
@@ -31516,6 +29786,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "owh" = (
@@ -31525,6 +29796,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "owt" = (
@@ -31572,10 +29844,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
+"oxh" = (
+/obj/effect/spawner/bundle/hobo_squat,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "oxj" = (
 /obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"oxx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard/aft)
 "oxT" = (
 /obj/structure/closet/secure_closet/exile,
 /obj/machinery/camera{
@@ -31602,15 +29884,20 @@
 /obj/item/clothing/gloves/color/latex,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"oyk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "oyv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/caution/white,
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "oyy" = (
@@ -31691,9 +29978,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -31708,11 +29992,11 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "oAn" = (
@@ -31747,6 +30031,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"oBl" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/black,
+/area/commons/dorms)
 "oBJ" = (
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
@@ -31787,6 +30078,17 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port)
+"oCY" = (
+/obj/effect/landmark/start/shaft_miner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
+"oDA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/tank_holder/oxygen,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "oDB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Quartermaster Maintenance";
@@ -31803,14 +30105,16 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
 "oDV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/service/library)
 "oEH" = (
@@ -31891,10 +30195,9 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "oGy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "oGQ" = (
@@ -31903,12 +30206,8 @@
 /area/service/hydroponics)
 "oGZ" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "oHf" = (
@@ -31919,12 +30218,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "oHg" = (
@@ -31967,6 +30263,8 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "oHu" = (
@@ -31992,7 +30290,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "oIO" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -32009,7 +30307,6 @@
 /area/maintenance/starboard)
 "oJl" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "oJn" = (
@@ -32017,13 +30314,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command)
 "oJq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "oJO" = (
@@ -32070,27 +30367,18 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "oLk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"oLo" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "oLz" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -32099,12 +30387,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "oLG" = (
@@ -32118,23 +30402,28 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "oMm" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "oMx" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"oMz" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/service/library)
 "oMC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -32143,13 +30432,16 @@
 /area/cargo/miningdock)
 "oMD" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "oML" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "oNa" = (
@@ -32170,12 +30462,19 @@
 /obj/structure/window{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/blue,
 /area/service/library)
 "oOk" = (
 /obj/machinery/flasher/portable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"oOm" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/iron,
+/area/engineering/main)
 "oOA" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
@@ -32186,6 +30485,14 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"oOG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port)
 "oPa" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -32230,13 +30537,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/item/beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "oQV" = (
@@ -32257,34 +30560,27 @@
 "oRn" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/medbay/lobby)
 "oRu" = (
 /obj/effect/landmark/start/prisoner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "oRw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "oRY" = (
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/pen,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "oSt" = (
@@ -32320,31 +30616,57 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"oSP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"oSV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"oTb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"oTu" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/black,
+/area/commons/dorms)
 "oTO" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "oUB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"oUE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "oUM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air to Sat";
+	piping_layer = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command)
 "oVi" = (
@@ -32370,12 +30692,8 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "oVO" = (
@@ -32383,26 +30701,34 @@
 	name = "Hydroponics";
 	req_access_txt = "35"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
+"oVR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Ports"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"oVW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "oWd" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/violet{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"oWh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/maintenance/disposal/incinerator)
 "oWq" = (
 /obj/machinery/nanite_programmer,
 /obj/effect/turf_decal/bot,
@@ -32414,6 +30740,8 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "oWZ" = (
@@ -32430,16 +30758,10 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "oXl" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/power/smes/engineering{
-	charge = 5e+006
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/gravity_generator)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/storage/tech)
 "oXq" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -32469,10 +30791,6 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"oYl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/security/armory)
 "oYo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 1;
@@ -32500,12 +30818,6 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "oZS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/door/window/northright{
 	dir = 4;
 	name = "Library Desk Door";
@@ -32518,7 +30830,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/blue,
 /area/service/library)
 "oZZ" = (
 /obj/effect/turf_decal/tile/blue{
@@ -32557,6 +30869,13 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/electrical)
+"pcc" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "pcg" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -32568,6 +30887,11 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"pcs" = (
+/obj/machinery/light/directional/north,
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/wood/tile,
+/area/service/library)
 "pcH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -32593,10 +30917,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "pdg" = (
@@ -32621,27 +30946,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
-"pdM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"pex" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "peJ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -32676,12 +30980,14 @@
 /area/hallway/primary/aft)
 "pfr" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/engineering/main)
 "pgv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "pgy" = (
@@ -32703,12 +31009,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"phv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "phT" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating{
@@ -32734,6 +31034,11 @@
 /obj/machinery/light/small,
 /turf/open/floor/iron,
 /area/science/storage)
+"pif" = (
+/turf/open/floor/iron/smooth_corner{
+	dir = 8
+	},
+/area/engineering/gravity_generator)
 "piz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -32764,13 +31069,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
 "pjf" = (
@@ -32842,32 +31142,26 @@
 /obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "pls" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "plX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers,
 /turf/open/floor/engine,
 /area/engineering/main)
 "pmn" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "pmw" = (
@@ -32881,6 +31175,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "pmO" = (
@@ -32902,7 +31198,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pmW" = (
@@ -32966,62 +31261,44 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/server)
 "pnR" = (
-/obj/machinery/atmospherics/pipe/simple,
 /turf/open/floor/iron,
 /area/science/server)
 "poo" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/tile,
 /area/service/library)
-"pos" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "pox" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "poL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"poS" = (
+/obj/structure/transit_tube/horizontal,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/space/basic,
+/area/tcommsat/computer)
 "ppj" = (
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
-"ppA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "ppC" = (
 /obj/machinery/computer/rdservercontrol{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/science/server)
 "pqA" = (
@@ -33068,12 +31345,8 @@
 /area/engineering/atmos)
 "prU" = (
 /mob/living/simple_animal/bot/secbot/pingsky,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "psZ" = (
@@ -33085,8 +31358,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "pto" = (
@@ -33095,23 +31368,31 @@
 /turf/open/floor/carpet/royalblue,
 /area/command)
 "ptu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "pty" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "ptI" = (
 /obj/machinery/computer/telecomms/server,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
+"ptJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "ptM" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -33120,19 +31401,16 @@
 /area/command/heads_quarters/ce)
 "ptT" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "pua" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "pud" = (
@@ -33152,12 +31430,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "puG" = (
@@ -33174,6 +31448,8 @@
 	pixel_x = 24
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "puT" = (
@@ -33197,13 +31473,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "pwa" = (
@@ -33215,12 +31487,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"pwd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "pwf" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/ausbushes/brflowers,
@@ -33240,8 +31506,8 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "pwC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "pwJ" = (
@@ -33252,6 +31518,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -33263,12 +31533,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "pxc" = (
@@ -33289,13 +31555,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "pxG" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/bar)
 "pxP" = (
@@ -33304,12 +31566,15 @@
 	},
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"pyg" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "pyp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "pys" = (
@@ -33320,9 +31585,9 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "pyL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -33334,6 +31599,9 @@
 	pixel_x = -8;
 	pixel_y = -25
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "pyP" = (
@@ -33341,9 +31609,9 @@
 /area/science/mixing)
 "pzd" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "pzi" = (
@@ -33361,9 +31629,6 @@
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
 "pAh" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
@@ -33379,9 +31644,9 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "pAy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "pBg" = (
@@ -33428,20 +31693,15 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"pCN" = (
-/obj/machinery/atmospherics/pipe/manifold4w/yellow/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pDb" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
 	name = "robotics sorting disposal pipe";
 	sortType = 14
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "pDo" = (
@@ -33458,6 +31718,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"pEc" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/bar)
 "pEd" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -33480,9 +31747,9 @@
 	req_access_txt = "55"
 	},
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "pFC" = (
@@ -33512,21 +31779,30 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"pGN" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "pGW" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "pHi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/command)
+"pHj" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "pHR" = (
 /obj/machinery/button/door{
 	desc = "A remote control switch for the medbay foyer.";
@@ -33538,28 +31814,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"pHW" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "pIg" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
 	name = "genetics sorting disposal pipe";
 	sortType = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "pIn" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -33590,11 +31858,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"pJi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/service/library)
 "pJt" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -33613,18 +31876,14 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "pJW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
 	name = "custodial sorting disposal pipe";
 	sortType = 22
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "pKd" = (
@@ -33642,20 +31901,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"pKh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "pKk" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -33666,9 +31911,6 @@
 	},
 /area/maintenance/department/electrical)
 "pKV" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -33679,8 +31921,15 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"pLf" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "pLz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -33706,10 +31955,12 @@
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command)
 "pME" = (
@@ -33724,24 +31975,16 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "pMJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "pMS" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "pNw" = (
@@ -33750,13 +31993,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"pNP" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "pOa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -33767,15 +32003,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"pOl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron/grimy,
-/area/security/prison/safe)
 "pOS" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 1
@@ -33812,21 +32039,22 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "pPE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/aft)
 "pPL" = (
 /obj/effect/spawner/randomcolavend,
-/turf/open/floor/iron,
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
+"pPS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/main)
 "pQh" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -33873,12 +32101,6 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "pRr" = (
@@ -33887,6 +32109,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"pRF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "pRI" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -33904,8 +32131,7 @@
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "pRO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "pRP" = (
@@ -33913,26 +32139,33 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/cargo/sorting)
-"pRS" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
-	dir = 4
+"pRZ" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/turf/open/floor/iron/white,
-/area/medical/cryo)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "pSt" = (
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "pTb" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 4
 	},
-/obj/machinery/meter,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pTu" = (
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
+"pTB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/command)
 "pUm" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -33951,6 +32184,8 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "pUX" = (
@@ -33962,9 +32197,9 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "pVH" = (
@@ -33990,6 +32225,11 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/orange,
 /area/commons/vacant_room/office)
+"pWr" = (
+/obj/structure/table/wood,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/bar)
 "pWw" = (
 /obj/structure/cable/layer1,
 /turf/open/floor/iron/dark/telecomms,
@@ -34039,13 +32279,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"pXK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "pYa" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
@@ -34068,24 +32301,25 @@
 	},
 /turf/open/floor/carpet/black,
 /area/maintenance/starboard/aft)
+"pZY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "qab" = (
 /obj/effect/landmark/start/shaft_miner,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "qav" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "qay" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "qaz" = (
@@ -34111,14 +32345,14 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "qaK" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown,
 /turf/open/space/basic,
 /area/space/nearstation)
 "qaL" = (
@@ -34132,22 +32366,15 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
-"qaV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/turf/open/floor/iron/sepia,
-/area/service/chapel/main)
 "qbr" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qbw" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qbO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -34162,14 +32389,17 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"qbX" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "qcp" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 1
@@ -34188,9 +32418,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "qde" = (
@@ -34200,13 +32431,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "qdt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -34245,14 +32469,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"qei" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/layer1,
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/main)
 "qey" = (
 /obj/machinery/suit_storage_unit/rd,
 /obj/machinery/status_display/ai{
@@ -34298,14 +32514,22 @@
 /area/maintenance/disposal/incinerator)
 "qfG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/server)
 "qfX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"qgc" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 6
+	},
+/turf/open/floor/iron{
+	dir = 8
+	},
+/area/engineering/atmos)
 "qgg" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
@@ -34316,12 +32540,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/range)
 "qgk" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 5
-	},
 /obj/machinery/light/small,
 /turf/open/floor/iron,
 /area/science/server)
@@ -34338,21 +32560,24 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 4
-	},
+/obj/structure/lattice,
 /turf/open/space/basic,
-/area/engineering/atmos)
-"qhf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/area/space/nearstation)
+"qhd" = (
+/obj/structure/cable,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
+"qhf" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "qhx" = (
@@ -34362,10 +32587,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "qhX" = (
@@ -34377,6 +32600,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "qin" = (
@@ -34396,8 +32620,8 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "qiv" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/science/server)
@@ -34410,13 +32634,9 @@
 	name = "Head of Personnel";
 	req_access_txt = "57"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "qiF" = (
@@ -34446,6 +32666,11 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
 /area/engineering/main)
+"qjj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "qjs" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -34458,8 +32683,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "qkf" = (
@@ -34502,9 +32727,9 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "qlC" = (
@@ -34546,11 +32771,11 @@
 	name = "Starboard Solar Array"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/airless/solarpanel,
+/turf/open/floor/iron/solarpanel,
 /area/maintenance/solars/starboard/aft)
 "qnj" = (
 /obj/effect/decal/cleanable/generic,
-/obj/structure/closet/emcloset/anchored,
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "qnO" = (
@@ -34607,30 +32832,19 @@
 /area/maintenance/disposal/incinerator)
 "qpi" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "qpl" = (
 /obj/machinery/gulag_teleporter,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"qpm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "qpo" = (
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "qpp" = (
@@ -34656,17 +32870,29 @@
 /obj/machinery/doppler_array/research/science{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/science/mixing)
 "qqh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"qqk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "qqn" = (
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
+"qqC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qqE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -34683,23 +32909,28 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "qrr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/item/beacon,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "qrt" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
+"qrH" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qsa" = (
 /obj/structure/plaque/static_plaque/atmos{
 	pixel_y = -32
@@ -34743,6 +32974,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -34754,9 +32987,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/office)
 "qtc" = (
@@ -34769,12 +33003,13 @@
 "qtf" = (
 /turf/closed/indestructible/riveted,
 /area/science/test_area)
-"qtt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/visible{
-	dir = 9
+"qtz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "qtD" = (
 /obj/machinery/nuclearbomb/selfdestruct,
 /turf/open/floor/iron,
@@ -34786,13 +33021,6 @@
 /obj/effect/spawner/structure/window/reinforced/indestructable,
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"quk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "qvd" = (
 /obj/item/storage/secure/safe{
 	pixel_x = -23
@@ -34822,6 +33050,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "qwl" = (
@@ -34844,10 +33073,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
-"qwB" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qwZ" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -34855,6 +33080,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/range)
 "qxj" = (
@@ -34872,6 +33098,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/service/theater)
 "qxu" = (
@@ -34880,12 +33107,9 @@
 	},
 /area/maintenance/central)
 "qxD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "qxO" = (
@@ -34907,14 +33131,15 @@
 "qzX" = (
 /turf/open/floor/carpet/black,
 /area/security/prison)
+"qzZ" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "qAe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "qAw" = (
@@ -34929,6 +33154,13 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron,
 /area/command)
+"qAM" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/main)
 "qBf" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "Robotics Belt B";
@@ -34944,16 +33176,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "qBL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qBR" = (
@@ -35007,6 +33236,7 @@
 "qDG" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/effect/decal/cleanable/confetti,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "qDX" = (
@@ -35025,21 +33255,11 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"qEC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/robotics/lab)
 "qEP" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
@@ -35050,15 +33270,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
-"qFd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "qFh" = (
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
@@ -35077,7 +33288,10 @@
 /area/hallway/primary/fore)
 "qFV" = (
 /obj/effect/spawner/randomsnackvend,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "qGQ" = (
 /obj/effect/turf_decal/tile/green{
@@ -35100,13 +33314,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "qHj" = (
@@ -35114,7 +33324,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "qHp" = (
@@ -35124,6 +33335,11 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/starboard/fore)
+"qHu" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/engine_smes)
 "qHw" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -35186,15 +33402,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
-"qKk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+"qKs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/command)
 "qKG" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "teleportershutters";
@@ -35205,43 +33418,31 @@
 "qKN" = (
 /turf/closed/wall/r_wall,
 /area/command/teleporter)
+"qKS" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qLb" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command)
-"qLe" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "qLq" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
-"qLs" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
+"qLt" = (
+/obj/structure/tank_holder/oxygen,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qLB" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
@@ -35261,14 +33462,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"qMo" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "qMx" = (
 /obj/structure/cable,
 /obj/machinery/light_switch{
@@ -35278,14 +33471,8 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"qMQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
 "qMT" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "qNh" = (
@@ -35301,25 +33488,20 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "qNo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
-	},
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "qNv" = (
@@ -35337,19 +33519,16 @@
 	req_access_txt = "10;24"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "qPW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "qPY" = (
@@ -35368,41 +33547,30 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "qQd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "qQf" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "qQg" = (
 /obj/structure/closet/crate/bin,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "qQr" = (
@@ -35417,15 +33585,20 @@
 /area/service/bar)
 "qQD" = (
 /obj/machinery/medical_kiosk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
+"qQH" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Tech Storage";
+	req_access_txt = "19;23"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "qRb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -35443,34 +33616,24 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
-"qRp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+"qRG" = (
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/exam_room)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/service/hydroponics/garden)
 "qRL" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"qRU" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qSL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "qSY" = (
@@ -35483,9 +33646,13 @@
 	dir = 8;
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"qTO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "qTV" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -35504,13 +33671,11 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "qUD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "qVf" = (
@@ -35566,17 +33731,11 @@
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "qXP" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 9
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"qXV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "qXX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -35592,12 +33751,8 @@
 /area/medical/virology)
 "qYx" = (
 /obj/effect/landmark/start/quartermaster,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qYz" = (
@@ -35623,23 +33778,22 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "qYS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "qYW" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "qYZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/biohazard,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/medical/virology)
 "qZr" = (
@@ -35650,31 +33804,28 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/command)
+"qZG" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "qZN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "qZR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "rac" = (
@@ -35690,13 +33841,18 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
+"ral" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Mix"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rau" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -35710,9 +33866,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/server)
 "raE" = (
@@ -35740,13 +33895,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "raY" = (
@@ -35766,6 +33917,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
 "rbk" = (
@@ -35779,13 +33931,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "rbK" = (
@@ -35800,11 +33948,9 @@
 /turf/open/floor/grass,
 /area/cargo/office)
 "rbN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "rbU" = (
@@ -35816,9 +33962,8 @@
 	pixel_x = 8;
 	pixel_y = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "rcx" = (
@@ -35841,7 +33986,6 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "rcG" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -35852,6 +33996,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rcM" = (
@@ -35860,31 +34005,15 @@
 	req_one_access_txt = "9"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/science/genetics)
-"rcV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/landmark/start/librarian,
-/turf/open/floor/wood,
-/area/service/library)
-"rdO" = (
-/obj/structure/cable/layer1,
-/turf/open/floor/iron,
-/area/engineering/main)
 "rei" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/command)
 "rek" = (
@@ -35917,15 +34046,15 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
 "reS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "reV" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -35934,9 +34063,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "rfn" = (
@@ -35966,12 +34094,19 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
+"rgW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/starboard/aft)
 "rhb" = (
 /obj/item/radio/intercom{
-	pixel_y = 25
+	pixel_y = 37
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -35982,17 +34117,19 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/science/mixing)
-"rhh" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/machinery/button/massdriver{
-	id = "toxinsdriver";
-	pixel_y = 24
+/obj/machinery/computer/pod/old/mass_driver_controller/toxinsdriver{
+	pixel_y = 26
 	},
+/turf/open/floor/iron,
+/area/science/mixing)
+"rhh" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/science/mixing)
 "rho" = (
@@ -36017,23 +34154,10 @@
 "rif" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
-"rip" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable/layer3,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/command/storage/satellite)
 "riy" = (
 /obj/machinery/light{
 	dir = 8
@@ -36052,11 +34176,7 @@
 /area/maintenance/port/aft)
 "rjm" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/computer/security/telescreen/toxins{
-	dir = 8;
-	pixel_x = 30
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
@@ -36079,12 +34199,7 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
 "rke" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "rkx" = (
@@ -36151,6 +34266,14 @@
 "rmy" = (
 /turf/open/floor/plating,
 /area/security/prison/safe)
+"rmB" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/turf/closed/wall,
+/area/medical/cryo)
+"rmK" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "rmP" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -36159,6 +34282,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "rmU" = (
@@ -36170,12 +34295,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"rnb" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
+"rni" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
-/area/engineering/main)
+/area/hallway/secondary/entry)
 "rnj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron,
@@ -36194,8 +34322,17 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
+"rnY" = (
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "roz" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -36221,8 +34358,8 @@
 	name = "Break Room";
 	req_access_txt = "39"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "rpZ" = (
@@ -36230,6 +34367,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "rqg" = (
@@ -36242,9 +34381,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rqj" = (
@@ -36260,21 +34399,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"rqA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/commons/dorms)
 "rqE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36371,12 +34500,6 @@
 	id = "AI Chamber entrance shutters";
 	name = "AI Chamber entrance shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	broadcasting = 1;
 	frequency = 1447;
@@ -36389,6 +34512,8 @@
 	pixel_x = -8;
 	pixel_y = 22
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "rtd" = (
@@ -36396,12 +34521,10 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "rtn" = (
@@ -36419,6 +34542,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/brig)
 "ruP" = (
@@ -36427,15 +34551,18 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/atmos_control/toxinsmix{
+	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
 "ruR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "rvp" = (
@@ -36446,18 +34573,30 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"rwb" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "aux_base_shutters";
+	name = "Auxillary Base Shutters"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/construction/mining/aux_base)
 "rwm" = (
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"rwo" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rwq" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Foyer";
 	req_one_access_txt = "32;19"
 	},
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "rwr" = (
@@ -36465,6 +34604,11 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"rwz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "rwH" = (
@@ -36485,7 +34629,7 @@
 	pixel_x = -24
 	},
 /obj/structure/bed/dogbed/ian,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "rxU" = (
@@ -36493,6 +34637,7 @@
 /area/cargo/office)
 "rxZ" = (
 /obj/item/grown/bananapeel,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "rym" = (
@@ -36516,45 +34661,17 @@
 	},
 /turf/open/floor/grass,
 /area/medical/medbay/central)
-"ryI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
-"ryJ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ryV" = (
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/command)
 "rza" = (
 /obj/effect/landmark/start/cyborg,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
 "rzJ" = (
@@ -36563,9 +34680,9 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "rAm" = (
@@ -36586,18 +34703,16 @@
 	name = "atmospherics sorting disposal pipe";
 	sortType = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rBl" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "rBp" = (
 /obj/structure/table/reinforced,
@@ -36605,16 +34720,6 @@
 /obj/item/pen,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"rBt" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "rCg" = (
 /obj/machinery/light,
 /turf/open/floor/iron,
@@ -36641,6 +34746,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rDt" = (
@@ -36665,13 +34772,9 @@
 	name = "Gateway Access";
 	req_access_txt = "62"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
 "rEm" = (
@@ -36681,7 +34784,10 @@
 "rEw" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "rEx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36744,7 +34850,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "rGG" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 5
 	},
 /turf/open/floor/iron,
@@ -36764,15 +34870,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "rHj" = (
@@ -36812,13 +34914,8 @@
 /area/medical/medbay/lobby)
 "rHH" = (
 /obj/effect/landmark/start/paramedic,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "rHI" = (
@@ -36827,6 +34924,7 @@
 	name = "privacy shutter"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
 "rIm" = (
@@ -36843,8 +34941,19 @@
 	pixel_x = -24
 	},
 /obj/structure/chair,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/brig)
+"rJK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "rKi" = (
 /obj/machinery/door/airlock/external{
 	name = "Tcoms External Access";
@@ -36852,12 +34961,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/command)
@@ -36872,18 +34975,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"rKW" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "rKX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "rKZ" = (
@@ -36894,22 +34991,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "rLj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
@@ -36932,45 +35019,30 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"rLO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
-"rMe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "rMn" = (
 /obj/machinery/nanite_program_hub,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/science/nanite)
 "rMu" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/command,
+/obj/machinery/power/smes/engineering{
+	charge = 5e+006
+	},
 /turf/open/floor/iron,
-/area/engineering/storage/tech)
+/area/engineering/gravity_generator)
 "rME" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/science/nanite)
-"rNk" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
+"rMJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "rNp" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/door/window/eastleft{
@@ -36978,13 +35050,13 @@
 	name = "Coffin Storage";
 	req_access_txt = "22"
 	},
-/turf/open/floor/iron/sepia,
+/turf/open/floor/carpet/black,
 /area/service/chapel/main)
 "rNA" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "rNE" = (
@@ -37011,25 +35083,9 @@
 	name = "Medbay";
 	req_one_access_txt = "5"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"rOI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "rOJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -37046,13 +35102,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "rPv" = (
@@ -37090,37 +35142,25 @@
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
-"rRR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "rSo" = (
 /turf/closed/wall,
 /area/commons/storage/art)
-"rSA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply,
-/turf/open/floor/plating,
-/area/maintenance/central/secondary)
 "rSF" = (
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "rSS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "rST" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "rSU" = (
@@ -37128,6 +35168,8 @@
 	name = "Bar Storage";
 	req_access_txt = "25"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
@@ -37159,8 +35201,8 @@
 /obj/machinery/door/airlock/research/glass{
 	req_access_txt = "29"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "rTW" = (
@@ -37170,8 +35212,9 @@
 "rTZ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -37225,12 +35268,14 @@
 	name = "Auxiliary Chamber";
 	req_access_txt = "24"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "rVk" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hideout"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rVs" = (
@@ -37238,8 +35283,7 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rWe" = (
@@ -37262,19 +35306,11 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
-"rWB" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Pure to Recycle"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "rWP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "rWW" = (
@@ -37292,14 +35328,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"rWX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/prison)
 "rXc" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
@@ -37308,8 +35336,23 @@
 /area/security/office)
 "rXk" = (
 /obj/structure/chair/stool,
+/obj/structure/sign/painting/library_private{
+	dir = 4;
+	pixel_x = -32
+	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/library)
+"rXA" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms)
 "rYf" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister,
@@ -37333,13 +35376,14 @@
 	req_access_txt = "11"
 	},
 /obj/structure/cable,
+/obj/machinery/power/emitter/welded,
 /turf/open/floor/plating,
 /area/engineering/main)
 "rYi" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/violet,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rYp" = (
@@ -37361,40 +35405,29 @@
 "rYC" = (
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"rYD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rYJ" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"rYX" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "rYZ" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/secequipment,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "rZd" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/violet,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "rZu" = (
@@ -37412,6 +35445,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"rZy" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood,
+/area/service/bar)
 "rZB" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -37429,24 +35468,15 @@
 "rZW" = (
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
-"saa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/execution/education)
 "saq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
 	name = "bar sorting disposal pipe";
 	sortType = 19
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "sat" = (
@@ -37457,6 +35487,10 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
+"sbi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/prison)
 "sbx" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -37476,6 +35510,15 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
+"sbI" = (
+/obj/machinery/door/airlock/security{
+	name = "Interrogation";
+	req_access_txt = "63"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "sbJ" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
@@ -37502,15 +35545,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
-"sdl" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable/layer3,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "sdI" = (
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "sdM" = (
@@ -37522,6 +35560,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "sdR" = (
@@ -37553,7 +35593,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
+	dir = 4;
 	name = "Chamber Inject"
 	},
 /turf/open/floor/engine,
@@ -37563,11 +35603,16 @@
 	c_tag = "Science Hallway";
 	network = list("ss13","rd")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "seZ" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
 /area/engineering/main)
 "sfl" = (
 /obj/machinery/door/window/northleft{
@@ -37604,22 +35649,20 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"sfL" = (
-/obj/structure/cable/layer1,
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/main)
-"sgb" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+"sgp" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/gloves,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "sgE" = (
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "sgI" = (
@@ -37663,25 +35706,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"shl" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/command)
 "shF" = (
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "shG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "shO" = (
@@ -37692,22 +35725,14 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/grass,
 /area/science/xenobiology)
-"shQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/research)
 "sik" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
 	name = "Fitness"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "sis" = (
@@ -37747,24 +35772,16 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/security/brig)
+"ske" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/service/bar)
 "skp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/science/storage)
-"skC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "skG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -37791,12 +35808,16 @@
 	name = "SERVER ROOM";
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "slw" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "slB" = (
@@ -37823,9 +35844,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "smo" = (
@@ -37838,10 +35859,13 @@
 	req_access_txt = "7"
 	},
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "snf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "snh" = (
@@ -37883,6 +35907,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
+"sob" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/engineering/engine_smes)
 "sov" = (
 /turf/closed/wall/r_wall,
 /area/security/courtroom)
@@ -37890,25 +35919,29 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "soG" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/violet,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"soK" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit)
 "soQ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -37916,15 +35949,19 @@
 /obj/machinery/portable_atmospherics/canister/bz,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"soY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium{
+	name = "black plastitanium floor"
+	},
+/area/service/bar)
 "spj" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Maintenance";
 	req_access_txt = "35"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "spm" = (
@@ -37934,16 +35971,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"spo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "sps" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -37953,26 +35982,21 @@
 	name = "biohazard containment door"
 	},
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "spy" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "spB" = (
 /obj/effect/landmark/blobstart,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "sqy" = (
@@ -37987,9 +36011,6 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sqP" = (
@@ -37998,50 +36019,39 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "srf" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "Process Bypass to Waste"
+	name = "Process to Waste"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"sri" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "srC" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room";
 	req_access_txt = "7"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"srD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "srJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
 "srQ" = (
@@ -38049,44 +36059,32 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "srX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
 "ssp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/space/basic,
 /area/space/nearstation)
 "sst" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "ssG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "stc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
 "sth" = (
@@ -38104,19 +36102,31 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "stt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "stu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"suf" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"sup" = (
+/obj/docking_port/stationary/random{
+	id = "pod_2_lavaland";
+	name = "lavaland"
+	},
+/turf/open/space/basic,
+/area/space)
 "suU" = (
 /obj/structure/frame/machine,
 /turf/open/floor/wood{
@@ -38134,12 +36144,8 @@
 	name = "Toxins Launch Room";
 	req_access_txt = "7"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
 "svp" = (
@@ -38149,21 +36155,20 @@
 "svN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/range)
 "svO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "svX" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -38190,9 +36195,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "swL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "swN" = (
@@ -38203,7 +36206,8 @@
 /area/engineering/atmos)
 "sxe" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sxg" = (
@@ -38223,21 +36227,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "sxP" = (
 /turf/open/floor/grass,
 /area/medical/virology)
 "sye" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "syg" = (
@@ -38261,45 +36258,36 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
+"szl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/service/hydroponics)
 "szW" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
 	name = "secure storage"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/engineering/main)
 "szX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
-"sAx" = (
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "sAA" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sAF" = (
@@ -38317,11 +36305,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"sAI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/lab)
 "sBb" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -38332,15 +36315,12 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sBt" = (
@@ -38363,6 +36343,8 @@
 	name = "Visiting Room"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "sBT" = (
@@ -38390,6 +36372,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
+"sCG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "sCR" = (
 /mob/living/simple_animal/bot/floorbot,
 /obj/effect/turf_decal/tile/blue{
@@ -38431,10 +36418,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "sEr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/research/explosive_compressor,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/science/mixing)
 "sEt" = (
@@ -38448,8 +36432,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/thermomachine/heater{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
@@ -38476,10 +36460,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "sFT" = (
@@ -38487,9 +36469,9 @@
 	codes_txt = "patrol;next_patrol=8";
 	location = "7"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "sGv" = (
@@ -38512,18 +36494,16 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "sHe" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "sHx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "sHE" = (
@@ -38531,12 +36511,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "sHP" = (
@@ -38570,9 +36546,7 @@
 /area/cargo/office)
 "sIj" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
 /turf/open/floor/engine,
 /area/engineering/main)
 "sIv" = (
@@ -38581,11 +36555,9 @@
 	req_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "sIx" = (
@@ -38593,13 +36565,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "sIJ" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen/engine,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 22
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
@@ -38641,21 +36611,19 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "sJu" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "sJD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "sJJ" = (
@@ -38667,6 +36635,7 @@
 	pixel_y = -30
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
 "sJZ" = (
@@ -38676,7 +36645,7 @@
 /area/construction/mining/aux_base)
 "sKc" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "sKk" = (
@@ -38693,6 +36662,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "sKU" = (
@@ -38702,12 +36672,6 @@
 	departmentType = 5;
 	name = "Captain RC";
 	pixel_y = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
@@ -38723,9 +36687,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "sLa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "sLD" = (
@@ -38764,10 +36726,9 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 1
 	},
-/obj/machinery/meter,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "sMD" = (
@@ -38786,10 +36747,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "sNe" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sNP" = (
@@ -38870,6 +36831,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "sPs" = (
@@ -38888,21 +36850,9 @@
 	pixel_x = 24;
 	req_one_access_txt = "32;47;48"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"sPG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "sQO" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -38941,9 +36891,7 @@
 /area/maintenance/fore)
 "sRX" = (
 /obj/structure/chair/comfy/brown,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "sSv" = (
@@ -38970,19 +36918,23 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/security/prison)
-"sSK" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/engineering/main)
+/turf/open/floor/iron/dark,
+/area/security/prison)
 "sST" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/grass,
 /area/medical/virology)
+"sSV" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "sSZ" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating{
@@ -39016,6 +36968,7 @@
 	name = "Theatre Backstage";
 	req_access_txt = "46"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/central)
 "sTz" = (
@@ -39041,13 +36994,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"sTT" = (
-/obj/docking_port/stationary/random{
-	id = "pod_2_lavaland";
-	name = "lavaland"
-	},
-/turf/open/space,
-/area/space)
+"sTO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/bundle/hobo_squat,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "sTU" = (
 /obj/structure/chair{
 	dir = 4
@@ -39068,6 +37019,14 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"sTW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard)
 "sUA" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -39099,13 +37058,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "sVo" = (
@@ -39122,14 +37077,15 @@
 	dir = 1;
 	pixel_y = -27
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "sVz" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/violet,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "sVB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "sVI" = (
@@ -39137,7 +37093,7 @@
 	dir = 1;
 	name = "CO2 to Pure"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -39150,9 +37106,7 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "sVU" = (
@@ -39172,6 +37126,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"sWg" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/engineering/storage/tech)
 "sWt" = (
 /turf/open/floor/iron/white/side{
 	dir = 9
@@ -39181,8 +37140,13 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
+"sWJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "sWN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "sXk" = (
@@ -39190,12 +37154,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"sXm" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms,
-/area/science/xenobiology)
 "sXu" = (
 /obj/machinery/camera{
 	c_tag = "Security Armory";
@@ -39212,7 +37170,7 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "sXJ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -39236,6 +37194,11 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"sYo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "sYt" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -39268,25 +37231,17 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "tba" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Cell 4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "tbB" = (
@@ -39343,13 +37298,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "tdm" = (
@@ -39436,9 +37391,9 @@
 	name = "xenobiology sorting disposal pipe";
 	sortType = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "tfD" = (
@@ -39447,13 +37402,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"tfY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "tga" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -39490,16 +37438,14 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "thn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
 /obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Bridge Entry East";
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "thA" = (
@@ -39538,12 +37484,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"tif" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "tin" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -39569,9 +37509,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "tjb" = (
@@ -39580,11 +37518,6 @@
 /obj/item/mop,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"tju" = (
-/obj/structure/cable/layer1,
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/iron,
-/area/engineering/main)
 "tjx" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -39597,11 +37530,12 @@
 /obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/assembly/flash/handheld,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "tjP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "tjX" = (
@@ -39617,12 +37551,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "tke" = (
@@ -39653,12 +37583,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"tkl" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/command)
 "tkv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -39674,8 +37598,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "tkB" = (
@@ -39688,6 +37612,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"tkD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tll" = (
 /turf/open/floor/grass,
 /area/security/prison)
@@ -39727,6 +37660,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "tmj" = (
@@ -39742,21 +37676,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"tmI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "tmT" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -39785,10 +37707,7 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "tnP" = (
-/obj/structure/sign/painting/library{
-	pixel_x = 32
-	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/green,
 /area/service/library)
 "tnU" = (
 /obj/machinery/door/airlock{
@@ -39796,6 +37715,7 @@
 	req_access_txt = "27"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
 "top" = (
@@ -39815,6 +37735,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
 /turf/open/floor/engine,
 /area/engineering/main)
 "tpK" = (
@@ -39824,6 +37745,12 @@
 	},
 /turf/open/floor/iron,
 /area/command)
+"tpP" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "tqg" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -39856,23 +37783,9 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "tqP" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "tqR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -39907,12 +37820,10 @@
 "trn" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "trx" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -39932,7 +37843,6 @@
 	dir = 1;
 	id = "incineratorturbine"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/computer/security/telescreen/turbine{
 	dir = 1;
 	pixel_y = -30
@@ -39953,14 +37863,22 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -7;
+	pixel_y = 1
 	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/item/wrench/medical,
+/obj/item/storage/pill_bottle/mannitol,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "tsk" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -39996,9 +37914,19 @@
 	name = "Robotics Conveyor Belt";
 	pixel_x = -8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"tsI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"ttH" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/cafeteria,
+/area/maintenance/central)
 "ttL" = (
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -40013,22 +37941,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "tuo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "tuv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "tuX" = (
@@ -40057,12 +37981,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -40077,13 +37995,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"tvF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "tvO" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -40098,15 +38009,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
-"tvT" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
+"two" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/obj/effect/spawner/scatter/moisture,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "twD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -40115,6 +38024,12 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"twI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/mineral/plastitanium{
+	name = "black plastitanium floor"
+	},
+/area/service/bar)
 "txA" = (
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -40148,12 +38063,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -40162,13 +38071,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "txL" = (
@@ -40191,23 +38096,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "tyA" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
 /obj/structure/cable,
@@ -40222,13 +38117,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "tzk" = (
@@ -40237,9 +38129,9 @@
 /turf/open/floor/iron,
 /area/science/storage)
 "tzr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "tzG" = (
@@ -40258,6 +38150,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "tzS" = (
@@ -40267,21 +38160,9 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"tAq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/research)
 "tAr" = (
 /obj/docking_port/stationary/random{
 	dir = 4;
@@ -40321,20 +38202,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/science/research)
 "tBa" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/main)
 "tBk" = (
@@ -40349,12 +38226,6 @@
 	req_access_txt = "7"
 	},
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
@@ -40364,7 +38235,7 @@
 	},
 /obj/effect/turf_decal/caution/white,
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
+	dir = 8;
 	name = "Chamber Extract"
 	},
 /turf/open/floor/engine,
@@ -40388,11 +38259,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "tCT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "tCU" = (
@@ -40401,23 +38271,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/qm)
-"tEa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
 "tEs" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "tEu" = (
@@ -40500,13 +38360,9 @@
 /area/ai_monitored/command/storage/eva)
 "tGb" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
 "tGo" = (
@@ -40545,6 +38401,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"tHy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"tHM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tIA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40595,9 +38460,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/command)
 "tJA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/office)
 "tJB" = (
@@ -40606,16 +38471,6 @@
 "tJM" = (
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
-"tJT" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/central)
-"tJV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "tJZ" = (
 /obj/structure/table,
 /obj/item/book/random,
@@ -40630,10 +38485,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "tLj" = (
@@ -40671,6 +38524,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "tMD" = (
@@ -40679,6 +38533,12 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"tMS" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "tMU" = (
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
@@ -40690,15 +38550,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"tNd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "tNn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -40733,13 +38584,9 @@
 	},
 /area/maintenance/starboard/aft)
 "tPk" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "tPt" = (
@@ -40747,6 +38594,10 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/science/test_area)
+"tPD" = (
+/obj/effect/spawner/lootdrop/botanical_waste,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "tPL" = (
 /obj/structure/chair{
 	dir = 8
@@ -40765,11 +38616,11 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "tPW" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Air to Mix"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tPY" = (
@@ -40811,6 +38662,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
 "tRl" = (
@@ -40818,12 +38671,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "tRr" = (
@@ -40835,6 +38684,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"tRt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
+/area/medical/storage)
 "tRG" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -40864,11 +38717,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -40913,10 +38765,8 @@
 /area/maintenance/central)
 "tSI" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "tSN" = (
@@ -40932,7 +38782,8 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "tUn" = (
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "tUB" = (
@@ -40945,6 +38796,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/central)
+"tVv" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tVH" = (
 /turf/closed/wall,
 /area/service/hydroponics/garden)
@@ -40991,6 +38849,16 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"tWk" = (
+/obj/structure/table,
+/obj/structure/cable,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "tWG" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -41003,7 +38871,7 @@
 /turf/closed/wall,
 /area/maintenance/department/electrical)
 "tWP" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -41080,13 +38948,30 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ubb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+"uan" = (
+/obj/structure/window{
 	dir = 4
 	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/junglebush,
+/turf/open/floor/grass,
+/area/service/library)
+"uaN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
+"ubb" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "uby" = (
@@ -41102,18 +38987,22 @@
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
 "ubG" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/violet{
 	dir = 5
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ubH" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/dark/visible{
-	dir = 8
-	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"ubS" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Pure to Ports"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uce" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -41130,21 +39019,19 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "ucy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/central)
-"ucE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
+"ucK" = (
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/central)
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet/cyan,
+/area/hallway/primary/starboard)
 "udk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -41161,6 +39048,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "uds" = (
@@ -41188,17 +39077,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "udM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
-"udO" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "udV" = (
 /obj/structure/table/glass,
 /obj/structure/window{
@@ -41209,15 +39093,16 @@
 	pixel_x = 3;
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "uea" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "uei" = (
@@ -41226,6 +39111,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"ueJ" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/main)
 "ueQ" = (
 /obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/tile/green{
@@ -41244,6 +39139,8 @@
 	name = "Ian's Quarters";
 	req_access_txt = "57"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/heads_quarters/hop)
 "ufi" = (
@@ -41255,6 +39152,12 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ufR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/service/library)
 "ugj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/westleft{
@@ -41263,6 +39166,8 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/service/hydroponics)
 "ugm" = (
@@ -41281,12 +39186,10 @@
 /area/hallway/primary/central)
 "ugo" = (
 /obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "ugC" = (
@@ -41305,11 +39208,12 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "ugW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/brig)
 "uhD" = (
@@ -41360,9 +39264,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Garden"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "ujo" = (
@@ -41370,9 +39272,9 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ujF" = (
@@ -41415,15 +39317,20 @@
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command)
+"ukV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "uln" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -41445,6 +39352,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "ulu" = (
@@ -41500,7 +39408,7 @@
 /area/ai_monitored/turret_protected/ai)
 "unh" = (
 /obj/effect/landmark/start/roboticist,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
 "unF" = (
@@ -41555,15 +39463,10 @@
 	name = "Power Storage";
 	req_access_txt = "11"
 	},
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "unW" = (
 /obj/effect/spawner/structure/window,
@@ -41591,18 +39494,25 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "uop" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "uou" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/science/robotics/lab)
+"uow" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Two"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "uoC" = (
 /obj/structure/window/reinforced,
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
@@ -41613,17 +39523,10 @@
 /area/medical/virology)
 "uoG" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
-"uoI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "upp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -41643,12 +39546,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "uqd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41659,6 +39556,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "uqI" = (
@@ -41667,9 +39566,6 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -41691,9 +39587,9 @@
 	req_access_txt = "29"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "ure" = (
@@ -41742,12 +39638,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/lawoffice)
-"urR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "urS" = (
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
@@ -41765,16 +39655,13 @@
 "ust" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
-"usW" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+"ute" = (
 /obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/science/research)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "utq" = (
 /obj/structure/sign/warning/fire,
 /turf/closed/wall,
@@ -41808,6 +39695,12 @@
 /obj/structure/sign/warning/docking,
 /turf/closed/wall,
 /area/maintenance/port/aft)
+"uuH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "uuZ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -41821,15 +39714,9 @@
 "uvM" = (
 /turf/closed/wall,
 /area/science/mixing/chamber)
-"uvX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "uwb" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "uwe" = (
@@ -41848,12 +39735,11 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "uwy" = (
-/obj/machinery/atmospherics/pipe/simple/supply{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "uwP" = (
@@ -41871,13 +39757,13 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "uxg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/maintenance/disposal/incinerator)
+"uxr" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron/white,
+/area/science/research)
 "uxJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -41885,6 +39771,7 @@
 "uxT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
 	name = "Gas to Cold Loop"
 	},
 /turf/open/floor/engine,
@@ -41898,7 +39785,17 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "uyd" = (
-/obj/structure/bookcase/random/religion,
+/obj/structure/table/wood/fancy/royalblue,
+/obj/machinery/door/window{
+	name = "Secure Art Exhibition";
+	req_access_txt = "37"
+	},
+/obj/structure/sign/painting/library_secure{
+	pixel_y = 32
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/service/library)
 "uyn" = (
@@ -41912,28 +39809,20 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "uyz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "uze" = (
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
-"uzl" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/office)
 "uzs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -41950,15 +39839,11 @@
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"uzG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/security/prison)
+"uAk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/science/research)
 "uAo" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -41984,15 +39869,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"uBj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+"uAM" = (
+/obj/machinery/computer/security/telescreen/toxins{
+	dir = 8;
+	pixel_x = 30
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/item/assembly/signaler,
+/obj/item/binoculars,
+/turf/open/floor/iron,
+/area/science/mixing)
+"uBj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "uBm" = (
 /obj/structure/chair/stool,
-/turf/open/floor/wood,
+/turf/open/floor/wood/large,
 /area/service/library)
 "uBt" = (
 /obj/effect/turf_decal/tile/green{
@@ -42010,10 +39906,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "uBy" = (
@@ -42039,12 +39933,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "uBY" = (
@@ -42068,9 +39956,7 @@
 /area/engineering/main)
 "uCt" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "uCA" = (
@@ -42080,30 +39966,22 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"uCB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/prison)
 "uCC" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "AI Upload Access";
 	req_access_txt = "16"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"uCK" = (
+/turf/open/floor/wood/large,
+/area/service/library)
 "uCO" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock";
@@ -42112,17 +39990,21 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"uCP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium{
+	name = "black plastitanium floor"
+	},
+/area/service/bar)
 "uCU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "uDc" = (
@@ -42135,18 +40017,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/prison)
-"uDy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+"uDw" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/port/fore)
 "uDD" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "uDH" = (
@@ -42155,17 +40034,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"uDQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "uDR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -42174,23 +40048,11 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"uER" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/command)
 "uFa" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "uFb" = (
@@ -42200,6 +40062,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"uFm" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/security/brig)
 "uFr" = (
 /turf/closed/wall/r_wall,
 /area/engineering/gravity_generator)
@@ -42208,14 +40081,10 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"uFK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "uGs" = (
 /obj/structure/window{
 	dir = 8
@@ -42231,19 +40100,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
-"uGE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "uGL" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -42255,27 +40115,6 @@
 	name = "black plastitanium floor"
 	},
 /area/maintenance/central)
-"uHu" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
-"uHC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
 "uHL" = (
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
@@ -42290,6 +40129,9 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "uHP" = (
@@ -42302,9 +40144,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uIa" = (
@@ -42326,31 +40169,34 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"uIc" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Pure to Ports"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "uIx" = (
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "uJa" = (
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"uJb" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "Skynet_launch";
+	name = "mech bay"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/science/robotics/mechbay)
 "uJd" = (
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "toxinsdriver"
+/obj/machinery/mass_driver/toxins{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
 "uJg" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "uJs" = (
@@ -42377,23 +40223,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
-"uJL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "uJY" = (
 /turf/open/floor/plating,
 /area/science/mixing)
 "uKo" = (
-/obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
 	id = "toxinsdriver";
 	name = "toxins launcher bay door"
@@ -42406,8 +40239,8 @@
 	req_access_txt = "55"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "uLe" = (
@@ -42432,11 +40265,21 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/science/test_area)
+"uLD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/command/teleporter)
 "uLE" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
 "uMa" = (
@@ -42454,12 +40297,18 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "uMe" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"uMh" = (
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/engineering/gravity_generator)
 "uMp" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -42486,9 +40335,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "uNb" = (
@@ -42537,7 +40384,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "uOK" = (
-/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -42548,6 +40394,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uOT" = (
@@ -42562,7 +40409,7 @@
 	name = "Atmospherics Maintenance";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/violet{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -42583,18 +40430,11 @@
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
 "uQv" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/service,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
-"uQz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/engineering/gravity_generator)
 "uQW" = (
 /obj/structure/chair,
 /obj/structure/cable,
@@ -42612,7 +40452,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -42679,15 +40519,18 @@
 /turf/open/floor/iron,
 /area/command)
 "uTh" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"uTB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard/fore)
 "uUb" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -42711,12 +40554,6 @@
 /area/service/hydroponics)
 "uUm" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -42724,6 +40561,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "uUx" = (
@@ -42731,21 +40570,15 @@
 	dir = 8
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/engine,
 /area/engineering/main)
 "uUA" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Cell 6"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "uUX" = (
@@ -42758,6 +40591,9 @@
 /obj/structure/window{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "uVe" = (
@@ -42767,7 +40603,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "uVi" = (
@@ -42788,14 +40624,6 @@
 "uVs" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/central/secondary)
-"uVx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "uVB" = (
 /obj/structure/cable,
 /obj/machinery/power/emitter/welded{
@@ -42808,10 +40636,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uVH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/engineering/main)
 "uVQ" = (
 /obj/effect/turf_decal/tile/purple,
@@ -42831,14 +40660,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "uWf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
 "uWy" = (
@@ -42846,6 +40671,14 @@
 	pixel_x = 2
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Hydroponics Desk";
+	req_one_access_txt = "30;35"
+	},
+/obj/structure/window{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/service/hydroponics)
 "uWF" = (
@@ -42859,6 +40692,13 @@
 "uWM" = (
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"uXv" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "uXR" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
@@ -42899,13 +40739,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
-"uYu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port/aft)
 "uYy" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -42917,7 +40750,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -42939,21 +40773,17 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "uZo" = (
 /obj/effect/mapping_helpers/dead_body_placer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "uZu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Ports to Proccess"
-	},
+/obj/machinery/atmospherics/components/trinary/filter/flipped,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uZE" = (
@@ -42970,18 +40800,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"uZP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "uZT" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -42989,8 +40811,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "vaF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/service/library)
@@ -43001,9 +40821,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/engine,
 /area/engineering/main)
 "vbq" = (
@@ -43017,30 +40835,25 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "vbv" = (
-/obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "vbG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/service/bar)
 "vbT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "vcp" = (
@@ -43054,11 +40867,19 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "vcx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
 /area/hallway/secondary/entry)
+"vcX" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "vdm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -43076,9 +40897,7 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "veT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/plating,
 /area/security/brig)
 "veU" = (
@@ -43103,6 +40922,8 @@
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
 "vgb" = (
@@ -43117,13 +40938,9 @@
 	name = "Morgue";
 	req_access_txt = "6;5"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "vgt" = (
@@ -43170,6 +40987,13 @@
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"vil" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vit" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -43180,21 +41004,22 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"viD" = (
+/turf/open/floor/iron/cafeteria,
+/area/maintenance/central)
 "vjx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "vjA" = (
 /obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "vjO" = (
@@ -43205,22 +41030,11 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
-"vjX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/science/storage)
 "vkd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "vkf" = (
@@ -43255,10 +41069,9 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/service/bar)
 "vkU" = (
@@ -43338,22 +41151,16 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
-"vmN" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/main)
+"vmO" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vmQ" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vnc" = (
 /obj/structure/grille/broken,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -43384,24 +41191,28 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"vnL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vnX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "vol" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
 	},
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
@@ -43434,6 +41245,8 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "vpr" = (
@@ -43449,27 +41262,12 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/hallway/primary/aft)
-"vps" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/main)
 "vpJ" = (
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "vpQ" = (
@@ -43499,6 +41297,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"vqo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "vqs" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior Access - East";
@@ -43537,11 +41340,16 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
+"vrH" = (
+/obj/structure/chair/comfy/beige{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "vrL" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -43553,7 +41361,9 @@
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "vrT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/command)
 "vsh" = (
@@ -43564,12 +41374,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "vsp" = (
@@ -43600,14 +41406,13 @@
 	id = "atmos";
 	name = "Atmospherics Blast Door"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vsH" = (
@@ -43635,18 +41440,8 @@
 /area/tcommsat/server)
 "vsX" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
-"vtk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "vtp" = (
 /obj/machinery/computer/cargo,
 /turf/open/floor/iron,
@@ -43701,9 +41496,9 @@
 	name = "Mining Dock";
 	req_access_txt = "48"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "vuD" = (
@@ -43738,16 +41533,10 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
-"vvt" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/iron/sepia,
-/area/service/chapel/office)
 "vvx" = (
 /obj/machinery/light{
 	dir = 1
@@ -43761,13 +41550,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "vvH" = (
@@ -43787,9 +41572,7 @@
 /turf/closed/wall/r_wall,
 /area/command/gateway)
 "vvR" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "vvX" = (
@@ -43798,14 +41581,21 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
+"vwf" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/grass,
+/area/service/library)
 "vwg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -43820,8 +41610,16 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vwr" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vwz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -43836,7 +41634,7 @@
 /area/command)
 "vyd" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
 "vye" = (
@@ -43849,7 +41647,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "vyj" = (
@@ -43860,8 +41658,7 @@
 	req_access_txt = "2"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "vyo" = (
@@ -43869,12 +41666,10 @@
 	dir = 8
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/machinery/embedded_controller/radio/airlock_controller/incinerator_toxmix{
 	pixel_x = -24
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
 "vyp" = (
@@ -43884,6 +41679,16 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
+"vyq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/aft)
 "vyu" = (
 /turf/closed/wall,
 /area/service/hydroponics)
@@ -43910,21 +41715,17 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "vyY" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "vzc" = (
@@ -43941,6 +41742,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/commons/fitness)
 "vzP" = (
@@ -43955,12 +41759,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing/chamber)
-"vzY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
 "vAa" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -43992,10 +41790,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "vAA" = (
@@ -44013,18 +41809,14 @@
 /area/security/courtroom)
 "vAK" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "vAS" = (
@@ -44047,17 +41839,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"vBP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "vBY" = (
 /turf/closed/wall,
 /area/commons/vacant_room/office)
@@ -44099,18 +41880,15 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "vDs" = (
-/obj/structure/table,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "vDB" = (
 /obj/structure/sign/warning/pods{
 	pixel_x = 32
@@ -44118,12 +41896,6 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"vDJ" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/main)
 "vDN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
@@ -44134,12 +41906,8 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "vEc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/turf/open/floor/iron/smooth_corner,
+/area/engineering/gravity_generator)
 "vEr" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -44157,25 +41925,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/starboard)
-"vEx" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "vEA" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -44185,8 +41934,6 @@
 /area/maintenance/central)
 "vEB" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -44194,6 +41941,8 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "vEG" = (
@@ -44222,6 +41971,9 @@
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "vFu" = (
@@ -44231,12 +41983,10 @@
 /area/space/nearstation)
 "vFy" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
-"vFF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/cargo/office)
 "vGr" = (
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/structure/table,
@@ -44247,12 +41997,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vGB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vGF" = (
@@ -44260,17 +42006,22 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "vGN" = (
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"vGO" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "vHe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44291,6 +42042,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
+"vHl" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "vHn" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -44314,13 +42071,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "vHG" = (
@@ -44328,15 +42082,12 @@
 	name = "EVA Storage";
 	req_access_txt = "18"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/eva)
 "vHY" = (
@@ -44406,10 +42157,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -44434,7 +42185,7 @@
 /area/hallway/secondary/exit)
 "vKu" = (
 /obj/effect/turf_decal/stripes,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "vKH" = (
@@ -44452,9 +42203,9 @@
 	name = "Auxillary Base Construction";
 	req_one_access_txt = "32;47;48"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "vKQ" = (
@@ -44515,29 +42266,22 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
-"vNn" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"vNy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
+"vNb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/turf/open/floor/iron,
+/area/command)
+"vNy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vNQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "vNW" = (
@@ -44552,7 +42296,7 @@
 	dir = 1;
 	name = "Plasma to Pure"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -44564,12 +42308,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "vOM" = (
@@ -44591,28 +42332,25 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "vPR" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
 	name = "N2 to Airmix"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vPT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
 "vPZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "vQo" = (
@@ -44628,21 +42366,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command)
-"vRs" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/service/hydroponics)
 "vRx" = (
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
@@ -44652,29 +42375,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
-"vRU" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/service/hydroponics)
 "vSd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/holopad/secure,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "vSt" = (
@@ -44682,11 +42386,9 @@
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "vSI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Ports"
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vSM" = (
@@ -44697,9 +42399,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "vTh" = (
@@ -44732,6 +42434,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "vTP" = (
@@ -44749,7 +42453,7 @@
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "vUu" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "vUE" = (
@@ -44790,25 +42494,20 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "vVk" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/engine,
 /area/engineering/main)
 "vVw" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "vWc" = (
@@ -44816,10 +42515,9 @@
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command)
 "vWf" = (
@@ -44839,12 +42537,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"vWR" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/secondary/entry)
 "vXg" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -44868,13 +42560,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vXt" = (
@@ -44903,9 +42591,7 @@
 /area/maintenance/starboard)
 "vXY" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "vYs" = (
@@ -44970,7 +42656,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 9
 	},
 /turf/open/space/basic,
@@ -44997,7 +42683,7 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "waO" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -45020,11 +42706,17 @@
 /area/engineering/main)
 "wbb" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"wbu" = (
+/turf/open/floor/iron/smooth_corner{
+	dir = 4
+	},
+/area/engineering/gravity_generator)
 "wby" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -45033,10 +42725,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"wbI" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "wcp" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -45045,6 +42733,9 @@
 /area/engineering/atmos)
 "wcH" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -45063,9 +42754,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "wda" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "wdx" = (
@@ -45083,9 +42774,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "wdH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "wec" = (
@@ -45114,32 +42803,27 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"wfj" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/closet/emcloset{
-	anchored = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "wfm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"wfN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "wfT" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -45174,12 +42858,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
-"whq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/command)
 "whG" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -45193,9 +42871,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "whJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "whQ" = (
@@ -45232,6 +42910,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/command)
+"wix" = (
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/wood/tile,
+/area/service/library)
 "wiH" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
@@ -45268,33 +42950,24 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "wjM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "wjQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
-"wjT" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "wjV" = (
 /obj/machinery/light{
 	dir = 8
@@ -45309,12 +42982,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "wkU" = (
@@ -45324,22 +42991,20 @@
 	},
 /obj/machinery/vending/cigarette,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "wlb" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "N2 to Pure"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wlQ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
 "wlT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/iron/sepia,
@@ -45351,22 +43016,28 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "wmb" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
 /turf/open/floor/engine,
 /area/engineering/main)
 "wmq" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown,
 /turf/open/space/basic,
 /area/space/nearstation)
+"wmr" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "wmC" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -45416,9 +43087,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "wpl" = (
@@ -45427,26 +43096,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard)
-"wpm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/robotics/lab)
 "wpn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "wpu" = (
@@ -45458,14 +43114,15 @@
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
+"wpw" = (
+/turf/closed/wall/r_wall,
+/area/hallway/primary/port)
 "wpL" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "wpS" = (
@@ -45491,21 +43148,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "wqn" = (
 /obj/machinery/computer/security/telescreen/vault{
 	pixel_x = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
@@ -45530,30 +43180,14 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"wqO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/robotics/lab)
 "wrm" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -45569,28 +43203,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/engine,
 /area/engineering/main)
-"wrp" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
-"wrs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
-/area/science/robotics/lab)
 "wrw" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -45611,10 +43226,8 @@
 "wrL" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
 "wsd" = (
@@ -45649,6 +43262,7 @@
 /area/maintenance/disposal)
 "wsx" = (
 /obj/effect/landmark/start/scientist,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/nanite)
 "wsB" = (
@@ -45710,28 +43324,29 @@
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "wwd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron/sepia,
+/turf/open/floor/carpet/red,
 /area/service/chapel/main)
 "wwo" = (
 /obj/machinery/computer/security/labor,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "wwz" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/toolcloset,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron/smooth,
 /area/engineering/main)
 "wwK" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wwO" = (
@@ -45755,13 +43370,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "wxH" = (
@@ -45772,13 +43384,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "wyf" = (
@@ -45817,11 +43425,12 @@
 	dir = 1;
 	network = list("ss13","prison")
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "wzD" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -45832,6 +43441,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "wzM" = (
@@ -45841,8 +43453,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
 "wzY" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -45856,13 +43468,9 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "wAv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "wBg" = (
@@ -45891,23 +43499,13 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "wBI" = (
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
-"wBK" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "wBR" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Storage Maintenance";
@@ -45939,12 +43537,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/door_buttons/access_button{
 	idDoor = "Virology_Airlock_Interior";
@@ -45962,6 +43554,8 @@
 	pixel_y = 22;
 	req_access_txt = "39"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "wCI" = (
@@ -45981,21 +43575,16 @@
 /area/hallway/primary/aft)
 "wCX" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "wDc" = (
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "wDi" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wDq" = (
@@ -46020,19 +43609,6 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
-"wEC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "wEF" = (
 /obj/machinery/light{
 	dir = 4
@@ -46067,35 +43643,32 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "wGg" = (
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "wGl" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wGq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"wGX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+"wGL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"wGX" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "wHd" = (
@@ -46115,6 +43688,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"wHG" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/security/brig)
+"wHI" = (
+/obj/machinery/research/explosive_compressor,
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "wHJ" = (
 /obj/machinery/camera{
 	c_tag = "Security Briefing Room South";
@@ -46136,6 +43720,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
 "wIT" = (
@@ -46168,13 +43753,13 @@
 	id = "rnd2";
 	name = "research lab shutters"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
 "wKf" = (
-/obj/structure/cable/layer1,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "wKh" = (
@@ -46187,6 +43772,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"wKi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "wKr" = (
 /obj/structure/table,
 /obj/machinery/status_display/evac{
@@ -46210,6 +43799,8 @@
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/service/chapel/main)
 "wKH" = (
@@ -46225,11 +43816,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "wLc" = (
@@ -46252,12 +43841,6 @@
 /obj/machinery/door/airlock/command/glass{
 	name = "Ian's Quarters";
 	req_access_txt = "57"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
@@ -46315,6 +43898,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
+"wNw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/mixing)
 "wNx" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -46323,12 +43912,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "wNB" = (
@@ -46371,24 +43954,19 @@
 /turf/open/floor/iron/grimy,
 /area/security/prison)
 "wOE" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/medical,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/turf/open/floor/iron/smooth_large,
+/area/engineering/gravity_generator)
 "wOI" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/medical/virology)
 "wPc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "wPl" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -46402,13 +43980,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/main)
 "wPB" = (
@@ -46424,15 +43998,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"wPG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "wPQ" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
@@ -46440,9 +44005,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "wPU" = (
@@ -46454,32 +44017,17 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
-"wQP" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Tech Storage";
-	req_access_txt = "23"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/storage/tech)
 "wQR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -46503,12 +44051,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"wRJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
+"wRF" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Pure Outlet to Ports"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wRL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -46525,7 +44073,7 @@
 	desc = "The chefs most 'trusted' pet Goat. Just don't stare at him too long.";
 	name = "Pete"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "wSA" = (
@@ -46543,9 +44091,9 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "wSE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wSF" = (
@@ -46556,22 +44104,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "wTe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "wTl" = (
@@ -46590,9 +44132,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -46602,6 +44141,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wTL" = (
@@ -46636,12 +44176,12 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "wUN" = (
-/obj/structure/lattice,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/simple/green{
+	dir = 4
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -46649,6 +44189,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "wVb" = (
@@ -46669,18 +44210,14 @@
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "wVB" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "wVI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "wVR" = (
@@ -46694,6 +44231,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "wWn" = (
@@ -46709,6 +44247,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"wWM" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	name = "Tech Storage";
+	req_access_txt = "23"
+	},
+/turf/open/floor/plating,
+/area/engineering/storage/tech)
 "wXl" = (
 /turf/closed/wall,
 /area/service/library)
@@ -46760,12 +44306,8 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "wXY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "wYg" = (
@@ -46785,17 +44327,9 @@
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "wYo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/bar)
-"wYB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "wYE" = (
 /obj/item/paint/paint_remover,
 /turf/open/floor/plating,
@@ -46805,18 +44339,24 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "wZb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/door/airlock/command/glass{
 	name = "Control Room";
 	req_access_txt = "19; 61"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "wZK" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command)
+"wZU" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xaC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood,
@@ -46827,6 +44367,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/medical/virology)
 "xaH" = (
@@ -46834,7 +44376,7 @@
 	dir = 1;
 	name = "CO2 Outlet Pump"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -46843,9 +44385,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Garden"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "xbi" = (
@@ -46868,16 +44408,19 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "xbu" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xbv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engineering/gravity_generator)
+/turf/open/floor/iron,
+/area/engineering/storage/tech)
 "xbx" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "xbN" = (
@@ -46886,7 +44429,7 @@
 	name = "radiation shutters"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "xbT" = (
 /obj/effect/spawner/randomsnackvend,
@@ -47005,13 +44548,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
 "xeq" = (
@@ -47028,7 +44567,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "xeU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "xfi" = (
@@ -47057,7 +44596,7 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "xgn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
 	},
 /turf/open/floor/iron,
@@ -47065,7 +44604,7 @@
 "xgF" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
@@ -47085,13 +44624,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"xha" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/service/hydroponics)
 "xhd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -47117,6 +44649,10 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xiq" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/science/server)
 "xiy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -47145,11 +44681,20 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"xjx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xjD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
 "xjP" = (
@@ -47176,6 +44721,7 @@
 /obj/machinery/computer/security/hos{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "xkH" = (
@@ -47194,12 +44740,16 @@
 	name = "Captain's Desk Door";
 	req_access_txt = "20"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "xkT" = (
 /turf/open/floor/plating,
 /area/engineering/main)
+"xkU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xlm" = (
 /obj/structure/closet/wardrobe,
 /turf/open/floor/iron/dark,
@@ -47233,7 +44783,7 @@
 	dir = 1;
 	name = "Plasma to Mix"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/green{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -47251,14 +44801,6 @@
 /obj/structure/closet/wardrobe,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
-"xmO" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "xmS" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
@@ -47267,23 +44809,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"xnh" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xnx" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "xnR" = (
@@ -47326,7 +44857,6 @@
 	desc = "It doesn't measure anything! Nobody knows why it's here.";
 	name = "Nothing Meter"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xoM" = (
@@ -47337,8 +44867,8 @@
 /obj/structure/sign/poster/official/love_ian{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
@@ -47348,6 +44878,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"xpi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/security/armory)
 "xpv" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/iron,
@@ -47375,34 +44909,19 @@
 "xqj" = (
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"xqk" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/office)
 "xqx" = (
 /obj/effect/landmark/start/bartender,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
 /area/service/bar)
 "xqz" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "xqY" = (
@@ -47461,13 +44980,17 @@
 "xrN" = (
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/hos)
-"xrU" = (
-/obj/effect/landmark/start/station_engineer,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
+"xrZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"xsb" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/tcommsat/computer)
 "xsd" = (
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
@@ -47490,6 +45013,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "xsj" = (
@@ -47537,26 +45061,18 @@
 /area/command/heads_quarters/cmo)
 "xsI" = (
 /obj/structure/table,
-/obj/item/circuitboard/machine/HFR_corner,
-/obj/item/circuitboard/machine/HFR_corner,
-/obj/item/circuitboard/machine/HFR_corner,
-/obj/item/circuitboard/machine/HFR_corner,
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
 	pixel_y = -7
 	},
-/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/cable_coil{
+	pixel_x = -1;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "xsM" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "xsR" = (
@@ -47564,29 +45080,19 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "xtg" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
 	name = "N2O to Mix"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"xti" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "xtn" = (
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -47594,6 +45100,8 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xto" = (
@@ -47607,7 +45115,7 @@
 /obj/structure/chair/office/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "xts" = (
@@ -47629,6 +45137,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
 "xtK" = (
@@ -47672,7 +45181,9 @@
 "xut" = (
 /obj/effect/turf_decal/box,
 /obj/effect/landmark/start/security_officer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/range)
 "xuz" = (
@@ -47732,10 +45243,15 @@
 "xvt" = (
 /turf/closed/wall,
 /area/service/kitchen)
+"xvu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "xvE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "xvK" = (
@@ -47748,19 +45264,22 @@
 "xvP" = (
 /turf/closed/wall,
 /area/security/detectives_office)
+"xwd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xwj" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"xwZ" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "xxa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "xxf" = (
@@ -47772,6 +45291,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/storage)
 "xxj" = (
@@ -47805,7 +45326,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "xxC" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 9
 	},
 /turf/open/floor/iron,
@@ -47831,12 +45352,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "xyI" = (
@@ -47846,9 +45363,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "xyN" = (
@@ -47858,9 +45376,8 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xyS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
 "xyV" = (
@@ -47900,6 +45417,16 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/starboard/aft)
+"xAw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/service/chapel/main)
+"xAU" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "xAV" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -47916,6 +45443,11 @@
 "xBJ" = (
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
+"xBN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "xBZ" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
@@ -47924,7 +45456,7 @@
 	dir = 8
 	},
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "xCg" = (
@@ -47934,25 +45466,23 @@
 "xCC" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "xCJ" = (
-/obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "xCS" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/atmos_control/incinerator{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/violet,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "xCW" = (
@@ -47964,18 +45494,14 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "xDh" = (
@@ -47988,9 +45514,6 @@
 	dir = 1
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/machinery/button/ignition/incinerator/toxmix{
 	pixel_x = -25;
 	pixel_y = -5
@@ -47999,8 +45522,14 @@
 	pixel_x = -25;
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
+"xDB" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/port/fore)
 "xDX" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/mafia_outfit,
@@ -48027,9 +45556,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "xEh" = (
-/obj/machinery/atmospherics/components/trinary/filter/critical{
-	dir = 4;
-	filter_type = "n2"
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -48112,18 +45640,10 @@
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
-"xFM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/medical/virology)
 "xGm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -48166,29 +45686,11 @@
 /obj/item/storage/firstaid/regular,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
-"xHv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+"xHz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "xIg" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -48219,11 +45721,10 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "xJL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/gravity_generator)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/techstorage/tcomms,
+/turf/open/floor/iron/dark,
+/area/engineering/storage/tech)
 "xKa" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -48251,11 +45752,12 @@
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/ai_upload)
 "xLf" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/start/cyborg,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "xLw" = (
@@ -48276,17 +45778,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
-"xLx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "xLM" = (
 /obj/machinery/door/airlock/external{
 	name = "Atmospherics External Airlock";
@@ -48316,17 +45807,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"xMD" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xMX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "xNm" = (
@@ -48370,7 +45863,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/smooth,
 /area/engineering/main)
 "xOW" = (
 /obj/machinery/light/small{
@@ -48385,12 +45878,10 @@
 /area/tcommsat/server)
 "xPV" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "xQm" = (
@@ -48432,10 +45923,9 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "xRi" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/security,
-/turf/open/floor/iron/dark,
-/area/engineering/storage/tech)
+/obj/machinery/gravity_generator/main/station,
+/turf/open/floor/iron/smooth_half,
+/area/engineering/gravity_generator)
 "xRt" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/item/radio/intercom{
@@ -48469,30 +45959,21 @@
 /area/science/mixing)
 "xRS" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
 "xSt" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "xSz" = (
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
-"xSC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/command)
 "xSH" = (
 /obj/machinery/button/door{
 	id = "xenobio4";
@@ -48507,6 +45988,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "xSS" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "xUl" = (
@@ -48535,11 +46020,9 @@
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "xUG" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "xUQ" = (
@@ -48581,6 +46064,9 @@
 	pixel_x = -29
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "xWs" = (
@@ -48601,11 +46087,18 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
+"xWP" = (
+/turf/open/floor/iron/edge,
+/area/engineering/main)
 "xWX" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
+"xXh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "xXj" = (
 /obj/structure/filingcabinet/security,
 /turf/open/floor/vault,
@@ -48626,6 +46119,11 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/engineering/main)
+"xXu" = (
+/obj/effect/loot_site_spawner,
+/obj/effect/spawner/lootdrop/maint_drugs,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xXv" = (
 /obj/structure/festivus{
 	name = "Dancer Pole"
@@ -48636,9 +46134,15 @@
 	},
 /area/maintenance/starboard/aft)
 "xXF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/orange,
 /area/commons/vacant_room/office)
+"xXP" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "xXQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -48677,7 +46181,7 @@
 	name = "Fore/Port Solar Array"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/airless/solarpanel,
+/turf/open/floor/iron/solarpanel,
 /area/maintenance/solars/port/fore)
 "xZz" = (
 /obj/structure/cable,
@@ -48691,6 +46195,7 @@
 	name = "Engineering Foyer";
 	req_one_access_txt = "10;24"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "yal" = (
@@ -48715,18 +46220,21 @@
 	location = "Atmospherics"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "yay" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
@@ -48844,9 +46352,9 @@
 /area/service/kitchen)
 "ydj" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "ydl" = (
@@ -48889,6 +46397,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "ydD" = (
@@ -48905,12 +46415,8 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "ydM" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "SupermatterExternal";
-	name = "radiation shutters"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
 /area/engineering/main)
 "ydT" = (
 /obj/structure/table,
@@ -48953,37 +46459,21 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
-"yen" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "yez" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "yeH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/gateway)
 "yeZ" = (
@@ -48994,21 +46484,14 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "yfs" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -49024,13 +46507,10 @@
 	name = "HoP sorting disposal pipe";
 	sortType = 15
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "yfA" = (
@@ -49054,24 +46534,15 @@
 /obj/item/chair/stool/bar,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
-"ygf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ygg" = (
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"ygi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "ygm" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "camdola_containment";
@@ -49084,13 +46555,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "ygp" = (
@@ -49099,17 +46566,6 @@
 "ygB" = (
 /turf/closed/wall,
 /area/security/prison)
-"ygV" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/main)
 "yhG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -49142,13 +46598,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "yiQ" = (
@@ -49165,12 +46617,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"yje" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/construction/mining/aux_base)
 "yjk" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -49186,23 +46632,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "yjp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -49233,17 +46669,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "yjI" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/grass,
@@ -49266,13 +46701,13 @@
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/bed/dogbed/runtime,
+/obj/structure/bed/dogbed/runtime{
+	desc = "A comfy-looking cat bed. You can even strap your pet in, in case the gravity turns off. It has an inscription: Requiescat in Pace, Camdola."
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "ykB" = (
@@ -49318,12 +46753,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
-"ymh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 
 (1,1,1) = {"
 gfQ
@@ -60200,7 +57629,7 @@ oRu
 bRe
 ygB
 anC
-apJ
+xyS
 apU
 asI
 pMF
@@ -60270,30 +57699,30 @@ gfQ
 gfQ
 gfQ
 gfQ
+xlO
+xlO
+xlO
 gfQ
+xlO
+xlO
+xlO
 gfQ
+xlO
+xlO
+xlO
 gfQ
+xlO
+xlO
 gfQ
+xlO
+xlO
+xlO
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+xlO
+xlO
+xlO
+fsz
+sHc
 gfQ
 gfQ
 gfQ
@@ -60527,30 +57956,30 @@ gfQ
 gfQ
 gfQ
 gfQ
+fsz
 gfQ
+fsz
 gfQ
+fsz
 gfQ
+fsz
 gfQ
+fsz
 gfQ
+fsz
 gfQ
+fsz
+fsz
 gfQ
+fsz
 gfQ
+fsz
 gfQ
+fsz
 gfQ
+fsz
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -60710,11 +58139,11 @@ yhG
 yhG
 yin
 ajp
-uzG
+jbw
 amk
 ygB
 anT
-uCB
+osZ
 xlD
 xlD
 vBc
@@ -60784,30 +58213,30 @@ gfQ
 gfQ
 gfQ
 gfQ
+fsz
 gfQ
+fsz
 gfQ
+fsz
 gfQ
+xlO
+xlO
+xlO
 gfQ
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+xlO
+xlO
+xlO
+xlO
+nAl
+fsz
+xlO
 gfQ
 gfQ
 gfQ
@@ -61027,9 +58456,9 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
+xlO
+xlO
+fsz
 xlO
 xlO
 xlO
@@ -61045,26 +58474,26 @@ xlO
 xlO
 xlO
 gfQ
-gfQ
+mfS
 gfQ
 rpu
-xlO
-xlO
+fsz
+fsz
+bTW
+fsz
+fsz
+bTW
+fsz
+fsz
+bTW
+fsz
+fsz
+bTW
+fsz
 fsz
 xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-fsz
-xlO
-xlO
-xlO
-xlO
 gfQ
-gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -61223,13 +58652,13 @@ agS
 aix
 ajv
 akP
-pwd
-alS
+osZ
+pua
 ihj
 amy
-xyS
-ctV
-arm
+osZ
+dbl
+osZ
 dnN
 ygB
 nJA
@@ -61284,7 +58713,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 xlO
@@ -61301,33 +58730,33 @@ xIg
 xIg
 xIg
 xlO
-gfQ
-gfQ
-gfQ
-xlO
-gfQ
-gfQ
-fsz
-gfQ
-gfQ
-fsz
-gfQ
-gfQ
-fsz
-gfQ
 gfQ
 fsz
 gfQ
 xlO
+lLY
+dDZ
+dDZ
+dDZ
+dDZ
+dDZ
+dDZ
+dDZ
+dDZ
+dDZ
+dDZ
+aYD
 gfQ
+fsz
+xlO
+fsz
+xlO
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+xlO
+xlO
+xlO
+xlO
+xlO
 gfQ
 gfQ
 gfQ
@@ -61486,7 +58915,7 @@ apc
 xlD
 xlD
 arz
-uCB
+osZ
 xlD
 xLR
 rmy
@@ -61541,50 +58970,50 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-xlO
-lLY
-dDZ
-dDZ
-dDZ
-dDZ
-dDZ
-dDZ
-dDZ
-dDZ
-dDZ
-dDZ
-aYD
-gfQ
 xlO
 gfQ
 gfQ
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+xlO
+blf
+kmG
+aUN
+aUN
+aUN
+aUN
+aUN
+aUN
+aUN
+aUN
+aUN
+sJl
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
 gfQ
+fsz
 gfQ
+gfQ
+gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -61743,7 +59172,7 @@ xaQ
 srQ
 srQ
 mSU
-uCB
+osZ
 xlD
 ygB
 rmy
@@ -61762,12 +59191,7 @@ ihX
 jes
 eqD
 ioL
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+ihX
 gfQ
 gfQ
 gfQ
@@ -61811,16 +59235,21 @@ gfQ
 fsz
 gfQ
 gfQ
+gfQ
+gfQ
 fsz
 gfQ
 gfQ
 fsz
-xIg
+gfQ
+gfQ
+fsz
+sHc
 xIg
 xIg
 xlO
 blf
-kmG
+kws
 aUN
 aUN
 aUN
@@ -61830,19 +59259,19 @@ aUN
 aUN
 aUN
 aUN
-kIC
+aYD
+fsz
 fsz
 xlO
+xlO
+xlO
+xlO
+xlO
+xlO
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+xlO
+xlO
+xlO
 gfQ
 gfQ
 gfQ
@@ -62000,7 +59429,7 @@ amm
 amz
 iDu
 ygB
-uCB
+osZ
 xlD
 ygB
 nJA
@@ -62077,7 +59506,8 @@ xlO
 xlO
 xlO
 blf
-kws
+fsz
+kmG
 dDZ
 dDZ
 dDZ
@@ -62086,19 +59516,18 @@ dDZ
 dDZ
 dDZ
 dDZ
-dDZ
-aYD
+sJl
+gfQ
+fsz
+gfQ
+gfQ
 gfQ
 fsz
 gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -62257,7 +59686,7 @@ euO
 tll
 anU
 ygB
-fuQ
+osZ
 asN
 ygB
 ygB
@@ -62335,29 +59764,29 @@ gfQ
 gfQ
 vYN
 fsz
-lLY
-aUN
-aUN
-aUN
-aUN
-aUN
-aUN
-aUN
-aUN
-kIC
+sSV
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
+fsz
 gfQ
 fsz
 gfQ
 gfQ
 fsz
 fsz
+fsz
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
+fsz
+fsz
+fsz
 bnA
 bnA
 bnA
@@ -62530,7 +59959,7 @@ qlb
 mPW
 vvX
 jes
-uZi
+dEF
 qZR
 wDK
 ihX
@@ -62579,10 +60008,10 @@ xGp
 xGp
 xGp
 xGp
-rnb
-hmf
+muR
+muR
 iwq
-hmf
+muR
 muR
 xGp
 xGp
@@ -62610,11 +60039,11 @@ bnA
 bnA
 bnA
 bnA
-clp
-bnA
+fsz
+fsz
 gfQ
 gfQ
-gfQ
+fsz
 bnA
 jUQ
 jUQ
@@ -62787,8 +60216,8 @@ wwo
 ftA
 gQk
 bzC
-uZi
-qZR
+cgJ
+opY
 opY
 ihX
 lEY
@@ -62865,9 +60294,9 @@ vSM
 vSM
 vSM
 vSM
-fsz
+joR
 bnA
-jHh
+bnA
 bnA
 gfQ
 gfQ
@@ -63044,7 +60473,7 @@ way
 sdf
 bQE
 jes
-uZi
+dEF
 cwX
 xCg
 ihX
@@ -63091,8 +60520,8 @@ xGp
 fZe
 bbB
 wmb
-dKQ
-dKQ
+wmb
+wmb
 jTX
 wmb
 jhE
@@ -63100,7 +60529,7 @@ wmb
 jTX
 wmb
 kre
-wmb
+vVk
 uUx
 mHZ
 ozi
@@ -63122,15 +60551,15 @@ fOQ
 ifx
 fOQ
 vSM
-fsz
+joR
 bnA
-clp
+jHh
 clp
 gfQ
 gfQ
 fsz
 bnA
-reV
+aOX
 jUQ
 reV
 bnA
@@ -63285,7 +60714,7 @@ uiV
 srQ
 srQ
 mSU
-uCB
+osZ
 xlD
 ygB
 avf
@@ -63302,7 +60731,7 @@ ihX
 wFG
 ihX
 oLM
-ogY
+ihX
 ihX
 ihX
 aOh
@@ -63379,7 +60808,7 @@ fOQ
 hUH
 fOQ
 vSM
-fsz
+joR
 bnA
 bnA
 bnA
@@ -63534,15 +60963,15 @@ xlD
 mRJ
 ahv
 aeI
-pwd
+osZ
 ndS
-pwd
-pwd
-apf
-pwd
-pwd
-eUB
-arp
+osZ
+osZ
+pua
+osZ
+osZ
+osZ
+osZ
 xlD
 ygB
 ygB
@@ -63550,7 +60979,7 @@ ygB
 ygB
 yin
 oFz
-saa
+iKe
 oKE
 wAs
 lYY
@@ -63558,7 +60987,7 @@ woq
 nqF
 yjp
 bfv
-bfv
+dAl
 ehE
 ksz
 hFs
@@ -63602,7 +61031,7 @@ xIg
 xlO
 gfQ
 xGp
-aUv
+czP
 ezE
 sIj
 aUj
@@ -63612,7 +61041,7 @@ rmU
 aUr
 rmU
 aWw
-cnX
+aUI
 aUI
 czP
 aXk
@@ -63789,9 +61218,9 @@ yhG
 uDr
 npX
 adV
+sbi
 xlD
-xlD
-xlD
+apc
 oXQ
 xlD
 xlD
@@ -63799,7 +61228,7 @@ gjB
 xlD
 xlD
 nrR
-uCB
+osZ
 xlD
 ewP
 rmy
@@ -63807,7 +61236,7 @@ nti
 iBp
 yin
 pLG
-ktR
+wDc
 oGZ
 cDu
 klu
@@ -63815,8 +61244,8 @@ klu
 vyj
 uUm
 mFB
-ymh
-iof
+asr
+xPV
 kGh
 aIM
 aLT
@@ -63828,7 +61257,7 @@ xrN
 cVW
 bfj
 xky
-bSs
+jtM
 baE
 cUC
 gfQ
@@ -63855,13 +61284,13 @@ gfQ
 gfQ
 gfQ
 xlO
-xIg
+sHc
 xlO
 fsz
 xGp
-aUv
-aWg
-aUf
+czP
+xEh
+sIj
 oQV
 oQV
 rmU
@@ -63872,7 +61301,7 @@ rmU
 uya
 uya
 czP
-pHW
+vVk
 sbX
 xGp
 uYU
@@ -63881,15 +61310,15 @@ blf
 bnA
 fsz
 vSM
-tif
+cyz
 iJd
-lLR
+dPw
 vSM
 cyz
 iJd
 dPw
 vSM
-dPw
+sHe
 iJd
 nTJ
 vSM
@@ -64056,7 +61485,7 @@ qDw
 qDw
 qDw
 qDw
-uCB
+osZ
 xlD
 ygB
 rmy
@@ -64073,7 +61502,7 @@ nqF
 nqF
 nXh
 bez
-ick
+asr
 fDa
 hFs
 aOk
@@ -64106,20 +61535,20 @@ fsz
 fsz
 fsz
 fsz
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 xlO
+rpu
+rpu
+rpu
+gfQ
+fsz
 fsz
 fsz
 gfQ
 xGp
-aUv
+czP
 ezE
 aWf
-rmU
+oCg
 rmU
 rmU
 rmU
@@ -64127,7 +61556,7 @@ err
 rmU
 rmU
 rmU
-rmU
+oCg
 eAF
 kkt
 uxT
@@ -64136,15 +61565,15 @@ aUN
 dDZ
 kIC
 bnA
-fsz
-fsz
-fch
 lpf
-rBt
 lpf
 juJ
 lpf
-sJu
+cwS
+lpf
+juJ
+lpf
+cwS
 qgD
 sJu
 lpf
@@ -64159,7 +61588,7 @@ bnA
 clp
 cti
 adz
-xgH
+bXN
 lKx
 cti
 vzz
@@ -64305,7 +61734,7 @@ agd
 lBX
 ahC
 lBX
-lBX
+obt
 ygB
 dge
 kNf
@@ -64313,7 +61742,7 @@ qDw
 mNi
 kNf
 qDw
-uCB
+osZ
 xlD
 ygB
 mgQ
@@ -64330,14 +61759,14 @@ nGU
 nqF
 uRu
 bez
-dux
+asr
 sjX
 hFs
 hFs
 hFs
 hFs
 asJ
-bcZ
+rhI
 xrN
 qYG
 lZk
@@ -64358,24 +61787,24 @@ gfQ
 gfQ
 gfQ
 gfQ
-aUP
+vmO
 gfQ
 avX
 gfQ
-aUP
-gfQ
-gfQ
-gfQ
-gfQ
+vmO
+sHc
+xIg
+xIg
+sHc
 gfQ
 gfQ
 gfQ
 wVb
 wVb
 wVb
-aUv
-aWg
-aUf
+czP
+xEh
+sIj
 bFQ
 dLd
 gxp
@@ -64386,23 +61815,23 @@ hLk
 fIJ
 bFQ
 czP
-wrp
-twD
-vmN
-spo
-spo
-spo
-wbI
-wbI
-wbI
-hFT
+vVk
+sbX
+wVb
+rKZ
+rKZ
+rKZ
+bnA
+xzY
+xzY
+irn
 jMy
 prA
 xzY
 hQP
 iSn
 tve
-iVe
+xzY
 kwa
 rbe
 kfC
@@ -64559,15 +61988,15 @@ gfQ
 gfQ
 yhG
 agk
-agN
-agN
+hmt
+iOh
 agN
 anh
 ygB
-pOl
+wVI
 gjH
 qDw
-pOl
+wVI
 gbL
 qDw
 arq
@@ -64587,7 +62016,7 @@ lFh
 nqF
 wiO
 iMd
-lME
+mFB
 fDa
 aIO
 aPU
@@ -64620,63 +62049,63 @@ gfQ
 gfQ
 gfQ
 aUP
-mfS
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
+fsz
+fsz
+fsz
+fsz
 gfQ
 gfQ
 mBV
 ojU
 jJD
-aUv
+czP
 ezE
 tSI
 bnq
 kmy
-dAE
+gxp
 ndT
 mOE
 qYS
-lrw
+hLk
 vKu
 bnq
 xjD
-pHW
+vVk
 lqd
 wVb
 jNy
 dYm
 dYm
 vPD
-bnA
+xzY
 xow
 oVr
-qRU
-waO
 xzY
+acs
+fuX
 ffW
-rWB
-bMB
-xxC
-cAV
-fBy
+xzY
+sXJ
+xzY
+sXJ
+sXJ
 oIO
 xzY
 xzY
 xzY
 xzY
-xzY
-xzY
-xzY
-xzY
-xgH
+dlD
+iuZ
+iuZ
+iuZ
+iRr
 iQn
-xgH
+iRr
 gTe
 iQn
-xgH
+iRr
 bnA
 gfQ
 gfQ
@@ -64827,7 +62256,7 @@ qDw
 tba
 qDw
 qDw
-uCB
+osZ
 xlD
 xlD
 xlD
@@ -64876,46 +62305,46 @@ aUP
 gfQ
 gfQ
 gfQ
-wth
-wth
-wth
-wth
-wth
-wth
-wth
-wth
+uFr
+uFr
+uFr
+uFr
+uFr
+uFr
+uFr
+gfQ
 wVb
 dJa
 wVb
 uqI
 aWg
-aUi
+tSI
 bFQ
 hwC
-dAE
+gxp
 ndT
 thj
 qYS
-lrw
+hLk
 fIJ
 bFQ
 xjD
-pHW
-sbX
+vVk
+twD
 mcB
-qiF
+lFi
+tHy
+tHy
+tHy
+tHy
+tHy
+oMm
 xzY
-xzY
-xzY
-xzY
-xzY
-ntr
-enY
+irn
 waO
-xzY
 ffW
-aCC
-pCN
+xzY
+elh
 eIX
 xtg
 afo
@@ -64933,7 +62362,7 @@ bnA
 bnA
 bnA
 xgH
-xgH
+iRr
 bnA
 gfQ
 gfQ
@@ -65078,24 +62507,24 @@ ygB
 ygB
 ygB
 ygB
-aoC
-alU
-rSS
+jbw
+jbw
+jbw
 amL
-rSS
+jbw
 adY
-aoH
-rSS
-rSS
+osZ
+jbw
 rSS
 jbw
-dRj
+jbw
+jbw
 jbw
 jbw
 jbw
 ayG
 kDY
-nPs
+aye
 oHK
 mRd
 hmb
@@ -65107,7 +62536,7 @@ aJq
 nCq
 bAi
 tLS
-aXs
+ahL
 bUD
 xrN
 wLc
@@ -65133,14 +62562,14 @@ aUP
 gfQ
 gfQ
 gfQ
-wth
+uFr
 tqP
 vDs
-wNg
-xQD
+iUq
+qtz
 hxA
-jkr
-wth
+uFr
+uFr
 wVb
 wVb
 wVb
@@ -65149,15 +62578,15 @@ aYz
 aWk
 oCg
 rmU
-gQP
+rmU
 rmU
 nRT
 rmU
-gQP
+rmU
 rmU
 oCg
 uVe
-pHW
+vVk
 sbX
 xGp
 qiF
@@ -65168,10 +62597,10 @@ xzY
 xzY
 xzY
 xzY
-eCP
-cqL
+irn
+vSI
 kDK
-nZh
+ral
 hHX
 nZh
 hud
@@ -65189,8 +62618,8 @@ fsz
 fsz
 fsz
 bnA
-xgH
-xgH
+koB
+iRr
 bnA
 gfQ
 gfQ
@@ -65336,14 +62765,14 @@ aja
 jxE
 ygB
 alD
-asl
+jbw
 asf
 amM
 xlD
 xlD
-uCB
+uDr
 xlD
-xlD
+jbw
 xlD
 yin
 yin
@@ -65352,11 +62781,11 @@ yin
 yin
 yin
 bbP
-aJk
+aye
 kmC
 eHF
 hmb
-ciu
+nBW
 sBH
 iYh
 fDa
@@ -65390,16 +62819,16 @@ aEk
 gfQ
 kPn
 gfQ
-wth
-uOy
+uFr
+pLf
 vEc
-fmE
-fmE
-fPC
+uMh
+wbu
+hFX
 gKI
 iSD
-gfQ
-gfQ
+hjW
+rnY
 xGp
 czP
 jHw
@@ -65414,7 +62843,7 @@ tBF
 csU
 wrn
 qjZ
-wjT
+vVk
 sbX
 xGp
 qiF
@@ -65425,13 +62854,13 @@ xzY
 xzY
 xzY
 xzY
+irn
 xzY
+tkD
 xzY
-coG
-waO
-udO
-tsk
-oML
+elh
+oVR
+bwc
 xyN
 oML
 fBy
@@ -65446,7 +62875,7 @@ vSM
 vSM
 fsz
 bnA
-xgH
+oDA
 wjM
 bnA
 gfQ
@@ -65598,9 +63027,9 @@ qDw
 qDw
 qDw
 qDw
-arw
-asN
-xlD
+uDr
+thl
+jbw
 xlD
 yin
 caT
@@ -65647,17 +63076,17 @@ aEk
 aEk
 ocl
 aEk
-wth
-uOT
+uFr
+fAT
 bbx
 wOE
 xRi
 mFd
-wth
-wth
-wth
-wth
-wth
+fmp
+jLl
+ife
+qZG
+wVb
 fLo
 nbU
 gxV
@@ -65677,20 +63106,20 @@ wVb
 gfa
 aYb
 oUB
-aVU
-aVU
+aYs
+aYs
 iSm
 aYs
 xzY
-xzY
+irn
 xzY
 pTb
-eCP
-eig
+xzY
+ubS
 vSI
-kEW
+fuX
 xzY
-xzY
+nbI
 sXJ
 jcB
 xaH
@@ -65855,9 +63284,9 @@ qDw
 jMr
 uce
 qDw
-qLq
+kdY
 xlD
-xlD
+jbw
 xlD
 yin
 uea
@@ -65874,7 +63303,7 @@ ciu
 xke
 azA
 fDa
-bcZ
+rhI
 aQi
 gpV
 riy
@@ -65904,20 +63333,20 @@ gfQ
 aEk
 wFw
 sOT
-wth
-bbe
-bbx
-beg
+uFr
+pLf
+pif
+uMh
 bgb
 aTv
-aTx
-jnm
+gKI
+jLl
 jLl
 dbX
-wth
+wVb
 wVb
 xGp
-nsU
+ueJ
 wVb
 jXT
 jXT
@@ -65939,15 +63368,15 @@ bnA
 bnA
 sAA
 xzY
-dbq
-xzY
-fAP
-cSr
-uIc
+tVv
+tHy
+iTj
+eig
+mWH
 wDi
-qwB
+mWH
 aVr
-xzY
+oVW
 unX
 tsk
 sVI
@@ -65961,7 +63390,7 @@ vSM
 fsz
 bnA
 lOE
-ifY
+iRr
 nTe
 jUG
 xzY
@@ -65969,7 +63398,7 @@ xzY
 xzY
 cXs
 bnA
-alL
+bnA
 gfQ
 gfQ
 gfQ
@@ -66109,12 +63538,12 @@ ygB
 uBy
 uce
 qDw
-mTz
+gbL
 wVI
 qDw
-uCB
+uDr
 xlD
-xlD
+jbw
 asZ
 yin
 iYi
@@ -66161,20 +63590,20 @@ gfQ
 aEk
 oCT
 lYf
-wth
+uFr
 uQv
 lKL
 wPc
 bgV
 uop
-wth
+gKI
 aeO
 btK
 rMu
-wth
+wVb
 eSv
 uBW
-dOl
+biL
 vFl
 jXT
 xkT
@@ -66198,13 +63627,13 @@ foE
 xzY
 xzY
 xzY
+mGD
+wRF
+mWH
 xzY
-fAP
-uIc
-kEW
-sgb
+mWH
 myQ
-xzY
+vnL
 sXJ
 waO
 leT
@@ -66218,15 +63647,15 @@ vSM
 fsz
 bnA
 qTW
-xgH
+iRr
 gIp
 xzY
 xzY
 xzY
 xzY
 xzY
+xzY
 rKZ
-gfQ
 gfQ
 gfQ
 gfQ
@@ -66360,7 +63789,7 @@ fsz
 gfQ
 yin
 aic
-ajo
+vNQ
 rkL
 ygB
 qDw
@@ -66369,13 +63798,13 @@ qDw
 qDw
 mDZ
 qDw
-uCB
+uDr
 xlD
-xlD
+jbw
 xlD
 yhG
 asl
-buj
+ldL
 xlD
 yhG
 xlD
@@ -66388,7 +63817,7 @@ gQW
 eDb
 azD
 fDa
-bcZ
+rhI
 tia
 cuY
 jVL
@@ -66418,20 +63847,20 @@ gfQ
 aEk
 rlI
 waV
-wth
-bgX
-bgX
-wQP
-bgX
-bgX
-aTy
-wth
-wth
-wth
-bhs
+uFr
+sbJ
+uFr
+uFr
+uFr
+sbJ
+uFr
+jcZ
+bex
+jcZ
+hvm
 bih
-kRe
-tju
+uBW
+biL
 lur
 jXT
 gSW
@@ -66451,17 +63880,17 @@ tUn
 tjP
 aVW
 aXA
-aYt
+aYs
 xzY
 xzY
 xzY
 xzY
+qrH
+mWH
 xzY
-iQR
-qbw
-sgb
+mWH
 djS
-jdo
+wZU
 sXJ
 waO
 oIO
@@ -66475,15 +63904,15 @@ vSM
 fsz
 bnA
 dJu
-xgH
+iRr
 nhm
+xzY
 aQm
 nDS
 rEm
 xzY
 xzY
 rKZ
-gfQ
 gfQ
 gfQ
 gfQ
@@ -66621,40 +64050,40 @@ ajt
 vNQ
 alN
 alG
-alY
-gKM
-pwd
-aoH
-pwd
-arx
-xyS
-xyS
+osZ
+osZ
+osZ
+osZ
+osZ
+osZ
+osZ
+dbl
 xyS
 sIv
-bpR
-xyS
+osZ
+osZ
 osZ
 wBx
 osZ
 osZ
 osZ
 osZ
-bTh
+hKJ
 mpE
 aym
 bTh
-qLe
+oHf
 fDa
-bcZ
+rhI
 tia
 uXR
 yaY
 nXR
-sPG
+cXi
 hym
 mWM
-uoI
-xLx
+nvx
+tRl
 kyC
 nTC
 oSx
@@ -66675,10 +64104,10 @@ gfQ
 aEk
 oCT
 csI
-wVb
+aEk
 bbf
-sSK
-skC
+lca
+lca
 bgY
 lca
 edI
@@ -66686,10 +64115,10 @@ tBa
 grI
 vSN
 wjH
-biL
+pPS
 qcW
-rdO
-hBg
+biL
+xpv
 jXT
 pKk
 xkT
@@ -66698,8 +64127,8 @@ xkT
 pKk
 jXT
 koO
-aXN
-gft
+biL
+sth
 gxY
 wVb
 jtt
@@ -66713,13 +64142,13 @@ xzY
 xzY
 xzY
 xzY
-xzY
+qrH
 iQR
 atE
-iGt
-oqj
-nbI
-vNn
+mWH
+djS
+xzY
+sXJ
 waO
 oIO
 yfA
@@ -66732,15 +64161,15 @@ fsz
 fsz
 bnA
 itf
-xgH
+iRr
 gIp
+xzY
 nDS
 wfV
 nDS
 xzY
 xzY
 rKZ
-alL
 gfQ
 gfQ
 gfQ
@@ -66878,31 +64307,31 @@ yin
 yin
 yin
 xlD
-asl
+jbw
 oqT
 xlD
-asl
+jbw
 asP
 arz
 xlD
 xlD
 xlD
-rWX
+yhG
 xlD
-uDr
+ute
 xlD
 yhG
 xlD
-uDr
+ute
 xlD
 xlD
 aCA
 aFk
 avN
 eDb
-pex
+azA
 fDa
-bcZ
+rhI
 tia
 uXR
 vII
@@ -66919,7 +64348,7 @@ xIr
 dKC
 mnE
 eLO
-nuO
+xpi
 xsg
 kBM
 wlQ
@@ -66934,18 +64363,18 @@ rmY
 lxT
 tPY
 awk
-elt
+qAM
 wRa
 xGD
 xfM
 bgE
 flV
-elt
+oOm
 elt
 agf
 uOp
 biM
-hwE
+ibM
 ibM
 lNv
 pKk
@@ -66954,8 +64383,8 @@ pKk
 pKk
 pKk
 xbN
-vps
-rdO
+ibM
+biL
 sth
 fNB
 wVb
@@ -66969,13 +64398,13 @@ sAA
 xzY
 dbq
 xzY
+jdo
+qrH
+mWH
 xzY
-xzY
-iQR
-qbw
-sgb
+mWH
 djS
-vCv
+jdo
 sXJ
 waO
 oIO
@@ -66989,15 +64418,15 @@ vSM
 fsz
 bnA
 lZo
-xgH
+iRr
 nhm
+xzY
 rEm
 nDS
 aQm
 xzY
 xzY
 rKZ
-gfQ
 gfQ
 gfQ
 gfQ
@@ -67174,11 +64603,11 @@ cqA
 vVe
 rhI
 dLK
-mnE
+nuO
 ibE
 nuO
 gBJ
-gHW
+nuO
 wlQ
 fsz
 aUP
@@ -67188,9 +64617,9 @@ fsz
 fsz
 aEk
 rqj
-aEk
 wVb
-szW
+wVb
+fii
 szW
 wVb
 wVb
@@ -67202,37 +64631,37 @@ wNk
 iPv
 iPv
 mTg
-caq
+ajO
 nOr
 wVb
 rYg
 xkT
-xkT
+klb
 tEu
 xKV
 wVb
 izR
-mBt
+biL
 qBk
 biL
 qPA
-dFM
+aYs
 hDu
 lSx
 hDu
 hDu
 xtn
-ygf
+aYs
 xzY
 xzY
 xzY
+nbI
 xzY
+mWH
+mWH
+mWH
 xzY
-xzY
-elJ
-sgb
-kEW
-xzY
+nbI
 sXJ
 lwu
 xmb
@@ -67246,15 +64675,15 @@ vSM
 fsz
 bnA
 ngV
-xgH
+iRr
 gIp
 xzY
 xzY
 xzY
 xzY
 xzY
+xzY
 rKZ
-gfQ
 gfQ
 gfQ
 gfQ
@@ -67416,7 +64845,7 @@ gfQ
 xke
 azJ
 fDa
-bcZ
+rhI
 tia
 mZg
 egL
@@ -67431,11 +64860,11 @@ buV
 cXi
 rhI
 dMY
-mnE
+nuO
 eLR
 nuO
 bcA
-gHW
+nuO
 wlQ
 fsz
 aUP
@@ -67445,10 +64874,10 @@ fsz
 fsz
 aEk
 rqE
-aEk
+wVb
 ayb
-xkT
-xkT
+dfb
+jsN
 nxW
 xRI
 iPv
@@ -67458,40 +64887,40 @@ uHL
 uwP
 vtY
 wNk
-biM
-rdO
+jky
+uOp
 cHu
 wVb
-gSW
-xkT
-klb
-xkT
-pKk
+qiT
+xbN
+wVb
+xbN
+qiT
 wVb
 cgq
-caq
+ajO
 nYz
 fye
 wVb
 ghJ
-xzY
+suf
 vtD
 xzY
 xzY
 xzY
-bQh
-epn
-mxc
-kva
-hyo
-ubG
 xzY
-uZu
-uZu
-kdz
 xzY
+xzY
+xzY
+vCv
+xzY
+qgc
+uZu
+mWH
+mWH
+vCv
 nYX
-xnh
+tsk
 vOu
 mkM
 cES
@@ -67503,7 +64932,7 @@ vSM
 fsz
 bnA
 xsI
-xgH
+qjj
 gIp
 toN
 xzY
@@ -67511,7 +64940,7 @@ xzY
 xzY
 rCg
 bnA
-gfQ
+bnA
 gfQ
 gfQ
 gfQ
@@ -67673,7 +65102,7 @@ gfQ
 xke
 azM
 fDa
-bcZ
+rhI
 tia
 aXs
 aXs
@@ -67688,11 +65117,11 @@ pJt
 nvx
 dmp
 nuO
-obY
+nuO
 eLX
-oYl
+nuO
 oJl
-iuN
+nuO
 wlQ
 xke
 xke
@@ -67702,7 +65131,7 @@ xke
 fsz
 aEk
 rqj
-aEk
+wVb
 ayb
 ayb
 tVS
@@ -67715,37 +65144,37 @@ uIa
 pWG
 uHL
 wNk
-biM
-rdO
-xpv
-qiT
-wVb
+jky
+uOp
+xWP
+uXv
+qbX
+fkV
+jms
 ydM
-wVb
-ydM
-wVb
-qiT
-bix
-rdO
+tWk
+ukV
+tPk
+uOp
 gft
 lEQ
 wVb
 eYM
 wbb
 edM
-dGd
-lEN
+rwo
+rwo
+qqC
 oXq
-pXK
 bFZ
 cLV
-oXq
-hyo
+tHy
+tHy
 nJg
 oMm
-nJg
-kfl
-coG
+xzY
+xzY
+kdz
 xzY
 sXJ
 waO
@@ -67760,7 +65189,7 @@ vSM
 fsz
 bnA
 bnA
-gTe
+dJc
 bnA
 nzo
 rKZ
@@ -67918,19 +65347,19 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
 fsz
+vmO
+aUP
 pVH
 aUP
-aUP
-aUP
+xke
+xke
 xke
 xke
 xke
 lsr
 tZP
-bcZ
+rhI
 gyC
 aXs
 oZu
@@ -67947,7 +65376,7 @@ rhI
 thO
 oOk
 sst
-eZB
+nuO
 xYa
 hUo
 wlQ
@@ -67959,7 +65388,7 @@ xke
 fsz
 aEk
 rqL
-aEk
+wVb
 ayb
 ayb
 fTD
@@ -67972,23 +65401,23 @@ oqW
 hAJ
 tuo
 dsA
-lPX
-rdO
-rdO
+biM
+uOp
+xWP
 xOU
-nvW
-grJ
+fkV
+fkV
 haH
-grJ
+fkV
 fkV
 iIJ
-jbU
-vDJ
-uHu
+biL
+biL
+qBk
 biD
 wVb
 wTA
-wzY
+iQy
 weO
 idL
 dtK
@@ -68016,7 +65445,7 @@ vSM
 vSM
 fsz
 bnA
-xgH
+pZY
 das
 bnA
 tnB
@@ -68175,31 +65604,31 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
 fsz
 gfQ
 gfQ
 gfQ
 gfQ
 avT
+xke
+fRl
 fRl
 xke
-pex
+azA
 ttL
 xIr
-bcZ
-bcZ
-bcZ
-bcZ
-bcZ
-bcZ
-bcZ
+rhI
+rhI
+rhI
+rhI
+rhI
+rhI
+rhI
 bhG
 bzj
-bcZ
-bcZ
-bcZ
+rhI
+rhI
+rhI
 xIr
 eKb
 eKb
@@ -68216,7 +65645,7 @@ xke
 fsz
 aEk
 rqj
-aEk
+wVb
 ayb
 ayb
 dEk
@@ -68229,38 +65658,38 @@ fHp
 duY
 uHL
 wNk
-rYX
+jky
 uOp
-rdO
-qei
-sfL
-sfL
+xWP
+xGp
+fkV
+fkV
 moj
-sfL
-sfL
-bii
-ygV
-sbJ
+fkV
+fkV
+iIJ
+wth
 fjO
-nwX
-uFr
+fjO
+wth
+wth
 mgy
 dTo
 cvX
 snK
-wzY
 xzY
+cTf
 tWP
 xgn
-jXV
+elh
 asq
-oML
+xXh
 oCI
-oML
+xXh
 sNe
 sNe
 aYp
-oML
+xXh
 xxC
 waO
 oIO
@@ -68274,7 +65703,7 @@ fsz
 fsz
 bnA
 kDr
-xgH
+iRr
 bnA
 aUP
 gfQ
@@ -68432,17 +65861,17 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
 fsz
-sTT
+sup
 gfQ
-gfQ
+alL
 gfQ
 avV
+uow
+fRl
 veT
 gny
-pex
+azA
 cXp
 bfv
 bfv
@@ -68473,7 +65902,7 @@ xke
 xke
 aEk
 rqL
-aEk
+wVb
 ayb
 ayb
 dEk
@@ -68487,8 +65916,8 @@ qMx
 nxp
 jtB
 kgG
-xrU
 biL
+lZH
 ksc
 uVH
 uVH
@@ -68496,20 +65925,20 @@ fPF
 uVH
 uVH
 chl
-srD
+fjO
 nwX
 osr
 fSL
-uFr
+dIg
 cQT
 xbu
 nGh
-wwK
-wzY
+dhI
 xzY
+cTf
 duk
 xzY
-jXV
+elh
 uPB
 wGl
 hTo
@@ -68689,14 +66118,14 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
 fsz
 gfQ
 gfQ
 gfQ
 gfQ
 avT
+xke
+niD
 ayo
 xke
 lQx
@@ -68720,7 +66149,7 @@ bez
 asr
 bez
 bez
-bez
+dug
 mhS
 nQs
 bfv
@@ -68730,7 +66159,7 @@ fHW
 xke
 waV
 rqj
-aEk
+wVb
 wVb
 wVb
 wVb
@@ -68745,28 +66174,28 @@ iPv
 eSq
 vvx
 uOp
-uOp
+xWP
 jvy
-mwJ
-mwJ
+seZ
+seZ
 ooH
 seZ
 pfr
 wwz
-fFl
+fjO
 xbv
-ihs
 oXl
-uFr
+oXl
+wth
 iub
 lHU
 ips
 dax
 wzY
-xzY
+oSP
 loD
 hIz
-eZw
+hHr
 dkt
 wRu
 wlb
@@ -68779,16 +66208,16 @@ dkt
 dkt
 qXP
 coG
+xwd
 xzY
 xzY
-xzY
-xzY
-xgH
+bvo
+eAq
 mRy
-xgH
+iRr
 gTe
 tzS
-xgH
+iRr
 bnA
 aUP
 gfQ
@@ -68946,13 +66375,13 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
 fsz
+vmO
 aUP
 aUP
 aUP
-aUP
+xke
+xke
 xke
 xke
 xke
@@ -68968,15 +66397,15 @@ jNn
 deM
 ihf
 olZ
-ndz
+dcP
 bxg
-ndz
+dcP
 dcP
 jjA
 emM
 feI
 jhM
-jhM
+jdu
 jdu
 dPY
 xFu
@@ -69003,24 +66432,24 @@ xXr
 hMw
 uOp
 hfJ
-hnd
+sOf
 hSL
 hSL
 unP
 hSL
 hSL
-uFr
-nwX
-uFr
-eOD
-nwX
-uFr
-uFr
+wth
+aTy
+qQH
+wth
+wth
+bhs
+wth
 uHP
 kJd
 kWL
-wzY
-xzY
+gzz
+cTf
 pKV
 svX
 uRj
@@ -69033,12 +66462,12 @@ vol
 trx
 kaC
 xAX
-lJu
-xzY
-coG
-xzY
-xzY
-xzY
+bvo
+rwo
+gZh
+rwo
+rwo
+bvo
 cwg
 bnA
 bnA
@@ -69223,12 +66652,12 @@ kji
 sHE
 kcR
 jdC
-gbh
-gbh
-gbh
+bVO
+bVO
+bVO
 ctz
-gbh
-gbh
+bVO
+bVO
 jdC
 jdC
 bdX
@@ -69258,26 +66687,26 @@ rsu
 wVb
 cpP
 cQt
-uOp
+ibM
 xtu
-sOf
-vsX
-eLP
+sob
+qHu
+bWC
 fMN
 eLP
 vsX
-uFr
+wth
 dEa
 bir
-qFd
-lVx
+wNg
+xQD
 xJL
-uFr
+wth
 rqg
 uYy
 wdH
 wUN
-rgq
+hGI
 qaK
 rgq
 wmq
@@ -69286,7 +66715,7 @@ qaK
 rgq
 wmq
 rgq
-wmq
+fjy
 rgq
 wmq
 rgq
@@ -69470,16 +66899,16 @@ gfQ
 gfQ
 gfQ
 xke
-ciu
+bIf
 rJa
 ocz
-aMA
-ciu
-bbR
-mqQ
+wHG
+fwW
+sbI
+uFm
 sHE
 kcR
-gbh
+bVO
 tqr
 olN
 dfH
@@ -69503,8 +66932,8 @@ aEZ
 wFw
 sRp
 tQd
-wFw
-wFw
+rIm
+rIm
 wFw
 rsu
 oCT
@@ -69515,7 +66944,7 @@ oCT
 wFw
 wsY
 jyK
-uOp
+iFa
 cUt
 sOf
 sIJ
@@ -69523,17 +66952,17 @@ rKX
 mHQ
 fWV
 kNc
-uFr
-uHC
-biy
-biy
-biy
-ryI
-uFr
+wth
+uOy
+nBp
+uuH
+fmE
+fPC
+wth
 sBb
 tRP
-uZP
-fsz
+bnA
+gSq
 vSM
 nTJ
 iJd
@@ -69543,11 +66972,11 @@ nTJ
 iJd
 sHe
 vSM
-sHe
+dvV
 iJd
 sHe
 vSM
-fsz
+joR
 rKZ
 uPl
 bnA
@@ -69727,16 +67156,16 @@ gfQ
 gfQ
 gfQ
 xke
-ciu
+oyk
 elI
 lcn
 aMA
-ciu
+gPZ
 vQo
 aYB
-sHE
+lfI
 kcR
-gbh
+bVO
 biP
 jVV
 dxa
@@ -69756,11 +67185,11 @@ miB
 noK
 osN
 lWI
-rIm
-oCT
-oCT
+rwz
+nhh
+oOG
 ozE
-waV
+aEk
 xbx
 xbx
 xbx
@@ -69772,21 +67201,21 @@ xbx
 xbx
 wVb
 wPl
-uOp
+iFa
 cUt
 sOf
 xUG
-qpo
+bWC
 wKf
-olV
+eLP
 lLQ
-uFr
-tNd
-biy
-biy
+wth
+uOT
+nBp
+cSj
 fAC
 dRA
-uFr
+wth
 wqJ
 vJI
 bnA
@@ -69804,7 +67233,7 @@ kML
 tMU
 cdQ
 vSM
-fsz
+joR
 rKZ
 oWd
 bzw
@@ -70017,7 +67446,7 @@ qwl
 rsu
 jdj
 mpc
-waV
+aEk
 gfQ
 gfQ
 gfQ
@@ -70028,24 +67457,24 @@ gfQ
 gfQ
 gfQ
 wVb
-vEx
+jyK
 ajO
 lgW
-sOf
+hnd
 tlX
 qpo
 fZQ
 olV
 alJ
-uFr
+wth
+fYt
+moO
+gAC
+biy
 bio
-biy
-biy
-biy
-bio
-uFr
-axl
-ryJ
+wth
+rqg
+tRP
 bnA
 fsz
 vSM
@@ -70061,7 +67490,7 @@ mML
 bWA
 mML
 vSM
-fsz
+joR
 rKZ
 oWd
 tdK
@@ -70071,8 +67500,8 @@ nqV
 qiS
 lws
 trF
-qMQ
-ezh
+pYa
+pYa
 pYa
 pYa
 pYa
@@ -70250,7 +67679,7 @@ xvP
 mqQ
 sHE
 kcR
-gbh
+bVO
 mKc
 aSD
 jdC
@@ -70274,7 +67703,7 @@ qyp
 rvF
 wFw
 mpc
-waV
+aEk
 gfQ
 xBz
 xBz
@@ -70294,15 +67723,15 @@ sOf
 sOf
 sOf
 sOf
-uFr
-bio
-bio
-bio
-awl
-bio
-uFr
-axl
-ryJ
+wth
+dlE
+moO
+cro
+fmE
+fmE
+wth
+rqg
+tRP
 bnA
 fsz
 vSM
@@ -70318,17 +67747,17 @@ mML
 gac
 mML
 vSM
-fsz
+joR
 rKZ
 huI
 gkd
-aDx
+sVz
 gAY
 omM
 rZd
 nDV
 xCS
-aDx
+sVz
 mAK
 sVz
 oeV
@@ -70505,9 +67934,9 @@ aRK
 pnf
 gZr
 mqQ
-cUY
+sHE
 aZK
-gbh
+bVO
 mKc
 qik
 bRx
@@ -70531,7 +67960,7 @@ rIm
 rwr
 sRw
 tSN
-waV
+aEk
 gfQ
 xBz
 xUo
@@ -70551,15 +67980,15 @@ bhS
 bhU
 bhZ
 siB
-uFr
-uFr
-uFr
-uFr
-uFr
-uFr
-uFr
+wth
+wth
+wWM
+sWg
+sWg
+wth
+wth
 dxC
-ryJ
+tRP
 bnA
 fsz
 vSM
@@ -70575,7 +68004,7 @@ vSM
 vSM
 vSM
 vSM
-fsz
+joR
 rKZ
 pwJ
 mgF
@@ -70583,7 +68012,7 @@ udr
 pUL
 nqV
 esA
-oWh
+lws
 tdm
 qEP
 dLz
@@ -70788,7 +68217,7 @@ sov
 mpc
 waV
 tUB
-waV
+aEk
 gfQ
 xBz
 vCn
@@ -70806,8 +68235,8 @@ bhL
 nzd
 nzd
 aGO
-wGg
-wGg
+lfZ
+lfZ
 yaj
 icd
 tmy
@@ -70816,7 +68245,7 @@ inV
 lJm
 bMW
 eYL
-cOb
+tRP
 bnA
 fsz
 fsz
@@ -70832,7 +68261,7 @@ fsz
 fsz
 fsz
 fsz
-fsz
+joR
 rKZ
 iJy
 igd
@@ -70842,9 +68271,9 @@ nqV
 qiS
 ptu
 qoM
-sVz
+eWx
 gRB
-sVz
+eWx
 fWF
 pYa
 pYa
@@ -71045,7 +68474,7 @@ sov
 mpc
 waV
 waV
-waV
+aEk
 gfQ
 xBz
 nEJ
@@ -71068,12 +68497,12 @@ xWC
 mDY
 vYu
 mFo
-vYu
+bRN
 qsa
 bnA
 sET
 cfC
-emy
+tRP
 bnA
 bnA
 bnA
@@ -71092,15 +68521,15 @@ bnA
 bnA
 bnA
 uDH
-eGB
-mUO
+tdK
+pYa
 vGF
 nqV
 nqV
 nqV
 cOe
-mUO
-qtt
+pYa
+pYa
 pYa
 wPU
 pYa
@@ -71302,7 +68731,7 @@ sov
 mpc
 wFw
 tXR
-waV
+aEk
 gfQ
 xBz
 xsr
@@ -71349,14 +68778,14 @@ wQR
 wQR
 rTZ
 ddh
-uYu
-dXE
+tdK
+pYa
 lvL
 erh
 qfu
 gNl
 pAh
-bfM
+pYa
 fsz
 fsz
 fsz
@@ -71544,13 +68973,13 @@ axU
 ofq
 olI
 lJW
-eOb
-eOb
-gNZ
+hVa
+hVa
+hVa
 hVa
 fOU
-fSl
-fSl
+mtA
+mtA
 mtA
 ihD
 ozD
@@ -71559,7 +68988,7 @@ sov
 mpc
 jdj
 tYV
-waV
+aEk
 gfQ
 xBz
 xXj
@@ -71581,16 +69010,16 @@ rrv
 eBB
 nhw
 xCJ
-oaO
+mFo
 pIn
 rqR
 bnA
 bnA
-bnA
+kSV
 ewM
 bnA
 bnA
-uDy
+mmM
 tuj
 eSr
 vZs
@@ -71599,21 +69028,21 @@ tuj
 jls
 tuj
 tuj
-djN
-veV
+tYO
+mDy
 vZs
 lib
 aHw
 aHw
 aHw
 aHw
-fcm
-fzU
-fzU
-fzU
-fzU
-fzU
-qtt
+pYa
+pYa
+pYa
+pYa
+pYa
+pYa
+pYa
 fsz
 gfQ
 gfQ
@@ -71816,7 +69245,7 @@ sov
 mpc
 oCT
 tZa
-waV
+aEk
 gfQ
 xBz
 xBz
@@ -71826,7 +69255,7 @@ xBz
 xBz
 xBz
 gfQ
-xok
+wpw
 rqv
 aGg
 cwr
@@ -71843,10 +69272,10 @@ pIn
 tkB
 vZs
 low
-wcH
-wcH
-fgQ
-fgQ
+fSo
+muZ
+sxe
+sxe
 rAG
 muZ
 sxe
@@ -71872,7 +69301,7 @@ fsz
 fsz
 fsz
 fsz
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -72046,8 +69475,8 @@ rSZ
 iYx
 kDO
 amO
-aYc
-ldw
+uFm
+asr
 kcR
 xke
 vHv
@@ -72073,7 +69502,7 @@ sov
 ehU
 lZx
 aEZ
-waV
+aEk
 gfQ
 gfQ
 gfQ
@@ -72083,7 +69512,7 @@ fjN
 gfQ
 gfQ
 gfQ
-xok
+wpw
 cXn
 vYu
 vYu
@@ -72095,9 +69524,9 @@ mDY
 mDY
 nhw
 tNn
-iNF
+etw
 yfs
-vZs
+nTG
 vZs
 rDp
 aHw
@@ -72114,7 +69543,7 @@ aHw
 aHw
 aHw
 aHw
-tYO
+xjx
 aof
 tuj
 aHw
@@ -72129,8 +69558,8 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+fsz
+xlO
 gfQ
 gfQ
 gfQ
@@ -72297,7 +69726,7 @@ avg
 nrT
 qiz
 uJa
-aAi
+bxZ
 xke
 lVd
 aTn
@@ -72312,7 +69741,7 @@ xMu
 eCf
 hWW
 vYu
-uqd
+ggx
 tIA
 iVw
 ePA
@@ -72330,17 +69759,17 @@ jNV
 waV
 aER
 waV
-waV
+aEk
 gfQ
-xok
+wpw
 fjN
 fjN
-vtk
+dCo
 fjN
 fjN
-xok
+wpw
 gfQ
-xok
+wpw
 fXp
 pJH
 pJH
@@ -72354,9 +69783,9 @@ bim
 pJH
 biz
 mCN
+ckw
 vZs
-tuj
-vHe
+vyq
 neN
 gfQ
 gfQ
@@ -72386,8 +69815,8 @@ gfQ
 gfQ
 gfQ
 gfQ
-gWK
 gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -72554,14 +69983,14 @@ ehq
 ehq
 xUQ
 xUQ
-aty
+xUQ
 xke
 xke
 xke
 xke
 xke
 aYn
-ngZ
+asr
 bAP
 xke
 pWR
@@ -72587,17 +70016,17 @@ xok
 xok
 bfG
 tZm
-xok
-xok
+wpw
+wpw
 bhq
 bhe
 vYu
-vtk
+dCo
 vYu
 bhe
 bhq
-xok
-xok
+wpw
+wpw
 mzT
 ujF
 ujF
@@ -72612,8 +70041,8 @@ ujF
 fxU
 mne
 vZs
-tuj
-vHe
+vZs
+vyq
 neN
 gfQ
 gfQ
@@ -72644,7 +70073,7 @@ vsQ
 gfQ
 gfQ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -72811,9 +70240,9 @@ sVb
 sVb
 sVb
 sVb
-aAm
-rNk
-aYX
+xUQ
+xUQ
+kCk
 aTp
 aUQ
 xke
@@ -72826,7 +70255,7 @@ rPv
 xke
 cBP
 vYu
-dqN
+uqd
 bwn
 euy
 pLL
@@ -72849,7 +70278,7 @@ vMe
 awT
 raM
 pLL
-bgK
+pGN
 pLL
 raM
 aFQ
@@ -72867,9 +70296,9 @@ pLL
 pLL
 pLL
 bgK
-pLL
+hlG
 aTu
-fgQ
+qKS
 foP
 neN
 gfQ
@@ -72885,7 +70314,7 @@ gfQ
 gfQ
 gfQ
 aHw
-tYO
+xjx
 tuj
 tuj
 tuj
@@ -72901,7 +70330,7 @@ dGU
 gfQ
 gfQ
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -73084,45 +70513,45 @@ eCf
 cBP
 vYu
 drd
-xyI
+lAk
 kEt
-dcN
-dcN
-dcN
 orB
-dcN
-dcN
-dcN
-dcN
-dcN
-dcN
-pKh
-dcN
-dcN
-dcN
+orB
+orB
+orB
+orB
+orB
+orB
+orB
+orB
+orB
+orB
+orB
+orB
+orB
 orB
 kEt
-xyI
-xyI
-xyI
-bgz
-bgL
-mwO
-xyI
-aFv
-xyI
-bgz
+lAk
 vHE
-xyI
-xyI
-xyI
+lAk
+lAk
+lAk
+mwO
+lAk
+aFv
+lAk
+lAk
+vHE
+lAk
+lAk
+lAk
 lAk
 xyI
 xyI
-dla
-dla
-cgW
-dla
+wAv
+wAv
+wAv
+wAv
 fXf
 aDB
 vZs
@@ -73158,7 +70587,7 @@ ndb
 gfQ
 gfQ
 gfQ
-gfQ
+bfu
 gfQ
 xAV
 gfQ
@@ -73321,13 +70750,13 @@ uxJ
 vUW
 atn
 atS
-avl
+aCs
 awR
 aBQ
 sVb
 bhr
-biF
-uJa
+xUQ
+jur
 uJa
 aUV
 xke
@@ -73357,18 +70786,18 @@ pNw
 vYu
 vYu
 vYu
-uDQ
+wAv
 xct
 llA
 vYu
 vYu
-vtk
+dCo
 hXc
 vYu
 vYu
 alH
 vYu
-qKk
+etw
 vYu
 vYu
 dOL
@@ -73399,7 +70828,7 @@ gfQ
 gfQ
 gfQ
 aHw
-tYO
+xjx
 vZs
 vZs
 vZs
@@ -73415,7 +70844,7 @@ ndb
 gfQ
 gfQ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -73576,15 +71005,15 @@ xhd
 xUQ
 uxJ
 vUW
-vUW
+ksI
 wyf
-avp
+aCs
 axs
 npx
 sVb
 bhD
 biF
-uJa
+adN
 uJa
 uJa
 lSd
@@ -73602,10 +71031,10 @@ dSu
 wXl
 wXl
 wXl
-rkx
-rkx
-rkx
-rkx
+uan
+bMD
+vwf
+aoP
 wXl
 wXl
 wXl
@@ -73629,12 +71058,12 @@ lRW
 sSv
 bEP
 xok
-xtO
+xok
 xok
 pzX
+beC
 xSz
-xSz
-xSz
+beC
 xSz
 vYu
 wAv
@@ -73656,7 +71085,7 @@ gfQ
 gfQ
 gfQ
 aHw
-tYO
+xjx
 fRs
 vZs
 uPm
@@ -73672,7 +71101,7 @@ ndb
 gfQ
 gfQ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -73835,7 +71264,7 @@ uxJ
 vUW
 wyf
 wyf
-avp
+aCs
 awa
 aBR
 sVb
@@ -73856,7 +71285,7 @@ cBP
 vYu
 aaH
 dSR
-xok
+wXl
 ePD
 fTj
 uBm
@@ -73864,14 +71293,14 @@ hXq
 lPO
 uBm
 oRf
-aQv
+hwA
 biS
 wXl
 xRK
 xRK
 wXl
 fhP
-mZF
+vqo
 xGY
 vBY
 vBY
@@ -73891,7 +71320,7 @@ xok
 grH
 xSz
 xSz
-xSz
+beC
 oiT
 vYu
 wAv
@@ -73914,7 +71343,7 @@ gfQ
 gfQ
 aHw
 uFE
-qNv
+fcJ
 ooZ
 uzs
 mmM
@@ -73929,7 +71358,7 @@ vsQ
 gfQ
 gfQ
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -74113,7 +71542,7 @@ cBP
 vYu
 aby
 vYu
-xok
+wXl
 ePQ
 aQv
 uBm
@@ -74121,7 +71550,7 @@ hXK
 iQW
 uBm
 aQv
-aQv
+uCK
 aED
 wXl
 xRK
@@ -74146,7 +71575,7 @@ vKj
 xGY
 xok
 niz
-urr
+ceP
 urr
 urr
 oPk
@@ -74154,8 +71583,8 @@ vYu
 wAv
 vYu
 vZs
-aof
-aof
+jpD
+jpD
 aHw
 gfQ
 gfQ
@@ -74173,7 +71602,7 @@ aHw
 tuj
 tuj
 uVD
-tYO
+xjx
 mmM
 vsQ
 vsQ
@@ -74186,7 +71615,7 @@ vsQ
 gfQ
 gfQ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -74349,14 +71778,14 @@ asV
 aBZ
 awW
 wyf
-avr
-awb
-ayq
-qaV
-aAn
+aCs
+cTO
+wyf
+wyf
+brX
 aCs
 vUW
-wyf
+vUW
 wwd
 wyf
 xke
@@ -74368,13 +71797,13 @@ xke
 xke
 sVb
 cYy
-aby
+mDM
 dTm
-xok
+wXl
 wyR
 aQv
 aQv
-aQv
+oMz
 aQv
 jNY
 ldd
@@ -74385,7 +71814,7 @@ wXl
 wXl
 wXl
 sSZ
-mZF
+vqo
 peX
 vBY
 yiA
@@ -74412,7 +71841,7 @@ wAv
 vYu
 vZs
 tuj
-tuj
+dAn
 aHw
 gfQ
 gfQ
@@ -74432,8 +71861,8 @@ tuj
 tuj
 cmm
 jfV
-vGt
-vGt
+gVT
+gVT
 roz
 sqP
 puR
@@ -74443,7 +71872,7 @@ vsQ
 gfQ
 gfQ
 gfQ
-gfQ
+fFC
 gfQ
 gfQ
 gfQ
@@ -74606,15 +72035,15 @@ sVb
 sVb
 sVb
 atV
-wyf
-wyf
-aBU
-wyf
-brX
-wyf
-vUW
-wyf
-wwd
+ksw
+aCs
+aWu
+aWu
+mIL
+aWu
+nRK
+nRK
+nRK
 aWt
 sVb
 aYU
@@ -74625,15 +72054,15 @@ bFs
 cbY
 cEi
 vYu
-aby
+kgY
 vYu
-vYu
+fSS
 rkx
 aQv
-aQv
+ufR
 hZX
 aQv
-aQv
+hiU
 leP
 oNX
 wXl
@@ -74642,8 +72071,8 @@ rXk
 nIT
 wXl
 xGY
-mZF
-xGY
+vqo
+eki
 vBY
 xaC
 xXF
@@ -74665,7 +72094,7 @@ gfQ
 gfQ
 pay
 bqm
-lsb
+oMD
 bqm
 vZs
 tuj
@@ -74687,7 +72116,7 @@ bYN
 vQC
 dAn
 tuj
-tYO
+cvJ
 rwH
 aof
 rhF
@@ -74700,7 +72129,7 @@ vsQ
 gfQ
 gfQ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -74870,23 +72299,23 @@ aIN
 sVb
 bAH
 vUW
-wyf
-aXQ
+vUW
+agP
 aWu
 adH
-qaV
-qaV
-qaV
-qaV
-bGE
+wyf
+wyf
+wyf
+wyf
+wyf
 ccl
 vYu
 vYu
 afa
-dXm
-dXm
+pGN
+pGN
 nfu
-fTH
+jOj
 jYf
 idJ
 iSJ
@@ -74926,9 +72355,9 @@ hEB
 cfI
 vZs
 tuj
-dAn
+tuj
 naz
-vQC
+xXu
 jkP
 gpP
 csh
@@ -74957,7 +72386,7 @@ fsz
 gfQ
 gfQ
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -75129,25 +72558,25 @@ vUW
 vUW
 vUW
 vUW
-ykS
+cIR
 vUW
 ykS
 vUW
 ykS
+xAw
 vUW
-bGQ
-ccY
-jZg
-jZg
-akw
+hsp
 vYu
 vYu
+mDM
+vYu
+fSS
 rkx
-fTQ
-gPA
-pJi
+aQv
+aQv
+aQv
 vaF
-jPM
+aQv
 lgb
 oZS
 wXl
@@ -75156,7 +72585,7 @@ kDl
 qBX
 wXl
 xtO
-mZF
+vqo
 xtO
 vBY
 awV
@@ -75185,18 +72614,18 @@ vZs
 tuj
 tuj
 hYd
-tuj
-tuj
+xkU
+sTO
 gpP
 csh
 hXX
-nft
+rMJ
 mhN
 nft
 dRd
 bYN
 qMi
-qMi
+eCe
 voR
 mcr
 evw
@@ -75214,7 +72643,7 @@ fsz
 gfQ
 gfQ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -75386,26 +72815,26 @@ vUW
 aGF
 vUW
 vUW
-wKA
-vUW
-wKA
-vUW
-wKA
-vUW
+kam
 nRK
-hsp
-vYu
-vYu
-cIK
+wKA
+nRK
+wKA
+nRK
+nRK
+eLv
+dCo
+dCo
+mDM
 dTp
-xok
-aDL
+wXl
+wyR
 aQv
 wXl
 wXl
 wXl
-rcV
-pJi
+jNY
+aQv
 hZE
 wXl
 wXl
@@ -75413,7 +72842,7 @@ wXl
 wXl
 wXl
 xtO
-ucE
+ucy
 uSb
 vBY
 jLJ
@@ -75443,11 +72872,11 @@ tuj
 tuj
 tuj
 hYd
-tuj
+ids
 gpP
 tVQ
 gIl
-acD
+lgw
 qYx
 aVq
 krh
@@ -75457,7 +72886,7 @@ wTe
 ash
 mpC
 bYN
-tYO
+iuu
 tuj
 naz
 vZs
@@ -75471,7 +72900,7 @@ fsz
 gfQ
 gfQ
 gfQ
-gfQ
+xlO
 gfQ
 xAV
 gfQ
@@ -75643,44 +73072,44 @@ aJZ
 aLJ
 vUW
 aVb
-vUW
-vUW
-vUW
-vUW
-vUW
-vUW
 nRK
+vUW
+vUW
+vUW
+vUW
+agP
+vUW
 ako
 vYu
 vYu
-xHv
+mDM
 ahh
-xok
+wXl
 aDL
-aQv
+wix
 fOx
 fOx
 fOx
-aQv
-aQv
-aQv
+wix
+fbo
+uCK
 aED
 wXl
 xGY
 qCP
 rwS
 xtO
-xGY
+xHz
 nLX
 vMh
 xbl
 aFh
-xGY
+xsR
 xGY
 jXh
 fBW
 xsR
-pVM
+ptJ
 aKh
 mRp
 xGY
@@ -75704,8 +73133,8 @@ aco
 act
 acx
 acB
+krh
 svp
-ake
 ocJ
 gxF
 bYN
@@ -75714,7 +73143,7 @@ spy
 gVQ
 gnJ
 bYN
-tYO
+iuu
 jls
 aof
 dAn
@@ -75727,8 +73156,8 @@ gfQ
 fsz
 gfQ
 gfQ
-gfQ
-gfQ
+fsz
+xlO
 gfQ
 gfQ
 gfQ
@@ -75900,23 +73329,23 @@ vUW
 aGF
 vUW
 vUW
-ykS
+cIR
 vUW
 ykS
 vUW
 ykS
+agP
 vUW
-nRK
 hsp
 vYu
 vYu
-xHv
+mDM
 aDA
-xok
+wXl
 uyd
-fVb
+poo
 tnP
-tnP
+awZ
 tnP
 poo
 qaS
@@ -75927,16 +73356,16 @@ dou
 qDG
 rxZ
 sTy
-bbt
-uMp
-uMp
-uMp
-uMp
-uMp
-uMp
-uMp
-uMp
-sgN
+dNR
+tsI
+tsI
+tsI
+tsI
+hgr
+hgr
+hgr
+hgr
+fme
 uMp
 uMp
 uMp
@@ -75962,7 +73391,7 @@ aHm
 acy
 acC
 cWY
-jDr
+acD
 acD
 iXW
 bYN
@@ -75972,7 +73401,7 @@ xOz
 lid
 bYN
 vwh
-tuj
+rYD
 tuj
 aof
 tuj
@@ -75984,7 +73413,7 @@ gfQ
 fsz
 gfQ
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -76162,20 +73591,20 @@ sYz
 acU
 sYz
 acU
+ims
 sYz
-bIg
 cdc
 pLL
 pLL
 tyx
 aDB
 wXl
-wXl
-wXl
-wXl
-wXl
-wXl
-wXl
+wyR
+pcs
+iNn
+iNn
+iNn
+cQM
 wXl
 mDp
 wXl
@@ -76185,21 +73614,21 @@ xQv
 rym
 xtO
 uMp
-xGY
+vqo
 wWn
 wWn
 ace
 wWn
 wWn
 wWn
+eki
+iDE
+ttH
+bdY
+acl
 xGY
 pVM
-xGY
-xGY
-xGY
-xGY
-pVM
-xGY
+xAU
 qks
 mfD
 rra
@@ -76207,7 +73636,7 @@ vnz
 kJU
 qks
 rau
-leo
+hEB
 exH
 smo
 mOJ
@@ -76217,10 +73646,10 @@ vSt
 nfi
 aHm
 kLm
-xwZ
+ctT
 ejv
-xmO
-tJn
+ctT
+acD
 xVA
 bYN
 kuM
@@ -76228,7 +73657,7 @@ rny
 gVQ
 wsN
 bYN
-tYO
+iuu
 tuj
 rfR
 fBs
@@ -76412,48 +73841,48 @@ rnH
 rPO
 wyf
 vUW
-wyf
+vUW
 aVc
 aWG
 aao
-bdC
-bdC
-bdC
-bdC
-aCs
+wyf
+wyf
+wyf
+wyf
+wyf
 bEZ
 vYu
 vYu
-xHv
+mDM
 vYu
 geF
-xtO
-fVp
-gQq
-xtO
-tJT
-xtO
-peX
+wXl
+wXl
+wXl
+wXl
+wXl
+wXl
+wXl
 uMp
-xGY
+alh
 xtO
 xtO
 xtO
 xtO
 xtO
 uMp
-xGY
+vqo
 wWn
 xcn
 acf
 sxg
 wNC
 wWn
-xGY
+eSn
 xGY
 nLX
 kKY
-uAA
+fWj
 pVM
 pVM
 tSy
@@ -76475,8 +73904,8 @@ rEM
 aHm
 npf
 ctT
-acD
-nMT
+ejv
+ctT
 acD
 acG
 bYN
@@ -76485,7 +73914,7 @@ reM
 xOz
 rCl
 bYN
-tYO
+iuu
 tuj
 veV
 fBs
@@ -76662,14 +74091,14 @@ xUQ
 xUQ
 rPO
 aGI
-avy
+aXG
 aIp
-vvt
+aXG
 aXG
 aAr
 aFE
-sYz
-aTL
+jHD
+jHD
 jHD
 aTl
 sVb
@@ -76681,16 +74110,16 @@ aZO
 ced
 cMa
 vYu
-xHv
+mDM
 vYu
 evM
 xtO
 fVP
 baK
-xtO
+uAA
 aXZ
-xGY
-uMp
+xtO
+jRu
 uMp
 uMp
 baK
@@ -76699,7 +74128,7 @@ uMp
 uMp
 uMp
 uMp
-xGY
+vqo
 wWn
 bfZ
 axk
@@ -76707,13 +74136,13 @@ nqh
 hqR
 wWn
 aTJ
-xGY
+bdY
 pVM
 xGY
+eki
+viD
 xGY
-nLX
-xGY
-ylK
+sgp
 qks
 uVQ
 fSf
@@ -76733,7 +74162,7 @@ aHm
 aHC
 ctT
 kCx
-nMT
+ctT
 acD
 acI
 sCZ
@@ -76924,9 +74353,9 @@ xOo
 oAw
 ybL
 aAs
-wwd
-vUW
 wyf
+vUW
+vUW
 aTf
 aWJ
 sVb
@@ -76938,25 +74367,25 @@ sVb
 sVb
 sVb
 cYZ
-xHv
+mDM
 vYu
 gla
 xtO
 fVV
 sgN
+uAA
 xtO
 xtO
-xtO
-uMp
+nHp
+two
 xGY
 xGY
-xGY
-xGY
+xsR
 pVM
 pVM
 xGY
 uMp
-uMp
+tsI
 wWn
 qxj
 gxf
@@ -76973,25 +74402,25 @@ xGY
 ylK
 qks
 xkH
-jse
+fSf
 cVt
 fqf
 buI
-tJV
+aSi
 ruR
 iuU
 smo
 mOJ
 mOJ
-aHt
+hfr
 vSt
 rEM
 aHm
 jAT
-vFy
+sri
 ank
 jDr
-acD
+tJn
 eMX
 acQ
 syK
@@ -76999,7 +74428,7 @@ ltt
 ldr
 sCZ
 jkP
-tYO
+iuu
 vZs
 hnF
 fBs
@@ -77181,9 +74610,9 @@ rPO
 rPO
 rPO
 rPO
-aXQ
-bdC
-bdC
+wyf
+wyf
+wyf
 mfJ
 wyf
 sVb
@@ -77192,10 +74621,10 @@ rIH
 rIH
 rIH
 uJa
-uJa
-aAS
-bhe
-xHv
+adN
+vwr
+xBN
+mDM
 bhe
 bhe
 eRj
@@ -77205,8 +74634,8 @@ sgN
 uMp
 uMp
 uMp
-xGY
-xGY
+lvC
+eki
 tdq
 tdq
 tdq
@@ -77247,7 +74676,7 @@ aHm
 ybc
 acD
 vFy
-jDr
+acD
 acD
 hYH
 ggf
@@ -77256,7 +74685,7 @@ ldr
 gFd
 oDB
 qNv
-jfV
+nnD
 jls
 vQC
 fBs
@@ -77449,10 +74878,10 @@ uJa
 xyp
 lSd
 uJa
-uJa
+hqh
 xyp
 vYu
-xHv
+mDM
 vYu
 xvt
 xvt
@@ -77461,7 +74890,7 @@ xvt
 xvt
 iUd
 xvt
-uMp
+gQq
 mDX
 ntJ
 tdq
@@ -77470,7 +74899,7 @@ qFV
 wkU
 kDD
 tdq
-bbt
+idf
 wWn
 wWn
 snh
@@ -77513,7 +74942,7 @@ tCU
 nKt
 sCZ
 vGt
-tuj
+ids
 vZs
 qaL
 fBs
@@ -77687,8 +75116,8 @@ xyp
 xyp
 aoY
 xyp
-uJa
-att
+uDw
+avg
 qnj
 xyp
 xyp
@@ -77720,14 +75149,14 @@ beZ
 xvt
 xvt
 awM
-pVM
+cdD
 bUU
-kDD
+nWy
 cch
 rBl
 epF
 czY
-uMp
+hrU
 uMp
 uMp
 sgN
@@ -77754,14 +75183,14 @@ pfj
 rxU
 pjf
 acJ
-hEI
+mKV
 jtX
 lMQ
 vPT
+mKV
+mKV
 jtX
-iPX
-jtX
-uzl
+mKV
 mKV
 tJA
 lku
@@ -77770,7 +75199,7 @@ ldr
 jnC
 sCZ
 vGt
-tuj
+ids
 vZs
 vZs
 fBs
@@ -77945,14 +75374,14 @@ uJa
 uJa
 uJa
 uJa
-aty
+xUQ
 uJa
 uJa
 agh
-lSd
 xyp
 xyp
 xyp
+xDB
 sVb
 sVb
 sVb
@@ -77994,7 +75423,7 @@ uMp
 wBR
 jbu
 xqx
-jbu
+byj
 cJh
 yfY
 wwT
@@ -78006,7 +75435,7 @@ qks
 iMU
 qks
 hgw
-rLe
+rJK
 exH
 rxU
 anc
@@ -78202,7 +75631,7 @@ xhd
 xhd
 xhd
 xyp
-aty
+xUQ
 lDb
 uJa
 rIH
@@ -78246,11 +75675,11 @@ vyu
 vyu
 vyu
 vyu
-tvF
+uMp
 xGY
 yfY
 pnC
-tBG
+uCP
 mJh
 laS
 yfY
@@ -78270,7 +75699,7 @@ jjd
 pjf
 mWW
 eBT
-pjf
+sKV
 acw
 acF
 acF
@@ -78284,7 +75713,7 @@ foc
 vHk
 sCZ
 oqU
-hYd
+cKZ
 tuj
 vGt
 fBs
@@ -78459,11 +75888,11 @@ nrY
 nrY
 nrY
 xhd
-aty
+xUQ
 uJa
 rIH
 uJa
-uJa
+fRK
 xyp
 uJa
 uJa
@@ -78503,8 +75932,8 @@ uiK
 fzx
 raY
 vyu
-wGX
-xGY
+uMp
+xsR
 yfY
 yfY
 rSU
@@ -78540,8 +75969,8 @@ acF
 acF
 acF
 acF
-sAx
-tuj
+rhF
+fkL
 vZs
 tvB
 fBs
@@ -78716,7 +76145,7 @@ nrY
 nrY
 nrY
 xhd
-atB
+atb
 uJa
 xyp
 xyp
@@ -78736,8 +76165,8 @@ aIB
 bJA
 lmz
 cMu
-cZu
-dtd
+jyG
+jUZ
 dfX
 xvt
 xvt
@@ -78760,17 +76189,17 @@ qqn
 bgn
 bgs
 vyu
-wGX
+uMp
 xGY
 yfY
 urj
-tBG
-tLl
+uCP
+iDj
 tLl
 bhR
+erb
 sZt
-sZt
-sZt
+erb
 ugH
 cgH
 fFk
@@ -78797,8 +76226,8 @@ xWk
 apC
 kFX
 rEK
-mQs
-jeu
+tuj
+ids
 bUm
 vGt
 fBs
@@ -78973,16 +76402,16 @@ nrY
 nrY
 nrY
 xhd
-ayT
+hrw
 uJa
 xyp
 wUy
 wUy
 xyp
-xyp
+qLt
 uJa
 xyp
-uJa
+oxh
 uJa
 aDj
 aYF
@@ -79018,34 +76447,34 @@ qqn
 axn
 vyu
 wGX
-xGY
+tPD
 yfY
 wsG
-tBG
-tBG
-tLl
-bhR
+jBN
+uCP
+iDj
+lbL
 xMg
 xMg
-xMg
+gvi
 wWt
 mQA
 mQA
 aRG
 yfY
 acc
-vBP
+rLe
 gTH
 rxU
 dMc
 pjf
-xqk
+ihq
 qsH
-jtX
+mKV
 vul
 dqX
 dqX
-aNW
+lnE
 lnE
 rpZ
 xwj
@@ -79230,12 +76659,12 @@ nrY
 nrY
 nrY
 xhd
-biF
+xUQ
 uJa
 xyp
 awu
 uJa
-uJa
+xyp
 xyp
 adt
 aID
@@ -79274,16 +76703,16 @@ vMY
 qqn
 gTE
 vyu
-wGX
+hgr
 dgo
 yfY
 oPa
 qWa
 tBG
 tLl
-bhR
-dWp
+pEc
 xMg
+lui
 xMg
 wWt
 aRn
@@ -79295,7 +76724,7 @@ rLe
 exH
 rxU
 xNs
-vFF
+pjf
 gZN
 fsH
 sKV
@@ -79318,7 +76747,7 @@ tuj
 nOy
 vRx
 qwe
-yje
+oJq
 oJq
 uDD
 aqu
@@ -79451,9 +76880,9 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
+vmO
+aUP
+wmK
 wmK
 wmK
 wmK
@@ -79487,7 +76916,7 @@ nrY
 nrY
 nrY
 xhd
-biF
+vil
 uJa
 xyp
 kzr
@@ -79537,15 +76966,15 @@ yfY
 dDF
 tBG
 tBG
-tLl
-bhR
+gzf
+lbL
 vbG
 xMg
 xMg
 bhT
 fij
 fij
-xMg
+gvi
 wSC
 cfI
 rLe
@@ -79553,8 +76982,8 @@ exH
 rxU
 vtp
 mLP
-nEB
 pjf
+lDs
 fjZ
 acF
 kSo
@@ -79573,7 +77002,7 @@ meS
 otG
 pyL
 vKO
-kEB
+rbN
 rbN
 sPy
 vkG
@@ -79715,7 +77144,7 @@ uwV
 acb
 uwV
 amK
-flU
+jEN
 ygg
 ygg
 ygg
@@ -79792,15 +77221,15 @@ hoy
 bhm
 yfY
 aYL
-tBG
-tBG
-tLl
-bhR
-vbG
+twI
+soY
+nCc
+lbL
+xMg
 hKH
 xMg
 wYo
-xMg
+gvi
 xMg
 xMg
 qDj
@@ -79810,7 +77239,7 @@ tni
 rxU
 jdB
 lZW
-osV
+jdB
 vfG
 jdB
 acF
@@ -79827,11 +77256,11 @@ gfQ
 gfQ
 gfQ
 meS
-tmI
+otG
 tuj
 fBs
 vmb
-nOy
+rwb
 fBs
 fBs
 fBs
@@ -79974,26 +77403,26 @@ fqa
 adn
 vcx
 vcx
-pos
-pos
-pos
-pos
-pos
-pos
-pos
-pos
-pos
-pos
-pos
-pos
-pos
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
 vcx
 vcx
 vcx
-pos
-pos
-ail
-ygg
+arN
+arN
+arN
+cdK
 wYX
 nrY
 nrY
@@ -80022,7 +77451,7 @@ eYd
 aNJ
 cPz
 jyG
-dvy
+jUZ
 ybn
 iUV
 bsk
@@ -80052,13 +77481,13 @@ yfY
 txA
 jQE
 tLl
-bhR
+lbL
 oee
-lcu
-bhX
+pxG
+eIV
 pxG
 bhX
-bhX
+rZy
 bhX
 vkH
 ali
@@ -80067,12 +77496,12 @@ wPB
 rxU
 njN
 yau
-cYs
 sIc
+fyC
 eEE
 rEK
 pSt
-qab
+oCY
 pSt
 lpp
 acF
@@ -80249,7 +77678,7 @@ wKh
 wYX
 oCD
 ygg
-akg
+arN
 alb
 uwV
 amd
@@ -80273,29 +77702,29 @@ aNu
 aNY
 nAA
 uJs
-bdM
+bcX
 bfL
 bDt
 bju
 unW
 ybn
 jUZ
-ybn
-iUV
-wpu
-bjZ
-bki
+oSV
+dmW
+lSL
+lou
+hVA
 bkj
 bkk
 jQi
 fyr
-tZG
+lou
 nwW
-rSF
-mwV
+axd
+axd
 qHj
-bbw
-hKq
+dDP
+axd
 udM
 bbw
 vOD
@@ -80309,7 +77738,7 @@ yfY
 yfY
 aQU
 aQZ
-xMg
+eId
 isQ
 xMg
 xMg
@@ -80324,12 +77753,12 @@ hxn
 rxU
 fyx
 sIc
-cYs
-sIc
+fyC
+fyC
 oTO
 rEK
 tqB
-pSt
+mcU
 pSt
 hMX
 acF
@@ -80341,7 +77770,7 @@ gfQ
 gfQ
 gfQ
 meS
-tmI
+otG
 tuj
 cxf
 gPg
@@ -80479,9 +77908,9 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
+vmO
+aUP
+wmK
 wmK
 wmK
 wmK
@@ -80507,13 +77936,13 @@ wYX
 oCD
 ygg
 akh
-aBA
+arN
 alO
 ame
-aBA
-aBA
-aBA
-aqh
+arN
+arN
+arN
+arN
 arN
 atK
 adM
@@ -80522,7 +77951,7 @@ adF
 adM
 tVH
 aeB
-akf
+qRG
 bFu
 nWg
 bFu
@@ -80530,7 +77959,7 @@ aNu
 aag
 nAA
 bxt
-bdM
+bcX
 bDt
 bDt
 bjv
@@ -80540,9 +77969,9 @@ bjV
 bdO
 ewu
 eUk
-bka
-aeR
-aeR
+uMe
+uMe
+uMe
 opa
 uMe
 lkS
@@ -80555,7 +77984,7 @@ uHO
 ita
 udV
 uUX
-vRs
+bak
 xgF
 vyu
 aQA
@@ -80566,17 +77995,17 @@ yfY
 afS
 kEX
 wjE
-wjE
+pxG
 hOZ
 sbE
-mQA
+pWr
 aRH
 sbE
 mQA
 aRH
 aRJ
 cfI
-rLe
+rJK
 exH
 fMo
 sIc
@@ -80586,8 +78015,8 @@ ceQ
 oQJ
 snF
 tgf
-pSt
-pSt
+mcU
+mLA
 hMX
 acF
 gfQ
@@ -80598,7 +78027,7 @@ gfQ
 gfQ
 gfQ
 meS
-tmI
+qBL
 tuj
 cxf
 xWs
@@ -80772,14 +78201,14 @@ ygg
 ygg
 ata
 ygg
-aAw
+atK
 aup
-bGI
-bGI
+pHj
+pHj
 jtk
 tVH
 bcv
-akf
+qRG
 bFu
 aTM
 bFu
@@ -80797,7 +78226,7 @@ bjW
 ybn
 exn
 eVc
-bkb
+tZG
 tZG
 tZG
 tZG
@@ -80810,40 +78239,40 @@ rSF
 qIB
 rET
 kwy
-kwy
+axv
 uVr
-vRU
-xha
-oVO
+bak
+rSF
+bhd
 bor
-tHa
+vyu
 mua
 mua
 yfY
 drj
+gvi
 xMg
+ske
 xMg
-xMg
-aRi
 aRt
-mQA
+pWr
 xrp
 aRt
 mQA
-xrp
+kGL
 yfY
 cfI
-opp
+rJK
 exH
 rmb
 sIc
 sIc
-faD
+fyC
 sIc
 moX
 rEK
 kTp
-pSt
+hql
 qab
 qXs
 acF
@@ -80855,11 +78284,11 @@ aHw
 aHw
 aHw
 xjP
-tmI
+otG
 lsi
 cxf
 tCO
-ulu
+kMP
 ulu
 jTb
 rKn
@@ -81029,9 +78458,9 @@ oBJ
 oBJ
 oBJ
 arP
-aAw
+atK
 auq
-bGI
+pHj
 bGI
 ays
 tVH
@@ -81054,7 +78483,7 @@ jUZ
 ybn
 exu
 xvt
-bkc
+eVc
 gSA
 wpu
 wpu
@@ -81067,26 +78496,26 @@ bkA
 fZc
 rET
 pmW
-pmW
+szl
 uVr
 bge
 xhx
 bhd
 pQP
-tHa
+vyu
 vyu
 vyu
 yfY
 qQu
 xMg
 xMg
-xMg
+eId
 xMg
 fcD
 aRB
 aiA
 fcr
-aRB
+jAb
 aiA
 yfY
 cfI
@@ -81095,7 +78524,7 @@ exH
 dIv
 vMX
 sIc
-faD
+fyC
 mXg
 mvc
 rEK
@@ -81112,14 +78541,14 @@ rhF
 tuj
 tuj
 aof
-tmI
+otG
 aof
 cxf
 dDQ
-ulu
+ssG
 ulu
 vKo
-vKo
+iwr
 vKo
 vKo
 ulu
@@ -81286,7 +78715,7 @@ amR
 aoZ
 oBJ
 arQ
-aAw
+atK
 ygg
 ygg
 ygg
@@ -81314,8 +78743,8 @@ eWe
 bkd
 gSZ
 ijE
-ijE
-ijE
+tpP
+tpP
 ijE
 xvt
 xvt
@@ -81331,13 +78760,13 @@ uGs
 ycD
 pQP
 abK
-vyu
-vyu
+eCZ
+jGz
 yfY
 yfY
 wSC
 qDj
-qDj
+bZn
 wSC
 yfY
 yfY
@@ -81373,7 +78802,7 @@ taP
 vZs
 jGd
 vtt
-ulu
+ssG
 ulu
 bsp
 bsp
@@ -81543,7 +78972,7 @@ amS
 apa
 oBJ
 arS
-aAw
+atK
 ygg
 ygg
 ygg
@@ -81552,7 +78981,7 @@ php
 ybn
 ybn
 ybn
-aTY
+jyG
 ybn
 ybn
 ybn
@@ -81568,7 +78997,7 @@ qHh
 gmh
 gmh
 eWh
-bkS
+xEd
 xEd
 xEd
 xEd
@@ -81581,7 +79010,7 @@ qlt
 qlt
 qlt
 sTN
-qlt
+aPZ
 qlt
 qlt
 qlt
@@ -81594,7 +79023,7 @@ aQK
 aQN
 xEd
 xEd
-xEd
+dLi
 xsj
 dLJ
 sDb
@@ -81630,7 +79059,7 @@ hEB
 bqm
 mku
 ulu
-ulu
+ssG
 ulu
 gmz
 gmz
@@ -81791,7 +79220,7 @@ gfQ
 gfQ
 aig
 wYX
-fWh
+cPb
 ald
 qUs
 amh
@@ -81805,15 +79234,15 @@ agj
 dzZ
 agj
 bcB
-akp
-bcH
+ngx
 jyG
 jyG
-aTZ
 jyG
 jyG
-aYH
-wBK
+jyG
+jyG
+jyG
+jyG
 jyG
 jyG
 jyG
@@ -81824,66 +79253,66 @@ dam
 eyP
 aIg
 jyG
-fby
-bkf
-wYB
-wYB
-wYB
-wYB
-wYB
-xti
-wYB
-oLo
-wYB
-wYB
-wYB
+pzd
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
 bIZ
-wYB
-wYB
-wYB
-wYB
-wYB
-bkf
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
 bXi
-wYB
-wYB
-bIZ
-wYB
-wYB
-wYB
-wYB
-wYB
-wYB
-xti
-wYB
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
+tzr
 tzr
 tzr
 tzr
 pzd
-uvX
+hEB
 kal
-pNP
-oMD
-gnu
-gnu
-aze
-eHx
-uvX
-uvX
-uvX
-uvX
-bUR
-cqB
 fTC
-uvX
-uvX
-uvX
-uvX
-uQz
-gnu
-gnu
+oMD
+hEB
+eHx
+eHx
+eHx
+hEB
+hEB
+hEB
+hEB
+hEB
+hEB
+fTC
+hEB
+hEB
+hEB
+hEB
+hEB
+hEB
+hEB
 sFT
-mSn
+hEB
 oMD
 pty
 stt
@@ -82057,7 +79486,7 @@ amU
 apx
 oBJ
 ass
-aAw
+agj
 ygg
 ygg
 ygg
@@ -82070,7 +79499,7 @@ aUa
 ybn
 aWP
 ybn
-aZc
+jyG
 ybn
 bjx
 ybn
@@ -82104,7 +79533,7 @@ ach
 kTF
 kTF
 bhh
-wfj
+kTF
 dML
 mVX
 fDD
@@ -82130,7 +79559,7 @@ dNk
 gPP
 wCT
 cfI
-qpm
+hEB
 jUM
 jUM
 cfI
@@ -82145,14 +79574,14 @@ bqm
 mku
 ulu
 vPZ
-urR
-vKo
+sCG
+soK
 oDP
-vKo
-vKo
-urR
-ssG
-ciA
+soK
+nau
+sCG
+sCG
+tMS
 wUo
 rjv
 eko
@@ -82314,7 +79743,7 @@ amZ
 apz
 ark
 ast
-vWR
+agj
 ygg
 ygg
 aQJ
@@ -82402,14 +79831,14 @@ yam
 jGd
 vtt
 kmH
-kOc
+mTd
+bsp
+bsp
 uCA
-uCA
-uCA
-uCA
-icF
-fRU
-ciA
+bsp
+ulu
+ulu
+tMS
 jjB
 fQn
 eko
@@ -82571,9 +80000,9 @@ oBJ
 oBJ
 oBJ
 asD
-aAw
+agj
 bGI
-bGI
+pHj
 ady
 xNm
 hzP
@@ -82584,7 +80013,7 @@ btv
 brB
 hzP
 xNm
-brG
+aZT
 ivy
 tGp
 boH
@@ -82645,7 +80074,7 @@ hGr
 aEw
 mXt
 fBA
-frF
+tiI
 tiI
 pPb
 htJ
@@ -82654,19 +80083,19 @@ ekR
 piX
 vmQ
 vmQ
-pMJ
+kiF
 eUg
 cxf
 yaC
-ulu
+ssG
 mTd
 gmz
 gmz
 gmz
 gmz
 ulu
-ssG
-ciA
+ulu
+vHl
 eko
 eko
 eko
@@ -82820,17 +80249,17 @@ wYX
 wYX
 wYX
 akq
-agj
-agj
-bcB
-agj
+atK
+atK
+hmk
+atK
 anb
+atK
 agj
-uGE
 agj
-atN
+agj
 cXz
-cXz
+vrH
 cXz
 xNm
 brg
@@ -82841,12 +80270,12 @@ aUd
 aVj
 aeN
 xNm
-brG
+aZT
 cBO
 tGp
 tGp
 tGp
-btD
+dVA
 tGp
 bjJ
 bjU
@@ -82872,21 +80301,21 @@ bgt
 bgo
 jTo
 xcl
-bgN
+bhk
 bhk
 bhk
 mEb
-lbU
-aQW
+cwc
+cwc
 oaP
 abR
 gIr
 rpM
-hpf
+cwc
 cwc
 whQ
 xcl
-cXu
+xcl
 xcl
 upJ
 rLe
@@ -82903,7 +80332,7 @@ aEw
 pwa
 vcp
 lzQ
-lzQ
+uLD
 utV
 fHl
 rEx
@@ -82911,19 +80340,19 @@ tRG
 boc
 wNh
 piX
-pPE
+iXJ
 sis
 cxf
 vAa
-ulu
+bXe
 mTd
 nbb
 leO
 pZr
 cbm
 ulu
-bXe
-ulu
+gxR
+sCG
 uCO
 hoU
 kfI
@@ -83049,9 +80478,9 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
+vmO
+aUP
+wmK
 wmK
 wmK
 wmK
@@ -83076,7 +80505,7 @@ nrY
 wYX
 oCD
 ygg
-akx
+atK
 ygg
 aen
 urp
@@ -83103,7 +80532,7 @@ ivy
 tGp
 bjm
 bKk
-btD
+dVA
 tGp
 jkp
 bjU
@@ -83146,7 +80575,7 @@ xcl
 aKN
 xcl
 hJP
-rLe
+rJK
 uio
 puT
 ezQ
@@ -83168,7 +80597,7 @@ yam
 meV
 yam
 yam
-pMJ
+vmQ
 vmQ
 cxf
 kvM
@@ -83180,7 +80609,7 @@ fig
 gEA
 ulu
 ulu
-ciA
+vHl
 eko
 eko
 eko
@@ -83333,7 +80762,7 @@ gLT
 wYX
 oCD
 ygg
-akx
+atK
 alm
 uwV
 wYX
@@ -83348,14 +80777,14 @@ xNm
 xNm
 xNm
 xNm
-bsK
+aGy
 bcV
 ivy
 ivy
 bsK
 vHo
 ivy
-brG
+aZT
 bdJ
 tGp
 tGp
@@ -83371,14 +80800,14 @@ gdx
 ydc
 iok
 eTG
-jmh
+jUD
 sPt
 aPB
 aPJ
 oRY
 sRg
 aPB
-rKW
+rHA
 sVQ
 sEy
 uZo
@@ -83393,7 +80822,7 @@ ueQ
 itX
 itX
 xaE
-xFM
+itX
 soa
 xcl
 xcl
@@ -83403,7 +80832,7 @@ xcl
 kot
 xcl
 cfI
-ais
+rJK
 pII
 anY
 dZA
@@ -83425,7 +80854,7 @@ kNA
 vmQ
 mfx
 yam
-pMJ
+vmQ
 xrb
 cxf
 lyY
@@ -83437,7 +80866,7 @@ vKo
 vKo
 ulu
 ulu
-ciA
+vHl
 fjt
 fjt
 eko
@@ -83572,25 +81001,25 @@ ade
 adw
 aeh
 aeh
-aex
-aex
-aex
-aex
-aex
-aex
-aex
-aex
-aex
-aex
-aex
-aex
-aex
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
+arN
 aeh
 aeh
 aeh
-aex
-aex
-aky
+arN
+arN
+arN
 alp
 uwV
 gfQ
@@ -83599,21 +81028,21 @@ gfQ
 gfQ
 gfQ
 ybK
-aCe
-vhx
+hIq
+yiQ
 xNm
 bre
 maz
 xNm
-aAO
+qxD
 aGy
 aGy
 agn
 qxD
-rqA
-rqA
-aZf
-ivy
+aZT
+aZT
+aZT
+rmK
 tGp
 bpd
 brH
@@ -83653,14 +81082,14 @@ rmP
 cRA
 kMl
 rtd
-nCM
+abY
 abU
 abY
 bQg
 brO
 xcl
 cfI
-wEC
+rJK
 daW
 anZ
 nXA
@@ -83669,8 +81098,8 @@ ukF
 jrJ
 lgv
 ptT
-hMM
-hMM
+qAe
+qAe
 ciJ
 tEs
 mVv
@@ -83683,7 +81112,7 @@ aoI
 vmQ
 yam
 xsM
-gUz
+vmQ
 cxf
 jzC
 ulu
@@ -83694,7 +81123,7 @@ lkO
 xFq
 ulu
 ulu
-ciA
+vHl
 fjt
 fjt
 eko
@@ -83827,7 +81256,7 @@ uwV
 acH
 wmK
 adJ
-aen
+rni
 ygg
 ygg
 ygg
@@ -83857,19 +81286,19 @@ gfQ
 gfQ
 ybK
 hyg
-vhx
+yiQ
 xNm
 hzP
 ayu
 ayX
-aAP
-ivy
-aVQ
+aGy
+rmK
+oTu
 asd
 aVu
 asd
-aVQ
-brG
+oTu
+aZT
 aZS
 tGp
 tGp
@@ -83877,7 +81306,7 @@ tGp
 cff
 tGp
 dak
-dxe
+bjU
 ybn
 ozS
 fhg
@@ -83889,10 +81318,10 @@ aPu
 sPt
 aPD
 aPL
-sPt
+cRt
 jUf
 ayF
-rLO
+rHA
 tcq
 sEy
 vbT
@@ -83940,7 +81369,7 @@ tJB
 tJB
 tJB
 tJB
-pPE
+egP
 cxf
 cxf
 lLy
@@ -84077,9 +81506,9 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
+vmO
+aUP
+wmK
 wmK
 wmK
 wmK
@@ -84114,7 +81543,7 @@ gfQ
 gfQ
 ybK
 hyg
-bdG
+bjj
 xNm
 vjO
 ayA
@@ -84197,8 +81626,8 @@ cdq
 dLA
 qtc
 tJB
-ppA
-dnU
+vmQ
+sis
 vmQ
 vmQ
 sis
@@ -84208,7 +81637,7 @@ vmQ
 cxf
 wIe
 wIe
-fjt
+lUD
 vlD
 hoU
 dVG
@@ -84370,8 +81799,8 @@ gfQ
 gfQ
 gfQ
 ybK
-hyg
-vhx
+hdE
+yiQ
 xNm
 xNm
 xNm
@@ -84395,7 +81824,7 @@ bjU
 ybn
 hBV
 fho
-jIV
+qqk
 hee
 hee
 auw
@@ -84403,13 +81832,13 @@ mjV
 mjV
 mNg
 mjV
-mjV
+dwP
 mjV
 qLO
-jIV
+qnO
 mjV
 uix
-jIV
+vNy
 vWk
 xoW
 mjV
@@ -84455,10 +81884,10 @@ mNX
 gRo
 tJB
 tJB
-pMJ
 vmQ
 vmQ
 vmQ
+vcX
 yam
 yam
 yam
@@ -84631,16 +82060,16 @@ aCL
 adP
 xNm
 awv
-maz
+irO
 xNm
 aBa
 ivy
 aLK
+oTu
+oBl
 aVQ
-asd
 aVQ
-aVQ
-ivy
+rmK
 aZV
 tGp
 tGp
@@ -84657,19 +82086,19 @@ beN
 beN
 jad
 jXG
-lmk
+wSE
 mPg
 wSE
+wfN
 wSE
 wSE
-qMo
-rOI
+wSE
 tcM
 ujo
-bfR
+wSE
 bgj
-wRJ
-wRJ
+vNy
+vNy
 ent
 vNy
 gGb
@@ -84688,7 +82117,7 @@ xcl
 aKO
 pnn
 jJn
-rLe
+rJK
 uio
 tmT
 yal
@@ -84712,7 +82141,7 @@ mGL
 eab
 fgY
 tJB
-pMJ
+vmQ
 vmQ
 vmQ
 tRG
@@ -84885,24 +82314,24 @@ ybK
 ybK
 ybK
 hyg
-vhx
+hIq
 xNm
-hzP
+kHI
 ayD
 azd
-aBf
+aGy
 ivy
-ivy
+rmK
 auV
 aVG
 azZ
 aYJ
-ivy
+rmK
 aZX
 tGp
 brA
 bLd
-btD
+dVA
 tGp
 ybn
 bjU
@@ -84928,7 +82357,7 @@ ygp
 ygp
 ygp
 ygp
-jIV
+vNy
 mjV
 dOQ
 dII
@@ -84969,8 +82398,8 @@ dpK
 eab
 geY
 tJB
-lVz
-uFK
+vmQ
+vmQ
 xDX
 edi
 yam
@@ -85142,7 +82571,7 @@ yiQ
 yiQ
 yiQ
 aaj
-vhx
+hIq
 xNm
 vjO
 xFe
@@ -85171,7 +82600,7 @@ fav
 beO
 jdG
 ezy
-lmA
+qnO
 aPR
 nBn
 oZZ
@@ -85191,18 +82620,18 @@ ksj
 mTo
 bel
 fVr
-shF
-shF
-shF
-shF
-shF
+xvu
+xvu
+xvu
+xvu
+xvu
 rZB
 uVs
 msF
-rSA
+aKO
 pnn
 wNb
-rLe
+rJK
 nNO
 prw
 rfU
@@ -85405,7 +82834,7 @@ awD
 xNm
 xNm
 aBo
-aLc
+rXA
 ljc
 xNm
 uDc
@@ -85428,7 +82857,7 @@ hev
 beP
 vqN
 khQ
-rRR
+qnO
 mRb
 nBH
 iie
@@ -85452,17 +82881,17 @@ shF
 shF
 shF
 shF
-shF
+hKa
 rZB
 uVs
 dAV
-rMe
+aKO
 pnn
 cfI
 rLe
-uio
+hOX
 ueS
-sts
+hNS
 nSf
 rxf
 nio
@@ -85471,8 +82900,8 @@ aSE
 hAu
 xnx
 uCC
-whq
-tkl
+qAe
+qAe
 cND
 tJB
 sKU
@@ -85482,8 +82911,8 @@ xkO
 lVI
 qOk
 tJB
-dSW
-eaE
+vmQ
+vmQ
 yam
 fsz
 gfQ
@@ -85656,7 +83085,7 @@ gfQ
 gfQ
 gfQ
 ybK
-vhx
+hIq
 yiQ
 yiQ
 gAn
@@ -85666,7 +83095,7 @@ aLc
 ljc
 xNm
 aMp
-aXT
+sKc
 aMQ
 aZi
 sKc
@@ -85685,7 +83114,7 @@ hhi
 ipn
 vqN
 kiL
-rRR
+qnO
 mRb
 nBH
 bkZ
@@ -85709,7 +83138,7 @@ shF
 shF
 shF
 shF
-shF
+wKi
 eaK
 uVs
 pnn
@@ -85719,7 +83148,7 @@ qCa
 rLe
 uio
 fdc
-unF
+etA
 ppj
 unF
 xoP
@@ -85733,13 +83162,13 @@ qAe
 cuz
 tJB
 cxw
+hlN
 tJB
 tJB
 tJB
 tJB
 tJB
-tJB
-pPE
+sis
 yam
 yam
 fsz
@@ -85913,7 +83342,7 @@ gfQ
 gfQ
 fsz
 ybK
-vhx
+hIq
 yiQ
 sRB
 yiQ
@@ -85942,7 +83371,7 @@ vqN
 vqN
 vqN
 kjC
-rRR
+qnO
 mRb
 nBH
 abD
@@ -85961,25 +83390,25 @@ mjV
 lMp
 shF
 shF
-phv
+rke
 shF
 shF
 shF
 shF
-shF
+wKi
 rZB
 bKt
 pjE
 lyG
 pnn
 rau
-ojV
+rLe
 uio
 uln
 unF
 unF
 wXz
-efs
+unF
 tTH
 aSG
 agw
@@ -85996,7 +83425,7 @@ jOm
 eab
 rDw
 tJB
-pPE
+sis
 yam
 yam
 fsz
@@ -86199,7 +83628,7 @@ hhL
 uby
 jip
 khQ
-rRR
+qnO
 mRi
 nBH
 eRz
@@ -86218,12 +83647,12 @@ mjV
 tRJ
 shF
 shF
-phv
+rke
 shF
 shF
 shF
 shF
-shF
+wKi
 rZB
 uVs
 pjE
@@ -86254,7 +83683,7 @@ mlD
 mlD
 tJB
 qdt
-gUz
+vmQ
 yam
 fsz
 fsz
@@ -86428,9 +83857,9 @@ gfQ
 gfQ
 ybK
 auJ
-vhx
-vhx
-vhx
+hIq
+hIq
+hIq
 kbg
 yiQ
 yiQ
@@ -86447,7 +83876,7 @@ xrI
 xrI
 eRs
 ybn
-aOw
+bjU
 lNJ
 vqN
 aOR
@@ -86456,21 +83885,21 @@ hiv
 isb
 jiQ
 kjT
-lmA
+qnO
 mRb
 nBH
 abD
 pTu
-qRp
+nFu
 rUN
 tkv
 jYJ
 mjV
 mjV
 mjV
-yen
-wSE
-uVx
+vNy
+vNy
+vNy
 mjV
 wdx
 tea
@@ -86480,7 +83909,7 @@ shF
 shF
 shF
 shF
-shF
+arc
 sIS
 uVs
 pjE
@@ -86687,7 +84116,7 @@ ybK
 avb
 ybK
 ybK
-vhx
+hIq
 kbg
 yiQ
 yiQ
@@ -86712,13 +84141,13 @@ fEc
 hiA
 taa
 jip
-khQ
-jIV
+dVq
+qnO
 mRb
 nBH
 iie
 fTr
-cki
+nFu
 rWe
 xiy
 vdD
@@ -86768,8 +84197,8 @@ iPn
 agU
 tJB
 ekR
-imS
-mze
+gUz
+gUz
 gUz
 yam
 gfQ
@@ -86944,7 +84373,7 @@ ybK
 iaf
 gxo
 ybK
-vhx
+hIq
 wrE
 yiQ
 aLr
@@ -86970,7 +84399,7 @@ fnK
 fnK
 fnK
 kjZ
-jIV
+qnO
 mRb
 nBH
 iie
@@ -87008,7 +84437,7 @@ eYG
 nOK
 prw
 lby
-aSx
+unF
 gej
 gwx
 prw
@@ -87026,7 +84455,7 @@ tJB
 tJB
 dZA
 eQR
-vmQ
+xrZ
 pMJ
 yam
 fsz
@@ -87201,7 +84630,7 @@ ybK
 aLB
 dGI
 ybK
-vhx
+hIq
 wrE
 kbg
 aLr
@@ -87218,7 +84647,7 @@ xrI
 xrI
 eRs
 ybn
-aOx
+bjU
 xbT
 vqN
 tVT
@@ -87232,7 +84661,7 @@ aPR
 nCm
 cnf
 iie
-cki
+nFu
 ydF
 tlL
 tQc
@@ -87265,7 +84694,7 @@ vpr
 lqk
 vwz
 gzu
-fal
+unF
 hQc
 eoN
 prw
@@ -87458,7 +84887,7 @@ ybK
 ybK
 ybK
 ybK
-vhx
+hIq
 kbg
 wrE
 aLs
@@ -87479,15 +84908,15 @@ bjU
 hPr
 vqN
 fqj
-quk
 bxj
 bxj
-jjR
+bxj
+knB
 knB
 lpc
 aOz
-aOz
-aOz
+gWb
+gWb
 gWb
 qSL
 rWs
@@ -87515,7 +84944,7 @@ pnn
 pnn
 pay
 cfI
-rLe
+uaN
 gRN
 mph
 eVo
@@ -87715,7 +85144,7 @@ lEE
 pGW
 ybx
 ybK
-vhx
+hIq
 yiQ
 yiQ
 rsd
@@ -87741,11 +85170,11 @@ hkq
 loU
 jku
 knV
-fnK
-aOz
+tRt
+rmB
 nCs
-aOz
-pRS
+wVB
+evf
 qUD
 rWP
 tqR
@@ -87790,7 +85219,7 @@ cND
 dwt
 cND
 cND
-cND
+dsX
 cND
 cND
 cND
@@ -87972,7 +85401,7 @@ lEE
 yiQ
 yiQ
 haO
-vhx
+hIq
 yiQ
 wrE
 aGM
@@ -87999,12 +85428,12 @@ loU
 jlf
 kor
 fnK
-mSS
 evf
 evf
 wVB
+wVB
 dLn
-aev
+rWP
 trH
 tQc
 oHo
@@ -88042,12 +85471,12 @@ qiA
 prw
 eQX
 cND
-uER
+mVv
 jsM
 qLb
-shl
-shl
-isG
+nog
+nog
+nog
 nog
 nog
 gGT
@@ -88229,7 +85658,7 @@ lEE
 nGL
 nGL
 ybK
-vhx
+hIq
 kbg
 wrE
 wEK
@@ -88258,7 +85687,7 @@ krR
 fnK
 mTW
 nDv
-aOz
+kEo
 ekh
 aQk
 aew
@@ -88299,7 +85728,7 @@ qAe
 cND
 cND
 iyG
-xSC
+qAe
 cND
 ukg
 jaa
@@ -88486,8 +85915,8 @@ ybK
 ybK
 ybK
 ybK
-vhx
-yiQ
+hIq
+cuO
 yiQ
 yiQ
 vaN
@@ -88503,7 +85932,7 @@ xrI
 xrI
 rnj
 dgp
-khO
+dAU
 aOG
 vqN
 bff
@@ -88533,24 +85962,24 @@ uze
 sIR
 uze
 gou
-hQq
+yeH
 yeH
 jVW
 vvO
 lkE
 cbj
-cbj
+ucK
 cbj
 eTf
 uWM
-hGZ
+iMZ
 iAp
 syg
-hhY
+iDr
 mjT
 prv
 eXs
-hhY
+iDr
 wZK
 qAe
 cND
@@ -88795,25 +86224,25 @@ chj
 meB
 vvO
 iUI
-rOj
-rOj
-rOj
+eAo
+eAo
+eAo
 vEt
 dgp
-frf
-iAp
+iMZ
+cTJ
 gZk
-tjx
+cjv
 oJn
 pMf
 vWc
 gQg
 cKk
-cos
+mVv
 ieQ
-hMM
-hMM
-tkl
+qAe
+qAe
+mVv
 cND
 ezH
 erg
@@ -88822,8 +86251,8 @@ dIV
 npm
 dfA
 hfO
-cND
-cND
+qKs
+vNb
 dvT
 vrT
 mLZ
@@ -89009,11 +86438,11 @@ bSw
 aMz
 aMJ
 uJv
-uJv
-aZY
 bdP
 bdP
-kqj
+bdP
+bdP
+bmR
 bmR
 cQB
 dhi
@@ -89057,7 +86486,7 @@ rOj
 rOj
 rOj
 uWM
-gXd
+iMZ
 dld
 fkU
 dZA
@@ -89078,7 +86507,7 @@ fsE
 wTL
 ilJ
 jYl
-kyk
+gAL
 qAC
 pOS
 dZA
@@ -89314,7 +86743,7 @@ uWM
 uWM
 uWM
 uWM
-gXd
+iMZ
 uWM
 jbI
 xsd
@@ -89323,7 +86752,7 @@ qpp
 tWI
 fLF
 pKs
-qVf
+qhd
 jyS
 cyB
 dZA
@@ -89335,11 +86764,11 @@ ecl
 ecl
 ecl
 jaa
-kyk
+gAL
 qAC
 gHq
 dZA
-ccb
+pHi
 oUM
 eRN
 dZA
@@ -89535,7 +86964,7 @@ dCO
 ydj
 qYW
 ydj
-hHx
+ydj
 ydj
 ydj
 jmU
@@ -89546,7 +86975,7 @@ nDO
 ydj
 xCC
 ydj
-tvT
+ydj
 ydj
 ydj
 pIg
@@ -89555,8 +86984,8 @@ ydj
 ydj
 ydj
 ydj
+lff
 ydj
-gBO
 ydj
 lsN
 ydj
@@ -89564,10 +86993,10 @@ lqD
 ydj
 ydj
 pMS
-tvT
 ydj
 ydj
 ydj
+pcc
 ydj
 ydj
 teX
@@ -89587,9 +87016,9 @@ dZA
 fjm
 uyz
 vyd
-cuJ
-cuJ
-lwC
+cgE
+cgE
+cgE
 cgE
 cgE
 mtq
@@ -89597,7 +87026,7 @@ qAC
 aOP
 dZA
 rKi
-iDr
+nIk
 oFA
 dZA
 gfQ
@@ -89784,7 +87213,7 @@ aNf
 amH
 aNn
 wCI
-yiQ
+tHM
 eJV
 rNA
 qTa
@@ -89811,7 +87240,7 @@ dfT
 tin
 tin
 slI
-uWM
+sWJ
 uWM
 uWM
 tin
@@ -89833,9 +87262,9 @@ tkA
 tkA
 ksb
 vAz
-mJQ
+iWb
 eKl
-qVf
+mht
 tWI
 xjX
 pVR
@@ -89846,7 +87275,7 @@ cND
 wZK
 cND
 cND
-cND
+pTB
 cND
 cND
 cND
@@ -89854,7 +87283,7 @@ cND
 bXY
 dZA
 ryV
-iDr
+nIk
 tZR
 iHs
 gfQ
@@ -90036,13 +87465,13 @@ ybK
 dYS
 ybK
 ybK
-yiQ
-sjT
+xMD
+itv
 baa
 aNo
 jHF
-wrE
-hyg
+ksE
+yiQ
 ybK
 xAk
 dDq
@@ -90068,7 +87497,7 @@ dxy
 xtt
 jIT
 ocu
-ocu
+bWS
 ocu
 pKd
 oVi
@@ -90111,7 +87540,7 @@ uZE
 iDr
 dZA
 qZr
-iDr
+nIk
 hXV
 gfQ
 gfQ
@@ -90294,12 +87723,12 @@ yiQ
 gAn
 vro
 yiQ
-yiQ
-bab
+eJV
+eJV
 beJ
 bsU
-bLy
-nxK
+ksE
+yiQ
 hhc
 xAk
 dFO
@@ -90325,7 +87754,7 @@ woo
 xtK
 rpt
 kuc
-kuc
+uJb
 rCG
 tEA
 tEA
@@ -90367,7 +87796,7 @@ eQH
 wmJ
 wmJ
 gfQ
-hOS
+aUP
 ssp
 hXV
 gfQ
@@ -90555,7 +87984,7 @@ aZl
 aZl
 aNp
 aYK
-sjT
+ecf
 nzD
 yiQ
 xAk
@@ -90624,7 +88053,7 @@ wmJ
 wmJ
 gfQ
 gfQ
-hOS
+aUP
 ssp
 hXV
 gfQ
@@ -90812,7 +88241,7 @@ yiQ
 biW
 aNo
 yiQ
-yiQ
+eJV
 yiQ
 rsd
 xAk
@@ -90863,7 +88292,7 @@ tmj
 tLd
 yal
 dKw
-yal
+pRZ
 itI
 wse
 gGu
@@ -90881,7 +88310,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-hOS
+aUP
 ssp
 dsw
 gfQ
@@ -91069,7 +88498,7 @@ bjd
 vEr
 vEr
 bjj
-wrE
+ksE
 ybK
 ybK
 xAk
@@ -91092,7 +88521,7 @@ koC
 koC
 unL
 tSh
-wpm
+aQu
 ljx
 muF
 fBg
@@ -91118,8 +88547,8 @@ uZT
 tRr
 tmj
 tLd
-hvE
-yal
+nqN
+cVL
 yal
 yal
 hvE
@@ -91138,7 +88567,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-hOS
+aUP
 ssp
 hXV
 gfQ
@@ -91326,7 +88755,7 @@ bje
 aNs
 blr
 jyY
-yiQ
+eJV
 sRB
 gER
 xAk
@@ -91395,7 +88824,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-hOS
+aUP
 ssp
 dsw
 gfQ
@@ -91583,7 +89012,7 @@ bjf
 aZn
 aNs
 vEr
-sjT
+ecf
 yiQ
 nFy
 xAk
@@ -91652,7 +89081,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-hOS
+aUP
 ssp
 hXV
 gfQ
@@ -91855,15 +89284,15 @@ jvA
 ezk
 wRL
 fUf
-nPx
-oeI
+nIB
+ygi
 dOK
 dOK
 dOK
 dOK
 dOK
 ioj
-qEC
+wpn
 ure
 pgy
 pgy
@@ -91909,7 +89338,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-hOS
+aUP
 ssp
 hXV
 gfQ
@@ -92097,30 +89526,30 @@ bjT
 yiQ
 beL
 yiQ
-yiQ
+eJV
 yiQ
 kcB
 dhq
 xvK
-sAI
-nQQ
-nQQ
+lNt
+lNt
+lNt
 gqN
-nQQ
-nQQ
+lNt
+lNt
 jyy
 ezk
 wRL
 oeI
-uJL
+nIB
 oeI
 oeI
-qXV
+oeI
 oeI
 oeI
 upp
 ioj
-wqO
+wpn
 xxa
 rTM
 edn
@@ -92137,7 +89566,7 @@ jig
 lQK
 ijy
 vTl
-iam
+jMo
 vTl
 pUm
 dYr
@@ -92167,9 +89596,9 @@ gfQ
 gfQ
 eqS
 wkn
-oiJ
-hXV
-gfQ
+jZO
+poS
+xsb
 gfQ
 gfQ
 gfQ
@@ -92180,7 +89609,7 @@ gfQ
 idc
 mlW
 mnV
-rip
+uWf
 mnV
 utH
 idc
@@ -92354,7 +89783,7 @@ aZn
 aNo
 bjA
 btl
-gAn
+pyg
 yiQ
 kcD
 xAk
@@ -92373,11 +89802,11 @@ nPX
 pcX
 pVd
 rae
-jsH
+pAy
 tuv
 urd
 vnX
-wrs
+wpn
 xxj
 dOK
 rYC
@@ -92394,7 +89823,7 @@ pCh
 tbE
 dBt
 vTl
-iam
+jMo
 vTl
 fHM
 xbi
@@ -92424,7 +89853,7 @@ gfQ
 gfQ
 xBZ
 fWC
-oiJ
+jZO
 rpp
 eqS
 xBZ
@@ -92611,7 +90040,7 @@ bjA
 baw
 bjA
 vEr
-yiQ
+eJV
 yiQ
 yiQ
 azg
@@ -92630,7 +90059,7 @@ vEU
 tJp
 tJp
 tJp
-oeI
+uAk
 tvm
 pgy
 vpQ
@@ -92651,7 +90080,7 @@ uZT
 dmA
 kpz
 vTl
-iam
+jMo
 vTl
 kpz
 glU
@@ -92681,7 +90110,7 @@ gfQ
 gfQ
 xBZ
 gay
-oiJ
+jZO
 xZa
 mQu
 xoM
@@ -92862,14 +90291,14 @@ ybK
 aLr
 aUu
 aVL
-vEr
-yiQ
+vGO
+eJV
 aZo
-wrE
+ksE
 hpS
-biX
-yiQ
-yiQ
+nkh
+eJV
+wGL
 yiQ
 rsd
 dJf
@@ -92918,10 +90347,10 @@ dCK
 tmj
 agy
 dXn
-pdM
-pdM
-nRl
-thC
+nqN
+nqN
+qTO
+oxx
 hvE
 xsd
 fLa
@@ -92937,7 +90366,7 @@ gfQ
 xAV
 gfQ
 xBZ
-oqG
+iiy
 fJZ
 wmO
 iiy
@@ -93119,7 +90548,7 @@ ybK
 ybK
 ybK
 sjT
-nzD
+fxC
 yiQ
 wrE
 yiQ
@@ -93135,8 +90564,8 @@ eGz
 fuF
 wsx
 hqF
-qeW
-jAR
+pRF
+jAG
 kyQ
 ltM
 mVs
@@ -93144,7 +90573,7 @@ nQn
 pjb
 qaH
 tJp
-oeI
+uAk
 tvm
 urU
 vrd
@@ -93178,7 +90607,7 @@ wse
 xsd
 gMq
 pbB
-yal
+qTO
 kga
 xsd
 iXC
@@ -93207,7 +90636,7 @@ hoj
 nHO
 kGn
 cUu
-sdl
+aJL
 xLf
 qay
 mEX
@@ -93376,7 +90805,7 @@ fsz
 gfQ
 xxF
 xxF
-aWS
+wmr
 xxF
 xxF
 xxF
@@ -93392,7 +90821,7 @@ bdR
 pQj
 pQj
 mte
-beX
+qeW
 jBy
 kAZ
 luR
@@ -93435,7 +90864,7 @@ xsd
 xsd
 xsd
 xsd
-iLZ
+ggF
 xsd
 xsd
 ahf
@@ -93451,7 +90880,7 @@ gfQ
 gfQ
 gfQ
 xBZ
-iiy
+gYL
 hLU
 iiy
 iiy
@@ -93612,20 +91041,20 @@ fsz
 fsz
 fsz
 fsz
+hZo
+fsz
+fsz
+fsz
+fsz
+fsz
+hZo
 fsz
 fsz
 fsz
 fsz
 fsz
 fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
+hZo
 fsz
 fsz
 fsz
@@ -93633,7 +91062,7 @@ fsz
 fsz
 xxF
 nFy
-xII
+oUE
 xxF
 xxF
 qLB
@@ -93660,10 +91089,10 @@ gbr
 tJp
 seW
 txK
-usW
-usW
-usW
-usW
+dfS
+dfS
+dfS
+dfS
 dfS
 pAy
 pAy
@@ -93674,11 +91103,11 @@ djH
 aws
 pFp
 mya
-mUb
-mUb
-mUb
+wjQ
+wjQ
+wjQ
 mqz
-mUb
+wjQ
 ikU
 vTl
 jsE
@@ -93692,7 +91121,7 @@ xsd
 mdJ
 ufF
 xsd
-tvz
+fdQ
 xsd
 xsd
 hDe
@@ -93867,30 +91296,30 @@ aUP
 aUP
 gfQ
 gfQ
-gfQ
-gfQ
-fsz
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
-gfQ
-gfQ
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
+aUP
 gfQ
 gfQ
 gfQ
 xxF
-xII
-xII
+eXn
+oUE
 xxF
 aZp
 akj
@@ -93912,17 +91341,17 @@ kBm
 tJp
 xst
 nTr
-jNr
+fXb
 qey
 tJp
-oeI
+uAk
 tvm
 utq
 vre
 vre
 vre
 utq
-oeI
+uxr
 cyp
 gtJ
 niU
@@ -93949,7 +91378,7 @@ uJy
 mJQ
 mJQ
 xsd
-yal
+qTO
 wse
 xsd
 cyi
@@ -94126,20 +91555,20 @@ fsz
 fsz
 fsz
 fsz
+hZo
+fsz
+fsz
+fsz
+fsz
+fsz
+hZo
 fsz
 fsz
 fsz
 fsz
 fsz
 fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
+hZo
 fsz
 fsz
 fsz
@@ -94185,7 +91614,7 @@ fwP
 bQC
 cTD
 cTD
-uFb
+jOf
 tmj
 tmj
 tmj
@@ -94206,7 +91635,7 @@ hvE
 thC
 mJQ
 xsd
-thC
+oxx
 iTL
 xsd
 ahf
@@ -94442,7 +91871,7 @@ gnT
 hjS
 gJw
 cTD
-vBA
+oTb
 vnF
 tmj
 jig
@@ -94463,7 +91892,7 @@ hvE
 mxm
 mJQ
 iLZ
-yal
+qTO
 iTL
 xsd
 lQu
@@ -94686,7 +92115,7 @@ nVw
 pnD
 qfG
 raD
-shQ
+pAy
 gks
 iAb
 vuN
@@ -94707,7 +92136,7 @@ jig
 jig
 nSz
 kPK
-oGy
+gID
 kmZ
 uDR
 uDR
@@ -94720,7 +92149,7 @@ xsd
 yal
 nzb
 xsd
-yal
+qTO
 thC
 xsd
 xsd
@@ -94944,7 +92373,7 @@ pnR
 qgk
 wnE
 skW
-tAq
+tvm
 iAb
 vuU
 wvq
@@ -94952,19 +92381,19 @@ xAd
 iAb
 lSr
 pOa
-nlv
+fWk
 piz
 pib
 cTD
-vBA
-jFS
+oTb
+sTW
 tmj
 dzj
 cKi
 hou
 mqn
 cQR
-oGy
+gID
 jsA
 lwL
 hsb
@@ -94977,12 +92406,12 @@ yal
 mJQ
 mJQ
 xsd
-yal
+qTO
 tNp
 itI
 xsd
 ahf
-fFL
+rgW
 vWf
 ufi
 xsd
@@ -95199,17 +92628,17 @@ mYg
 nZN
 ppC
 qiv
-wnE
-oeI
-tAq
+xiq
+uAk
+tvm
 iAb
-vvR
+lMh
 wwa
 vvR
 iAb
 fiW
 lgz
-vjX
+fWk
 piz
 piz
 cTD
@@ -95221,10 +92650,10 @@ jig
 jig
 nSz
 kPK
-oGy
+gID
 qTV
 uDR
-qLs
+lHP
 lHP
 tmj
 fXz
@@ -95234,9 +92663,9 @@ yal
 mJQ
 xsd
 xsd
-hvE
-hvE
-yal
+nqN
+nqN
+qTO
 mAn
 cfZ
 eQS
@@ -95262,11 +92691,11 @@ iQl
 iQl
 dCk
 ieH
-fAO
+cmf
 tMD
 wIT
 tMD
-ePz
+qav
 ieH
 dCk
 iQl
@@ -95458,7 +92887,7 @@ wnE
 wnE
 wnE
 slw
-tAq
+tvm
 uwy
 vye
 wwO
@@ -95478,10 +92907,10 @@ jig
 jig
 nSz
 kxZ
-oGy
+gID
 vTl
 uDR
-sXm
+lHP
 oYo
 tmj
 xsd
@@ -95506,7 +92935,7 @@ gfQ
 xBZ
 rCW
 iiy
-skG
+biV
 oiJ
 pWw
 oiJ
@@ -95519,11 +92948,11 @@ iQl
 iQl
 dCk
 dzX
-fAO
+cmf
 dCk
 dCk
 dCk
-ePz
+qav
 wTl
 dCk
 iQl
@@ -95714,10 +93143,10 @@ obW
 pqA
 qkf
 kGJ
-oeI
-tAq
+uAk
+tvm
 uyn
-vvR
+lMh
 wyS
 vvR
 uyn
@@ -95730,7 +93159,7 @@ cTD
 pyP
 vBA
 tmj
-koj
+tmj
 tmj
 tmj
 tmj
@@ -95738,7 +93167,7 @@ wXt
 dUW
 vTl
 uDR
-tfY
+uDR
 tmj
 tmj
 yal
@@ -95752,7 +93181,7 @@ yal
 fyK
 xsd
 djP
-yal
+qTO
 xsd
 suU
 uRk
@@ -95776,11 +93205,11 @@ iQl
 iQl
 dCk
 jey
-fAO
+cmf
 dCk
 sgI
 dCk
-ePz
+qav
 jey
 dCk
 iQl
@@ -95995,7 +93424,7 @@ nlX
 nlX
 nlX
 nlX
-wPG
+nlX
 tmj
 apm
 yal
@@ -96008,8 +93437,8 @@ xsd
 xsd
 xsd
 xsd
-yal
-yal
+gMI
+qTO
 xsd
 mli
 ahf
@@ -96230,8 +93659,8 @@ qmp
 kGJ
 smt
 tBm
-uBj
-vyp
+pyP
+gVY
 wBI
 vyp
 cgN
@@ -96266,7 +93695,7 @@ ixo
 xWy
 xsd
 apm
-thC
+oxx
 xsd
 izW
 wCa
@@ -96439,20 +93868,20 @@ fsz
 fsz
 fsz
 fsz
+hZo
+fsz
+fsz
+fsz
+fsz
+fsz
+hZo
 fsz
 fsz
 fsz
 fsz
 fsz
 fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
+hZo
 fsz
 fsz
 fsz
@@ -96487,14 +93916,14 @@ qoc
 kGJ
 snf
 tCT
-uBj
+pyP
 vzP
 wDq
 xDY
 cgN
 lUg
 rZW
-khe
+reW
 fKe
 rZW
 doi
@@ -96523,7 +93952,7 @@ kbB
 eoe
 xsd
 yal
-yal
+qTO
 xsd
 xsd
 xsd
@@ -96730,7 +94159,7 @@ gfQ
 xxF
 eeZ
 uyr
-uyr
+mqL
 gxg
 xxF
 xxF
@@ -96743,13 +94172,13 @@ pud
 pud
 kGJ
 soC
-tEa
+whJ
 uFa
-vzY
-vzY
-vzY
-daf
-vzY
+whJ
+whJ
+whJ
+whJ
+whJ
 whJ
 sVl
 gdX
@@ -96777,9 +94206,9 @@ eNi
 xsd
 tLM
 pZQ
-kbB
+cwY
 rVk
-yal
+qTO
 fzu
 yal
 yal
@@ -96953,20 +94382,20 @@ fsz
 fsz
 fsz
 fsz
+hZo
+fsz
+fsz
+fsz
+fsz
+fsz
+hZo
 fsz
 fsz
 fsz
 fsz
 fsz
 fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
+hZo
 fsz
 fsz
 fsz
@@ -96987,7 +94416,7 @@ gfQ
 xxF
 eha
 xII
-uyr
+sYo
 aWU
 xxF
 iDW
@@ -97007,7 +94436,7 @@ wDB
 wDB
 eAy
 ucg
-sES
+wNw
 eZf
 sES
 iys
@@ -97244,8 +94673,8 @@ gfQ
 xxF
 eif
 aZu
-nFy
-uyr
+qzZ
+sYo
 xxF
 xxF
 xxF
@@ -97528,7 +94957,7 @@ tGN
 nWX
 pyP
 vXD
-vnF
+ieR
 qtO
 sUF
 xGm
@@ -97766,7 +95195,7 @@ gfQ
 gfQ
 gfQ
 mVn
-omh
+pwC
 pwC
 pwC
 reS
@@ -98016,15 +95445,15 @@ mVn
 xxF
 xxF
 xxF
-xII
+xXP
 hCe
 mVn
 gfQ
 gfQ
 gfQ
 mVn
-iEb
-xII
+pwC
+aXr
 xII
 pyP
 stc
@@ -98280,8 +95709,8 @@ gfQ
 gfQ
 gfQ
 mVn
-iEb
-xII
+pwC
+buP
 pyP
 pyP
 svm
@@ -98523,22 +95952,22 @@ xII
 aXp
 xII
 xII
-xII
-xII
+eXn
+oUE
 djA
-fBE
+uTB
 eiw
-xII
-xII
-xII
+oUE
+oUE
+oUE
 hKE
 mVn
 mVn
 mVn
 mVn
 mVn
-iEb
-buP
+pwC
+mrq
 pyP
 rhb
 szX
@@ -98789,14 +96218,14 @@ xxF
 xxF
 xxF
 hLE
-iEb
+pwC
 hKE
-iEb
+pwC
 lWT
 lWT
 omu
 pyP
-pyP
+wHI
 rhh
 sCb
 qqE
@@ -99057,7 +96486,7 @@ qqd
 rjm
 sEr
 qqE
-uJY
+odN
 pyP
 wHd
 vBA
@@ -99311,8 +96740,8 @@ xxF
 omL
 pyP
 qqE
-qqE
-qqE
+lyK
+uAM
 tGN
 uKo
 tGN
@@ -99567,10 +96996,10 @@ mVn
 xxF
 fsz
 fsz
-gfQ
-gfQ
-gfQ
-nfz
+qqE
+qqE
+qqE
+tGN
 gfQ
 nfz
 fsz
@@ -101379,11 +98808,11 @@ gfQ
 gfQ
 gfQ
 gfQ
-aUP
+vmO
 gfQ
 tAr
 gfQ
-aUP
+vmO
 gfQ
 gfQ
 gfQ

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -27,12 +27,6 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"aaj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "aao" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -315,7 +309,7 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "acs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "act" = (
@@ -649,7 +643,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
@@ -3285,6 +3278,7 @@
 /area/commons/dorms)
 "ayE" = (
 /obj/effect/spawner/bundle/moisture_trap,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ayF" = (
@@ -3457,9 +3451,6 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/port/fore)
 "aAc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -3589,7 +3580,6 @@
 /area/commons/dorms)
 "aBp" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aBz" = (
@@ -3638,7 +3628,6 @@
 	req_access_txt = "12"
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aBZ" = (
@@ -3674,7 +3663,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -4891,8 +4879,8 @@
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "aOX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engineering/atmos)
@@ -6130,6 +6118,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aYg" = (
@@ -8872,10 +8861,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/supermatter)
-"bFZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "bGI" = (
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
@@ -9040,6 +9025,13 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"bMt" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/cargo/storage)
 "bMD" = (
 /obj/structure/window{
 	dir = 4
@@ -9393,6 +9385,10 @@
 /obj/item/transfer_valve,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
+"bYE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/turf/closed/wall/r_wall,
+/area/engineering/atmos)
 "bYN" = (
 /turf/closed/wall,
 /area/cargo/warehouse)
@@ -10231,7 +10227,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "czY" = (
@@ -10971,7 +10967,7 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "cZH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "cZR" = (
@@ -11005,7 +11001,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "dax" = (
@@ -11660,7 +11656,9 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "dtK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dtS" = (
@@ -11668,10 +11666,8 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/space/basic,
 /area/space/nearstation)
 "dud" = (
@@ -11699,13 +11695,6 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
-"duk" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Waste to Filter"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "duo" = (
 /obj/machinery/light{
 	dir = 8
@@ -12377,16 +12366,6 @@
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
-"dJc" = (
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Testing Room";
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron/dark,
-/area/engineering/atmos)
 "dJd" = (
 /obj/machinery/light,
 /obj/machinery/firealarm/directional/south,
@@ -12399,6 +12378,9 @@
 /obj/structure/closet/radiation,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/sign/poster/official/build{
+	pixel_y = 32
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
@@ -13643,7 +13625,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "esO" = (
@@ -13797,8 +13779,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "evz" = (
@@ -15298,6 +15280,10 @@
 	id = "Engineering";
 	name = "engineering security door"
 	},
+/obj/machinery/door/poddoor/shutters{
+	id = "TechShutters";
+	name = "tech storage shutters"
+	},
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "fjP" = (
@@ -15487,6 +15473,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
+"foV" = (
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
+	dir = 1;
+	pipe_color = "#00FF00"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fpc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -16015,6 +16008,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"fCA" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Waste Input to Filter"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fCN" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_y = -30
@@ -16739,6 +16739,13 @@
 	pixel_x = 22;
 	pixel_y = -22
 	},
+/obj/machinery/button/door{
+	id = "SMESShutters";
+	name = "SMES Shutters Control";
+	pixel_x = 24;
+	pixel_y = -9;
+	req_access_txt = "11"
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "fZW" = (
@@ -16972,6 +16979,11 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/cargo/qm)
+"ggn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ggF" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17277,6 +17289,11 @@
 /obj/item/paint/anycolor,
 /turf/open/floor/plating,
 /area/security/prison/safe)
+"grq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "grx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/status_display/evac/directional/north,
@@ -18278,8 +18295,8 @@
 	name = "Atmospherics Testing Room";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "gTE" = (
@@ -18447,7 +18464,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "gZh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -18622,14 +18639,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"hdE" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "hdJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -18882,6 +18891,14 @@
 	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
+"hlj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hlk" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/iron/white,
@@ -19039,6 +19056,18 @@
 "hoU" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"hoV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/button/door{
+	id = "TechShutters";
+	name = "Secure Shutters Control";
+	pixel_x = 24;
+	pixel_y = null;
+	req_access_txt = "19;23"
+	},
+/turf/open/floor/iron,
+/area/engineering/storage/tech)
 "hpP" = (
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 8;
@@ -19201,7 +19230,8 @@
 /area/engineering/atmos)
 "hud" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	name = "no2 to mix"
+	name = "no2 to mix";
+	pipe_color = "#FF7B00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -19339,11 +19369,6 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"hyg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "hym" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19665,12 +19690,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"hIz" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "hIB" = (
 /obj/structure/window{
 	dir = 8
@@ -19958,6 +19977,10 @@
 /area/service/lawoffice)
 "hSL" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "SMESShutters";
+	id_tag = null
+	},
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
 "hTo" = (
@@ -20872,7 +20895,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "iuZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ivy" = (
@@ -21461,8 +21484,8 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/aisat/exterior)
 "iQn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "iQM" = (
@@ -21499,9 +21522,9 @@
 /turf/open/floor/wood/large,
 /area/service/library)
 "iRr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "iRR" = (
@@ -21853,6 +21876,11 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
+"iZJ" = (
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "jaa" = (
 /turf/open/floor/carpet/royalblue,
 /area/command/bridge)
@@ -21938,7 +21966,8 @@
 "jcB" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 4;
-	name = "co2 to mix"
+	name = "co2 to mix";
+	pipe_color = "#FF7B00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -22917,6 +22946,9 @@
 	desc = "A plushie depicting a mothperson with a tiny hardhat. Remember: only you can prevent plasma fires.";
 	name = "Safety Moth Plushie"
 	},
+/obj/item/clothing/head/hardhat/orange{
+	pixel_y = 7
+	},
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "jHw" = (
@@ -23560,6 +23592,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"kcx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kcB" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -24745,7 +24784,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kJf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "kJn" = (
@@ -25321,6 +25360,13 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
+"ldm" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "ldr" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -25362,14 +25408,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"lff" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "lfg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25397,7 +25435,8 @@
 "lfS" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 1;
-	name = "n2 to mix"
+	name = "n2 to mix";
+	pipe_color = "#FF7B00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -26061,7 +26100,8 @@
 "lwu" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 4;
-	name = "plasma to mix"
+	name = "plasma to mix";
+	pipe_color = "#FF7B00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -26255,7 +26295,6 @@
 "lEQ" = (
 /obj/machinery/vending/engivend,
 /obj/machinery/light/directional/south,
-/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/engineering/main)
 "lEY" = (
@@ -26608,10 +26647,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "lNY" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lOx" = (
@@ -29168,7 +29207,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/plasteel/twenty,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "nhh" = (
@@ -29268,10 +29307,6 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/cargo/storage)
-"nkh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/maintenance/fore)
 "nkv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -29347,6 +29382,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/command/bridge)
+"noi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "noH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc/auto_name/east,
@@ -29577,11 +29619,11 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "ntV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/structure/rack,
 /obj/item/clothing/shoes/winterboots,
 /obj/item/clothing/suit/hooded/wintercoat,
 /obj/item/wrench,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "nuk" = (
@@ -29714,6 +29756,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"nyS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nyU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
@@ -30393,7 +30439,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "nTh" = (
@@ -31034,6 +31080,7 @@
 "okv" = (
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "okJ" = (
@@ -32259,7 +32306,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "oSV" = (
@@ -32854,7 +32901,6 @@
 	pixel_x = -24;
 	req_access_txt = "11"
 	},
-/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -33266,9 +33312,8 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron,
 /area/maintenance/fore)
 "pxC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -34405,11 +34450,6 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
 /area/engineering/main)
-"qjj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron/dark,
-/area/engineering/atmos)
 "qjs" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow{
@@ -34651,11 +34691,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "qqt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qqC" = (
@@ -34767,9 +34807,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/space)
+/area/cargo/office)
+"qta" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qtc" = (
 /obj/structure/displaycase/captain,
 /obj/effect/turf_decal/stripes/line{
@@ -35690,6 +35733,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/science/server)
 "raE" = (
@@ -35820,7 +35864,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rcM" = (
@@ -35970,11 +36014,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"rhH" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "rhI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -36394,7 +36433,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/computer/atmos_control/toxinsmix{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
@@ -37037,7 +37076,8 @@
 "rSV" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 1;
-	name = "air to mix"
+	name = "air to mix";
+	pipe_color = "#FF7B00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -37144,8 +37184,8 @@
 	name = "Auxiliary Chamber";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "rVk" = (
@@ -37797,7 +37837,7 @@
 "snK" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
-	name = "Waste to Filter"
+	name = "Waste Input"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -37947,13 +37987,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
-"srf" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Process to Waste"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "sri" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -38114,7 +38147,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "swp" = (
@@ -38770,7 +38802,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sNP" = (
@@ -39915,11 +39947,6 @@
 	},
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
-"trn" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/south,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "trx" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -39933,6 +39960,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
 "trF" = (
@@ -40296,7 +40324,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "tAr" = (
@@ -40351,10 +40379,10 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "tBe" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow,
 /obj/machinery/atmospherics/pipe/color_adapter{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tBk" = (
@@ -41011,6 +41039,13 @@
 "tTH" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
+"tTR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tUc" = (
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/iron,
@@ -41099,12 +41134,6 @@
 "tWI" = (
 /turf/closed/wall,
 /area/maintenance/department/electrical)
-"tWP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tXm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
 	dir = 4;
@@ -41499,8 +41528,8 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uiJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "uiK" = (
@@ -42904,13 +42933,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
-"uTh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "uTB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
@@ -44521,12 +44543,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"vHn" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "vHo" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
@@ -45027,6 +45043,10 @@
 /area/security/brig)
 "vVZ" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "SMESShutters";
+	id_tag = null
+	},
 /turf/open/floor/plating,
 /area/engineering/main)
 "vWc" = (
@@ -45509,7 +45529,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "wjQ" = (
@@ -45889,13 +45909,15 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
 /area/engineering/main)
 "wwK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Process to Waste Input"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -46008,10 +46030,10 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/corporate_showroom)
 "wzZ" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wAs" = (
@@ -46229,12 +46251,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"wGL" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "wGX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -47278,12 +47294,6 @@
 	dir = 4
 	},
 /area/commons/dorms)
-"xgn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xgF" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -49246,6 +49256,10 @@
 	dir = 8
 	},
 /area/command/gateway)
+"yeY" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "yeZ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -64612,7 +64626,7 @@ rKZ
 bnA
 oDu
 xzY
-irn
+oVr
 jMy
 prA
 xzY
@@ -64628,8 +64642,8 @@ vCv
 xzY
 xzY
 qmq
-xzY
-vHn
+yeY
+bnA
 bnA
 rKZ
 rKZ
@@ -64869,7 +64883,7 @@ dYm
 vPD
 xzY
 xow
-oVr
+irn
 xzY
 acs
 fuX
@@ -65407,7 +65421,7 @@ fPo
 csg
 bnA
 koB
-cZH
+grq
 bnA
 gfQ
 gfQ
@@ -66936,8 +66950,8 @@ atE
 mWH
 djS
 xzY
-sXJ
-waO
+tTR
+kcx
 wOk
 yfA
 cES
@@ -67446,7 +67460,7 @@ xzY
 nbI
 xzY
 mWH
-mWH
+wDi
 mWH
 xzY
 nbI
@@ -67720,7 +67734,7 @@ vSM
 joR
 bnA
 xsI
-qjj
+cZH
 gIp
 toN
 xzY
@@ -67954,7 +67968,7 @@ mcK
 mJy
 qqC
 oXq
-bFZ
+loD
 cLV
 tHy
 tHy
@@ -67977,7 +67991,7 @@ vSM
 joR
 bnA
 bnA
-dJc
+gTe
 bnA
 nzo
 rKZ
@@ -68211,7 +68225,7 @@ idL
 dtK
 epn
 wwK
-srf
+loD
 elh
 gue
 dGd
@@ -68465,10 +68479,10 @@ mgy
 dTo
 cvX
 snK
-xzY
+fCA
 cTf
-tWP
-xgn
+xzY
+xzY
 elh
 asq
 xXh
@@ -68491,7 +68505,7 @@ lpf
 nsx
 bnA
 kDr
-cZH
+grq
 bnA
 aUP
 fsz
@@ -68722,9 +68736,9 @@ cQT
 xbu
 nGh
 dhI
-xzY
+nyS
 cTf
-duk
+xzY
 xzY
 elh
 uPB
@@ -68972,17 +68986,17 @@ pfr
 wwz
 fjO
 xbv
-oXl
+hoV
 oXl
 wth
 iub
 lHU
 ips
 dax
-loD
+ggn
 oSP
-loD
-hIz
+foV
+riF
 aYx
 riF
 wRu
@@ -69512,7 +69526,7 @@ xzY
 ubG
 jdo
 cuF
-xzY
+qta
 iUA
 bnA
 fsz
@@ -69752,7 +69766,7 @@ uYy
 bnA
 gSq
 vSM
-nTJ
+bYE
 iJd
 sHe
 vSM
@@ -75403,10 +75417,10 @@ tuj
 tuj
 sGc
 xkh
-xkh
-xkh
-xkh
-buH
+bMt
+bMt
+bMt
+noi
 nft
 mhN
 nft
@@ -83816,7 +83830,7 @@ gfQ
 gfQ
 gfQ
 ybK
-hIq
+vhx
 yiQ
 xNm
 bre
@@ -84073,7 +84087,7 @@ gfQ
 gfQ
 gfQ
 ybK
-hyg
+vhx
 yiQ
 xNm
 hzP
@@ -84330,7 +84344,7 @@ gfQ
 gfQ
 gfQ
 ybK
-hyg
+vhx
 bjj
 xNm
 vjO
@@ -84587,7 +84601,7 @@ gfQ
 gfQ
 gfQ
 ybK
-hdE
+vhx
 yiQ
 xNm
 xNm
@@ -85101,7 +85115,7 @@ ybK
 ybK
 ybK
 ybK
-hyg
+vhx
 vhx
 xNm
 kHI
@@ -85358,7 +85372,7 @@ yiQ
 yiQ
 yiQ
 yiQ
-aaj
+yiQ
 vhx
 xNm
 vjO
@@ -85402,7 +85416,7 @@ vXg
 xpx
 ydp
 ygp
-uTh
+wSE
 wSE
 ksj
 mTo
@@ -85616,7 +85630,7 @@ ybK
 ybK
 ybK
 ybK
-trn
+vhx
 xNm
 awD
 xNm
@@ -86388,7 +86402,7 @@ gfQ
 gfQ
 ybK
 auH
-adS
+ldm
 rAk
 xNm
 xNm
@@ -86904,8 +86918,8 @@ ybK
 avb
 ybK
 ybK
-hIq
-kbg
+hlj
+yiQ
 xvq
 xvq
 etj
@@ -88706,7 +88720,7 @@ ybK
 hIq
 cuO
 yiQ
-yiQ
+iZJ
 etj
 xrI
 xrI
@@ -88961,9 +88975,9 @@ bjj
 yiQ
 yiQ
 aLF
-rhH
+wrE
 yiQ
-yiQ
+vhx
 etj
 etj
 etj
@@ -89772,7 +89786,7 @@ ydj
 ydj
 ydj
 ydj
-lff
+pcc
 ydj
 ydj
 lsN
@@ -93084,9 +93098,9 @@ eJV
 aZo
 ksE
 hpS
-nkh
 eJV
-wGL
+eJV
+cuO
 yiQ
 rsd
 dJf
@@ -93341,7 +93355,7 @@ yiQ
 wrE
 yiQ
 yiQ
-yiQ
+biX
 yiQ
 pkV
 yiQ

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -4392,7 +4392,7 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "aJy" = (
 /obj/machinery/shower{
 	dir = 8
@@ -4405,7 +4405,7 @@
 	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "aJG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -4471,7 +4471,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "aKl" = (
 /obj/structure/window,
 /obj/structure/flora/ausbushes/grassybush,
@@ -5690,7 +5690,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/service/hydroponics/garden)
 "aTV" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
@@ -7014,7 +7014,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "bdJ" = (
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -7134,7 +7134,7 @@
 "bet" = (
 /obj/machinery/gibber,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "beu" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -7176,7 +7176,7 @@
 "beG" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "beI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
@@ -7191,7 +7191,7 @@
 	dir = 1
 	},
 /turf/closed/wall,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "beL" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -7245,7 +7245,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "bfe" = (
 /obj/structure/table,
 /obj/machinery/door/window/westright{
@@ -9638,7 +9638,7 @@
 	pixel_y = 25
 	},
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "cbY" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/floor/grass,
@@ -12035,10 +12035,8 @@
 /turf/open/floor/carpet/orange,
 /area/security/detectives_office)
 "dwt" = (
-/obj/structure/fireaxecabinet{
-	pixel_x = -32
-	},
 /obj/machinery/door/firedoor,
+/obj/structure/fireaxecabinet/directional/west,
 /turf/open/floor/iron,
 /area/command/bridge)
 "dwx" = (
@@ -14284,10 +14282,6 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
-"eAI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/explab)
 "eBc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -14869,7 +14863,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "eSv" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
@@ -14944,7 +14938,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/tank_holder/oxygen,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing/chamber)
+/area/science/mixing)
 "eVc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
@@ -15043,6 +15037,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"eYt" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/medical_doctor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "eYx" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -17075,7 +17074,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "fXz" = (
 /obj/structure/grille/broken,
 /obj/structure/closet/crate,
@@ -17100,7 +17099,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "fYm" = (
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
@@ -17146,7 +17145,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "fZM" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -18480,7 +18479,7 @@
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "gLq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -19297,6 +19296,7 @@
 /area/service/lawoffice)
 "hiv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
 "hiA" = (
@@ -19373,6 +19373,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron,
 /area/medical/storage)
 "hkM" = (
@@ -20927,7 +20928,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "ife" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22234,7 +22235,7 @@
 	location = "Kitchen"
 	},
 /turf/open/floor/iron,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "iUe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22247,7 +22248,7 @@
 "iUh" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "iUi" = (
 /obj/machinery/power/solar{
 	id = "starboardsolar";
@@ -23063,6 +23064,7 @@
 /area/hallway/secondary/entry)
 "jtt" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/upper)
 "jtB" = (
@@ -25981,7 +25983,7 @@
 "kXR" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "kYj" = (
 /obj/machinery/light{
 	dir = 4
@@ -26626,10 +26628,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "lqd" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -28847,7 +28845,7 @@
 "mAb" = (
 /obj/machinery/food_cart,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "mAn" = (
 /obj/structure/grille/broken,
 /obj/structure/barricade/wooden,
@@ -29695,6 +29693,14 @@
 	},
 /turf/open/floor/iron,
 /area/command/teleporter)
+"mXC" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "mXI" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron,
@@ -35359,9 +35365,8 @@
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
 "qgc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron{
 	dir = 8
 	},
@@ -37056,6 +37061,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
+"rfK" = (
+/obj/machinery/atmospherics/components/binary/valve/digital,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rfR" = (
 /obj/effect/decal/cleanable/generic,
 /turf/closed/wall,
@@ -37177,9 +37186,6 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "rjq" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
 /obj/structure/table,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Control Room";
@@ -37187,6 +37193,7 @@
 	view_range = 10
 	},
 /obj/item/storage/firstaid/fire,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/upper)
 "rjv" = (
@@ -43164,7 +43171,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "uoM" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom/directional/north{
@@ -44622,10 +44629,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"uZu" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "uZE" = (
 /obj/structure/table,
 /obj/item/aicard,
@@ -45495,6 +45498,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
 "vvH" = (
@@ -46667,6 +46671,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "vYu" = (
@@ -47033,7 +47038,6 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/upper)
 "wjE" = (
@@ -47528,8 +47532,10 @@
 "wyW" = (
 /obj/machinery/icecream_vat,
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "wyY" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -48274,7 +48280,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "wSA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -49063,8 +49069,7 @@
 	},
 /obj/item/stack/sheet/iron/fifty,
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/newscaster/security_unit/directional/south,
-/obj/machinery/newscaster/directional/west,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/upper)
 "xlD" = (
@@ -50694,7 +50699,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/freezer,
-/area/service/kitchen)
+/area/service/kitchen/coldroom)
 "ybV" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
@@ -50910,6 +50915,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"yfA" = (
+/turf/closed/wall,
+/area/service/kitchen/coldroom)
 "yfW" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -66224,7 +66232,7 @@ fIJ
 bFQ
 czP
 vOL
-sbX
+mXC
 wVb
 rKZ
 rKZ
@@ -67780,9 +67788,9 @@ tVv
 weR
 iTj
 eig
-mWH
 wDi
-mWH
+rfK
+wDi
 aVr
 oVW
 unX
@@ -69066,7 +69074,7 @@ xzY
 nbI
 xzY
 mWH
-wDi
+xzY
 mWH
 xzY
 nbI
@@ -69323,8 +69331,8 @@ xzY
 vCv
 xzY
 qgc
-uZu
-mWH
+rfK
+wDi
 mWH
 vCv
 nYX
@@ -69579,7 +69587,7 @@ cLV
 tHy
 tHy
 nJg
-oMm
+mWH
 xzY
 xzY
 kdz
@@ -76222,7 +76230,7 @@ wXl
 wXl
 wXl
 sSZ
-vqo
+ryF
 peX
 vBY
 yiA
@@ -79291,13 +79299,13 @@ xyp
 cdf
 jUZ
 ybn
-xvt
-xvt
-xvt
-xvt
-xvt
+yfA
+yfA
+yfA
+yfA
+yfA
 iUd
-xvt
+yfA
 gQq
 mDX
 ntJ
@@ -79548,14 +79556,14 @@ xyp
 grx
 iwW
 ezL
-xvt
+yfA
 beG
 bet
 beG
 beK
 beZ
-xvt
-xvt
+yfA
+yfA
 awM
 cdD
 bUU
@@ -79805,14 +79813,14 @@ rSo
 oAg
 jUZ
 dTw
-xvt
+yfA
 cbG
 fXy
 aJF
 gLp
 ybR
 wyW
-xvt
+yfA
 ial
 aRD
 tdq
@@ -80062,7 +80070,7 @@ lfu
 ybn
 jUZ
 dbU
-xvt
+yfA
 eSu
 fYi
 wSt
@@ -80319,14 +80327,14 @@ lfu
 ybn
 jUZ
 dUr
-xvt
+yfA
 aJt
 fZq
 kXR
 ifc
 iUh
 mAb
-xvt
+yfA
 sOp
 vyu
 oFv
@@ -80576,7 +80584,7 @@ cMu
 jyG
 jUZ
 jLR
-xvt
+yfA
 xvt
 gas
 xvt
@@ -88559,8 +88567,8 @@ nFu
 rWe
 xiy
 vdD
-vkU
-vkU
+eYt
+eYt
 vkU
 yez
 kYj
@@ -98052,7 +98060,7 @@ gfQ
 gfQ
 mVn
 xII
-eAI
+uyr
 cNO
 cNO
 cNO

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -8208,6 +8208,11 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/service/chapel/main)
+"bnk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/engineering/main)
 "bnq" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engsm";
@@ -10366,6 +10371,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/status_display/evac/directional/north,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "czj" = (
@@ -10659,6 +10665,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/bridge)
+"cKA" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "cKG" = (
 /obj/structure/table,
 /obj/item/storage/box/prisoner{
@@ -20450,6 +20465,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"idR" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/engineering/break_room)
 "idW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -23303,6 +23324,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jND" = (
@@ -24158,6 +24180,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
+"knw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/engineering/main)
 "knB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25256,6 +25283,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "kQT" = (
@@ -27461,6 +27489,7 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/fueltank/large,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mgE" = (
@@ -30473,6 +30502,7 @@
 	},
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark/smooth_corner,
 /area/engineering/main)
 "nOv" = (
@@ -38534,6 +38564,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sAF" = (
@@ -44191,6 +44222,7 @@
 /area/tcommsat/server)
 "vsX" = (
 /obj/machinery/suit_storage_unit/engine,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "vtp" = (
@@ -45308,6 +45340,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/item/kirbyplants/random,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "vUW" = (
@@ -47161,6 +47194,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"wVF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/engine,
+/area/engineering/main)
 "wVI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -47887,6 +47927,7 @@
 /area/ai_monitored/security/armory)
 "xpv" = (
 /obj/structure/closet/radiation,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/engineering/main)
 "xpx" = (
@@ -48037,6 +48078,7 @@
 /obj/structure/cable,
 /obj/structure/filingcabinet/medical,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "xst" = (
@@ -48636,6 +48678,10 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"xFp" = (
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "xFq" = (
 /obj/machinery/light{
 	dir = 4
@@ -64100,13 +64146,13 @@ czP
 ezE
 sIj
 aUj
-aUj
+knw
 aWw
 rmU
 aUr
 rmU
 aWw
-aUI
+bnk
 aUI
 czP
 aXk
@@ -64867,7 +64913,7 @@ gfQ
 wVb
 wVb
 wVb
-czP
+wVF
 xEh
 sIj
 bFQ
@@ -68213,7 +68259,7 @@ jky
 uOp
 xWP
 uXv
-fkV
+xFp
 fkV
 plT
 ydM
@@ -71013,7 +71059,7 @@ eoI
 vJh
 fSK
 gDZ
-fve
+cKA
 xun
 jIE
 kQw
@@ -72325,7 +72371,7 @@ rqv
 aGg
 cwr
 nhw
-nZJ
+idR
 nZJ
 uOm
 wGg

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -137,7 +137,7 @@
 "aba" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/solars/port/fore)
 "abb" = (
 /turf/open/floor/plating,
@@ -196,6 +196,7 @@
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "abK" = (
+/obj/structure/chair,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "abL" = (
@@ -508,14 +509,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
-"adz" = (
-/obj/structure/window/plasma/reinforced,
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/engineering/atmos)
 "adA" = (
 /obj/structure/cable,
 /obj/machinery/light_switch{
@@ -527,6 +520,10 @@
 /obj/machinery/computer/cargo/request{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "adD" = (
@@ -686,8 +683,8 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "aey" = (
@@ -843,8 +840,10 @@
 "afo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "N2O to Pure"
+	name = "N2O to Pure";
+	pipe_color = "#FFFF00"
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "afp" = (
@@ -1286,6 +1285,7 @@
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "aju" = (
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron/white/side{
 	dir = 5
 	},
@@ -1311,9 +1311,6 @@
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
-	},
-/obj/item/radio/intercom{
-	pixel_x = -29
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -1873,11 +1870,11 @@
 	initial_gas_mix = "n2=100;TEMP=80"
 	},
 /area/science/server)
+"amY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "amZ" = (
-/obj/machinery/camera{
-	c_tag = "Arrivals Hallway - Sec Checkpoint";
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -2192,12 +2189,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
-"apq" = (
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
-/turf/open/floor/carpet/black,
-/area/security/prison)
 "apx" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -2460,12 +2451,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
-"asf" = (
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "asg" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -2941,6 +2926,14 @@
 	},
 /turf/open/floor/iron,
 /area/security/prison)
+"avK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "N2O to Mix"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "avN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3191,6 +3184,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "axC" = (
@@ -3990,6 +3984,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"aGq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "aGu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4433,6 +4431,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "aKw" = (
@@ -4453,7 +4452,7 @@
 /turf/open/space/basic,
 /area/medical/virology)
 "aKO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "aKP" = (
@@ -5635,9 +5634,7 @@
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "aUj" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/main)
 "aUr" = (
@@ -5714,7 +5711,7 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "aUI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/main)
 "aUK" = (
@@ -5913,7 +5910,7 @@
 	dir = 1;
 	network = list("ss13","engine")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aWg" = (
@@ -5987,8 +5984,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -6166,7 +6163,8 @@
 "aYp" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 1;
-	name = "air to pure"
+	name = "air to pure";
+	pipe_color = "#FFFF00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -6657,6 +6655,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot/right,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bbw" = (
@@ -6925,6 +6929,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"bdM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "bdO" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -7030,6 +7038,10 @@
 /obj/machinery/modular_computer/console/preset/cargochat/medical{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bex" = (
@@ -7401,10 +7413,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"bhs" = (
-/obj/structure/sign/warning/enginesafety,
-/turf/closed/wall/r_wall,
-/area/engineering/storage/tech)
 "bht" = (
 /obj/machinery/modular_computer/console/preset/id,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -7578,6 +7586,9 @@
 /area/hallway/primary/port)
 "biD" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
+/obj/structure/sign/warning/enginesafety{
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "biF" = (
@@ -7622,13 +7633,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library)
-"biV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
 "biW" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/iron,
@@ -7971,6 +7975,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot/right,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bkU" = (
@@ -8110,6 +8120,14 @@
 /obj/item/fuel_pellet,
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
+"bmL" = (
+/obj/structure/showcase/cyborg/old{
+	dir = 8;
+	pixel_x = 9;
+	pixel_y = 2
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "bmR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8351,7 +8369,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/airless,
 /area/medical/virology)
 "brX" = (
@@ -8434,7 +8451,9 @@
 /area/maintenance/fore)
 "bto" = (
 /obj/structure/chair/stool,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/maintenance/disposal)
 "btp" = (
 /turf/open/space/basic,
@@ -8729,6 +8748,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
+"bzL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "bAf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -8882,6 +8907,9 @@
 "bGI" = (
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"bHB" = (
+/turf/closed/wall/r_wall,
+/area/engineering/transit_tube)
 "bHK" = (
 /obj/machinery/camera{
 	c_tag = "Escape North";
@@ -9967,12 +9995,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"coG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "cpP" = (
 /turf/closed/wall,
 /area/engineering/main)
@@ -9996,6 +10018,14 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard)
+"csg" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/space/basic,
+/area/space/nearstation)
 "csh" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -10021,16 +10051,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
-"cti" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/engineering/atmos)
 "ctz" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig Control";
@@ -10110,7 +10133,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
-	name = "Air to External Ports"
+	name = "Air Supply to External Ports"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -10160,12 +10183,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"cwX" = (
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
-/turf/open/floor/iron,
-/area/security/execution/transfer)
 "cwY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet/black,
@@ -10396,6 +10413,22 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"cGZ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/engineering/main)
 "cHo" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -10437,6 +10470,14 @@
 	name = "black plastitanium floor"
 	},
 /area/service/bar)
+"cJB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "cJC" = (
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
@@ -10516,9 +10557,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "cOf" = (
@@ -10912,6 +10952,10 @@
 /obj/item/phone,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"cZH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "cZR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -10943,7 +10987,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "dax" = (
@@ -11087,9 +11131,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ddA" = (
 /obj/machinery/light{
@@ -11605,6 +11647,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dtS" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dud" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
@@ -11693,7 +11746,10 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "dvV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -12309,8 +12365,8 @@
 	name = "Atmospherics Testing Room";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "dJf" = (
@@ -12414,7 +12470,7 @@
 /area/hallway/primary/central)
 "dLn" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -12519,17 +12575,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
-"dML" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "dMY" = (
 /obj/structure/rack,
 /obj/item/storage/box/flashbangs{
@@ -12569,6 +12614,7 @@
 /obj/structure/rack,
 /obj/item/book/manual/wiki/tcomms,
 /obj/item/radio/off,
+/obj/item/multitool,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "dNn" = (
@@ -12753,7 +12799,8 @@
 /area/engineering/storage/tech)
 "dRO" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma{
-	dir = 4
+	dir = 4;
+	pipe_color = "#00FF00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -12800,7 +12847,7 @@
 "dTo" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
-	name = "Air to Distro"
+	name = "Air Supply to Distro"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -13168,6 +13215,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eeo" = (
@@ -13313,6 +13361,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"eju" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	color = "#0000FF";
+	pipe_color = "#0000FF"
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "ejv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13445,13 +13500,13 @@
 /obj/machinery/computer/cargo{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "epn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Air Output to Air Supply"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -13539,7 +13594,6 @@
 /area/security/courtroom)
 "esA" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "esC" = (
@@ -13707,7 +13761,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "evz" = (
@@ -13742,7 +13796,8 @@
 	name = "Atmospherics Maintenance";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "ewP" = (
@@ -13996,6 +14051,7 @@
 "eCZ" = (
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "eDb" = (
@@ -14438,7 +14494,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/command)
+/area/engineering/transit_tube)
 "eSn" = (
 /obj/effect/spawner/bundle/hobo_squat,
 /turf/open/floor/plating,
@@ -14495,7 +14551,7 @@
 	id = "foreportsolar";
 	name = "Fore/Port Solar Array"
 	},
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/solars/port/fore)
 "eUg" = (
 /obj/item/book/random,
@@ -14516,7 +14572,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/violet,
+/obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eUz" = (
@@ -14593,7 +14649,7 @@
 /turf/open/floor/iron,
 /area/command/bridge)
 "eWx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "eXn" = (
@@ -14680,7 +14736,8 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "eZw" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan{
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -14948,9 +15005,7 @@
 /area/commons/vacant_room/office)
 "ffT" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/pipe/smart/simple/violet{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ffW" = (
@@ -15168,10 +15223,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/brown,
 /turf/open/space/basic,
 /area/space/nearstation)
 "fjF" = (
@@ -15432,7 +15487,7 @@
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "fqT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
@@ -15607,6 +15662,10 @@
 "fvA" = (
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
+"fwg" = (
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/tcommsat/computer)
 "fwj" = (
 /obj/machinery/camera{
 	c_tag = "Experimentor Lab";
@@ -15743,6 +15802,10 @@
 	dir = 1
 	},
 /obj/machinery/modular_computer/console/preset/cargochat/cargo,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "fye" = (
@@ -15822,20 +15885,9 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"fAP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "fBg" = (
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
-"fBo" = (
-/obj/structure/table,
-/obj/item/multitool,
-/turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
 "fBp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -15925,19 +15977,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"fDD" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "fEc" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -16306,14 +16345,6 @@
 /obj/machinery/restaurant_portal/restaurant,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"fSo" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/port/aft)
 "fSK" = (
 /obj/structure/chair,
 /obj/machinery/light{
@@ -16580,6 +16611,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
+"fYm" = (
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "fYt" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -16949,15 +16983,6 @@
 /obj/machinery/air_sensor/atmos/toxin_tank,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
-"gjB" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
-/turf/open/floor/iron,
-/area/security/prison)
 "gjF" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -16989,20 +17014,9 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "gkd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/violet,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
-"gkm" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/iron,
-/area/ai_monitored/command/storage/eva)
 "gks" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17028,6 +17042,12 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"gmx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/aft)
 "gmz" = (
 /obj/structure/chair{
 	dir = 8
@@ -17131,6 +17151,12 @@
 /obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"gph" = (
+/obj/machinery/vending/cola/sodie,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "gpl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -17497,9 +17523,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gyC" = (
@@ -17604,8 +17630,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/violet,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "gBo" = (
@@ -17795,6 +17822,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/light,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/command/bridge)
 "gHt" = (
@@ -17923,6 +17951,7 @@
 	pixel_y = 11
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "gNn" = (
@@ -18065,6 +18094,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "gRN" = (
@@ -18164,7 +18194,7 @@
 	name = "Atmospherics Testing Room";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "gTE" = (
@@ -18259,11 +18289,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "gVE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
@@ -18337,9 +18363,7 @@
 /area/tcommsat/computer)
 "gZh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/violet{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gZk" = (
@@ -19078,15 +19102,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"huI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/violet{
-	dir = 10
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port/aft)
 "huR" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
@@ -19097,10 +19112,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/brig)
-"hvm" = (
-/obj/structure/sign/warning/enginesafety,
-/turf/closed/wall/r_wall,
-/area/engineering/main)
 "hvp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -19111,6 +19122,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hvG" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hvT" = (
 /obj/machinery/camera{
 	c_tag = "East Hallway - Engineering";
@@ -19138,6 +19163,7 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "hwA" = (
@@ -19215,10 +19241,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"hyo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "hzP" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
@@ -19512,14 +19534,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
-"hHX" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Pure to Pure"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "hIq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19549,6 +19563,16 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"hJO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/firecloset{
+	anchored = 1
+	},
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "hJP" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -19562,6 +19586,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"hKh" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Mix"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hKj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -19619,7 +19653,7 @@
 	},
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "hLt" = (
@@ -19772,10 +19806,10 @@
 /turf/open/floor/plating,
 /area/engineering/engine_smes)
 "hTo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	name = "no2 to pure";
+	pipe_color = "#FFFF00"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hTx" = (
@@ -20109,6 +20143,7 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/command/bridge)
 "ieH" = (
@@ -20191,10 +20226,7 @@
 /obj/structure/sign/warning/fire{
 	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "igj" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -20227,15 +20259,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
-"ihj" = (
-/obj/item/radio/intercom{
-	pixel_x = -29
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "ihq" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -20680,7 +20703,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "iuZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ivy" = (
@@ -20985,7 +21008,7 @@
 "iHs" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
-/area/command)
+/area/engineering/transit_tube)
 "iId" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -21155,14 +21178,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/security/brig)
-"iMJ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Air to Pure"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "iMP" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
@@ -21286,10 +21301,8 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/aisat/exterior)
 "iQn" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "iQM" = (
@@ -21326,7 +21339,8 @@
 /turf/open/floor/wood/large,
 /area/service/library)
 "iRr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "iRR" = (
@@ -21426,6 +21440,14 @@
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
+"iUi" = (
+/obj/machinery/power/solar{
+	id = "starboardsolar";
+	name = "Starboard Solar Array"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel/airless,
+/area/solars/starboard/aft)
 "iUq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -22111,16 +22133,10 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -22130,6 +22146,10 @@
 	},
 /obj/machinery/modular_computer/console/preset/cargochat/science{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
@@ -22264,6 +22284,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
+"juh" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Biohazard";
+	name = "biohazard containment door"
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/science/research)
 "jur" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -22594,7 +22625,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -22877,6 +22908,11 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/solars/starboard/aft)
+"jMO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "jMR" = (
 /obj/structure/closet/crate,
 /obj/item/stack/license_plates/empty/fifty,
@@ -22954,6 +22990,12 @@
 /obj/structure/falsewall,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"jPf" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "jQi" = (
 /obj/structure/table,
 /obj/item/storage/bag/tray{
@@ -23029,6 +23071,14 @@
 	},
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
+"jSH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table/wood,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "jTb" = (
 /obj/structure/window{
 	dir = 1
@@ -23083,7 +23133,7 @@
 /area/medical/medbay/lobby)
 "jTX" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "jUf" = (
@@ -23260,9 +23310,6 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "jYK" = (
-/obj/item/radio/intercom{
-	pixel_y = -30
-	},
 /obj/structure/table,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
@@ -23319,6 +23366,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/fore)
+"kby" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/tcommsat/server)
 "kbB" = (
 /turf/open/floor/carpet/black,
 /area/maintenance/starboard/aft)
@@ -23580,6 +23633,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "kjt" = (
@@ -23628,7 +23682,7 @@
 /area/medical/medbay/central)
 "kkt" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -23783,7 +23837,9 @@
 /turf/open/floor/plating/airless,
 /area/medical/virology)
 "koB" = (
-/obj/structure/tank_holder/extinguisher/advanced,
+/obj/structure/tank_holder/extinguisher/advanced{
+	anchored = 1
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "koC" = (
@@ -23911,17 +23967,15 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
 /obj/machinery/computer/cargo/request{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
@@ -24076,14 +24130,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
-"kwD" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/science/lab)
 "kwF" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
@@ -24286,13 +24332,6 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
-"kDK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kDO" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -24378,7 +24417,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/engineering/main)
 "kFX" = (
@@ -24753,6 +24791,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/command/bridge)
 "kNA" = (
@@ -24870,11 +24909,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"kSV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
 "kTf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/flasher{
@@ -25001,8 +25035,16 @@
 "kYD" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/solars/starboard/aft)
+"kZr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "laE" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -25131,7 +25173,8 @@
 /area/service/library)
 "leT" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/co2{
-	dir = 4
+	dir = 4;
+	pipe_color = "#00FF00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -25250,13 +25293,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"lhX" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "lib" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -25417,6 +25453,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/science/research)
 "llp" = (
@@ -25638,6 +25675,14 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
+"lrA" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Pure to Pure"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lrE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -25978,7 +26023,6 @@
 "lDO" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "lDV" = (
@@ -26047,6 +26091,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
+"lFI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/closet/emcloset,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "lFN" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -26168,16 +26220,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"lKx" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 1
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/engineering/atmos)
 "lKL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26350,10 +26392,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "lNY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lOx" = (
@@ -26637,6 +26679,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "lWC" = (
@@ -26683,7 +26726,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
-/area/command)
+/area/engineering/transit_tube)
 "lYe" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -26781,7 +26824,6 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "mbT" = (
-/obj/machinery/duct,
 /obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -27518,7 +27560,7 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "muR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/engineering/main)
 "muZ" = (
@@ -27577,10 +27619,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"mwm" = (
-/obj/structure/table,
-/turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
 "mwn" = (
 /obj/machinery/door/window/southleft{
 	dir = 4;
@@ -27731,6 +27769,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
 "mAP" = (
@@ -28108,7 +28147,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/command)
+/area/engineering/transit_tube)
 "mML" = (
 /turf/open/floor/engine/air,
 /area/engineering/atmos)
@@ -28189,6 +28228,10 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/shower{
+	pixel_y = 15
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "mPM" = (
@@ -28449,7 +28492,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "mVX" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -28465,6 +28507,9 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/item/radio/intercom{
+	pixel_y = -30
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "mWA" = (
@@ -28820,8 +28865,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/command)
+/area/engineering/transit_tube)
 "ngr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -28977,13 +29023,21 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "nky" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
 "nkD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
+"nlE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/vending/clothing,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "nlX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29392,7 +29446,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "nyO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
@@ -29566,6 +29620,15 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"nCY" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Air to Pure";
+	pipe_color = "#FFFF00"
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nDv" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -29599,11 +29662,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nDV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/violet,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "nEn" = (
@@ -29714,6 +29776,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/science/research)
 "nHg" = (
@@ -29748,7 +29811,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/command)
+/area/engineering/transit_tube)
 "nIB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29876,6 +29939,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "nOq" = (
@@ -29920,7 +29984,6 @@
 /area/construction/mining/aux_base)
 "nOA" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/machinery/duct,
 /obj/structure/girder,
 /obj/machinery/duct,
 /turf/open/floor/plating,
@@ -30036,7 +30099,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "nTh" = (
@@ -30305,12 +30368,12 @@
 "nYX" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 4;
-	name = "plasma to pure"
+	name = "plasma to pure";
+	pipe_color = "#FFFF00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "nZh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -30668,6 +30731,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "olc" = (
@@ -30817,7 +30881,6 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Turbine Inlet Pump"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "onb" = (
@@ -30854,8 +30917,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/showroomfloor,
-/area/command)
+/area/engineering/transit_tube)
 "ooZ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -30904,9 +30968,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "oqT" = (
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -31142,7 +31203,7 @@
 	},
 /obj/effect/turf_decal/caution/white,
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -31318,7 +31379,8 @@
 "oCI" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 1;
-	name = "n2 to pure"
+	name = "n2 to pure";
+	pipe_color = "#FFFF00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -31342,7 +31404,9 @@
 /area/engineering/atmos)
 "oDA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/tank_holder/oxygen,
+/obj/structure/tank_holder/oxygen{
+	anchored = 1
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "oDB" = (
@@ -31444,8 +31508,9 @@
 /area/security/execution/education)
 "oFA" = (
 /obj/structure/transit_tube/horizontal,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/command)
+/area/engineering/transit_tube)
 "oGk" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8;
@@ -31698,13 +31763,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"oML" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oNa" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -31793,7 +31851,7 @@
 /area/cargo/office)
 "oQL" = (
 /obj/structure/reagent_dispensers/plumbed{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -31938,7 +31996,7 @@
 	piping_layer = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/command)
+/area/engineering/transit_tube)
 "oVi" = (
 /obj/structure/sign/poster/ripped,
 /turf/closed/wall,
@@ -31992,9 +32050,7 @@
 /area/engineering/atmos)
 "oWd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/violet{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -32035,7 +32091,7 @@
 "oXq" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
-	name = "Process to Distro"
+	name = "Process to Air Supply"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -32254,6 +32310,12 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"pfh" = (
+/obj/machinery/vending/snack/green,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "pfj" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -32390,6 +32452,15 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/command/nuke_storage)
+"pjB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/science/research)
 "pjD" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -32420,6 +32491,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "pjZ" = (
@@ -32471,7 +32543,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "pmn" = (
@@ -32758,6 +32830,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "puG" = (
@@ -32776,7 +32849,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/maintenance/disposal)
 "puT" = (
 /turf/closed/wall/r_wall,
@@ -32859,9 +32932,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pwV" = (
 /obj/structure/table/reinforced,
@@ -32948,7 +33019,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/maintenance/disposal)
 "pyP" = (
 /turf/closed/wall/r_wall,
@@ -32980,6 +33053,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "pAx" = (
@@ -33104,7 +33178,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/maintenance/disposal)
 "pFR" = (
 /obj/structure/table,
@@ -33146,7 +33220,7 @@
 /area/maintenance/fore)
 "pHi" = (
 /turf/open/floor/iron/showroomfloor,
-/area/command)
+/area/engineering/transit_tube)
 "pHj" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet,
@@ -33210,6 +33284,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"pJx" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "pJH" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
@@ -33456,6 +33535,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/nanite)
+"pRH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "pRI" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -34021,8 +34105,8 @@
 /turf/closed/wall/r_wall,
 /area/engineering/main)
 "qjj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "qjs" = (
@@ -34037,7 +34121,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -34126,7 +34210,7 @@
 	name = "Starboard Solar Array"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars/starboard/aft)
 "qnh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34232,7 +34316,12 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Freezers";
+	dir = 4;
+	network = list("ss13","engine")
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "qqd" = (
@@ -34670,6 +34759,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "qEP" = (
@@ -34785,6 +34875,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
+"qID" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "qIL" = (
 /obj/structure/window{
 	dir = 8
@@ -35035,8 +35129,8 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "qRv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/engineering/main)
 "qRG" = (
@@ -35107,6 +35201,10 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"qUZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/maintenance/disposal/incinerator)
 "qVf" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35220,7 +35318,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/biohazard,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/medical/virology)
 "qZr" = (
@@ -35232,7 +35329,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/command)
+/area/engineering/transit_tube)
 "qZG" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -35273,13 +35370,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
-"ral" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix to Mix"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "rau" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -35444,7 +35534,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
-/area/command)
+/area/engineering/transit_tube)
 "rek" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/vault,
@@ -36077,6 +36167,7 @@
 /mob/living/simple_animal/pet/dog/corgi/ian,
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/command/corporate_showroom)
 "rxU" = (
@@ -36119,7 +36210,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/command)
+/area/engineering/transit_tube)
 "rza" = (
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable,
@@ -36247,6 +36338,10 @@
 /obj/machinery/modular_computer/console/preset/cargochat/service{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "rEx" = (
@@ -36446,7 +36541,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/command)
+/area/engineering/transit_tube)
 "rKn" = (
 /obj/structure/window{
 	dir = 4
@@ -36773,7 +36868,7 @@
 	name = "Auxiliary Chamber";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "rVk" = (
@@ -36816,7 +36911,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "rWW" = (
@@ -36887,10 +36982,10 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "rYi" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/violet,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rYp" = (
@@ -36935,7 +37030,7 @@
 /area/security/office)
 "rZd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/violet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "rZu" = (
@@ -37044,9 +37139,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"scP" = (
-/turf/open/space/basic,
-/area/engineering/atmos)
 "sdf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -37264,11 +37356,6 @@
 	dir = 1
 	},
 /area/engineering/break_room)
-"sjm" = (
-/obj/structure/window/plasma/reinforced,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "sjO" = (
 /obj/machinery/light/built,
 /turf/open/floor/wood,
@@ -37463,7 +37550,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/violet,
+/obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "soK" = (
@@ -37531,7 +37618,9 @@
 "spB" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/maintenance/disposal)
 "sqy" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
@@ -37764,7 +37853,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -38114,7 +38203,7 @@
 /area/cargo/office)
 "sIj" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "sIv" = (
@@ -38675,7 +38764,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "sVz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "sVB" = (
@@ -38723,6 +38812,7 @@
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "sWt" = (
+/obj/structure/closet/firecloset,
 /turf/open/floor/iron/white/side{
 	dir = 9
 	},
@@ -38953,9 +39043,7 @@
 /area/maintenance/central)
 "tdK" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "tdN" = (
 /obj/structure/window{
@@ -39490,6 +39578,7 @@
 	pixel_y = -30
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "trH" = (
@@ -39830,7 +39919,7 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "tAr" = (
@@ -39884,6 +39973,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/engineering/main)
+"tBe" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow,
+/obj/machinery/atmospherics/pipe/color_adapter{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tBk" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/gloves,
@@ -40254,6 +40350,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"tNf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tNg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40439,22 +40542,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"tRP" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "tRS" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -40502,7 +40589,7 @@
 /area/maintenance/central)
 "tSI" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -40644,6 +40731,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"tYR" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/command/bridge)
 "tYV" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -40686,7 +40777,7 @@
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
-/area/command)
+/area/engineering/transit_tube)
 "tZT" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/donkpockets,
@@ -40738,9 +40829,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
 "ubG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ubH" = (
@@ -41266,7 +41355,8 @@
 "unX" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 4;
-	name = "co2 to pure"
+	name = "co2 to pure";
+	pipe_color = "#FFFF00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -41606,7 +41696,8 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "N2 to Pure"
+	name = "N2 to Pure";
+	pipe_color = "#FFFF00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -41726,6 +41817,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "uBy" = (
@@ -41762,11 +41854,6 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "uCf" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Freezers";
-	dir = 4;
-	network = list("ss13","engine")
-	},
 /obj/structure/table,
 /obj/item/stack/cable_coil{
 	amount = 5
@@ -41871,9 +41958,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "uDR" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -42201,6 +42286,10 @@
 /obj/structure/sign/departments/science,
 /turf/closed/wall,
 /area/science/robotics/lab)
+"uNX" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "uNZ" = (
 /turf/closed/indestructible{
 	desc = "A wall impregnated with Fixium, able to withstand massive explosions with ease";
@@ -42282,9 +42371,7 @@
 	name = "Atmospherics Maintenance";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "uPm" = (
@@ -42447,7 +42534,7 @@
 	dir = 8
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -42644,9 +42731,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uYE" = (
@@ -42777,11 +42864,8 @@
 	},
 /area/hallway/secondary/entry)
 "vcX" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/structure/closet/crate/trashcart/filled,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vdm" = (
@@ -43130,10 +43214,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
 /turf/open/floor/iron/cafeteria,
 /area/engineering/atmos)
 "voM" = (
@@ -43157,6 +43240,7 @@
 	pixel_y = 24;
 	req_access_txt = "39"
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "voR" = (
@@ -43286,7 +43370,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/command)
+/area/engineering/transit_tube)
 "vsh" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -43472,7 +43556,9 @@
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/maintenance/disposal)
 "vvx" = (
 /obj/machinery/light{
@@ -43667,10 +43753,6 @@
 /obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"vzz" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/engineering/atmos)
 "vzM" = (
 /obj/machinery/light{
 	dir = 4
@@ -43950,6 +44032,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "vGN" = (
@@ -43990,7 +44073,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/turf/open/floor/iron,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "vHo" = (
 /obj/machinery/power/apc/auto_name/west,
@@ -44106,9 +44189,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vJJ" = (
@@ -44254,7 +44337,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "vOL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -44265,6 +44348,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"vPe" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/power/apc{
+	areastring = /area/command/corporate_showroom;
+	dir = 4;
+	name = "Ian's Room APC";
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "vPD" = (
 /obj/machinery/light,
 /obj/machinery/portable_atmospherics/canister,
@@ -44298,11 +44391,10 @@
 /turf/open/floor/iron,
 /area/security/courtroom)
 "vPR" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "N2 to Airmix"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/atmospherics/pipe/color_adapter{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vPT" = (
@@ -44326,6 +44418,16 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vQF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "vQI" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -44461,7 +44563,7 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "vVk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "vVw" = (
@@ -44684,7 +44786,6 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "wbb" = (
-/obj/machinery/meter,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -44757,7 +44858,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "wdH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "wec" = (
@@ -44946,13 +45047,16 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/warning/enginesafety{
+	pixel_x = -32
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "wjM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "wjQ" = (
@@ -45008,7 +45112,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "wmb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "wmq" = (
@@ -45019,7 +45123,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/brown,
+/obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
 "wmr" = (
@@ -45112,14 +45216,6 @@
 "wpw" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
-"wpL" = (
-/obj/structure/cable/layer1,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
 "wpS" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -45196,7 +45292,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
 "wrw" = (
@@ -45304,6 +45400,12 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wuD" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "wvq" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
@@ -45443,6 +45545,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
+"wzZ" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wAs" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/line{
@@ -46083,7 +46192,8 @@
 /area/engineering/main)
 "wRu" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
-	dir = 1
+	dir = 1;
+	pipe_color = "#00FF00"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -46258,7 +46368,7 @@
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
 "wVB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "wVI" = (
@@ -47055,7 +47165,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "xrE" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2o{
+	pipe_color = "#00FF00"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xrI" = (
@@ -47074,7 +47186,6 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "xsd" = (
@@ -47167,13 +47278,6 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"xtg" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2O to Mix"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xtn" = (
 /obj/machinery/light_switch{
 	pixel_x = -20;
@@ -47457,12 +47561,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"xyN" = (
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	name = "no2 to pure"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "xyS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -47573,7 +47671,7 @@
 /obj/machinery/computer/atmos_control/incinerator{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "xCW" = (
@@ -47827,6 +47925,9 @@
 "xJL" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
+/obj/structure/sign/warning/enginesafety{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "xKa" = (
@@ -48108,6 +48209,10 @@
 /obj/machinery/computer/cargo/request{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xUl" = (
@@ -48297,7 +48402,7 @@
 	name = "Fore/Port Solar Array"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/solarpanel,
+/turf/open/floor/iron/solarpanel/airless,
 /area/solars/port/fore)
 "xZz" = (
 /obj/structure/cable,
@@ -48805,6 +48910,12 @@
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"ykd" = (
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "ykm" = (
 /mob/living/simple_animal/pet/cat/runtime,
 /obj/effect/turf_decal/tile/blue{
@@ -60772,7 +60883,7 @@ ajv
 akP
 osZ
 pua
-ihj
+osZ
 amy
 osZ
 dbl
@@ -60875,11 +60986,11 @@ xlO
 xlO
 xlO
 xlO
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
+rpu
+rpu
+rpu
+rpu
 gfQ
 gfQ
 gfQ
@@ -61136,7 +61247,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -61392,12 +61503,12 @@ xlO
 xlO
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+xlO
+xlO
+xlO
+fsz
+xlO
+xlO
 gfQ
 gfQ
 gfQ
@@ -61614,7 +61725,7 @@ gfQ
 xGp
 xGp
 xGp
-xGp
+wVb
 xGp
 xGp
 xGp
@@ -61650,11 +61761,11 @@ gfQ
 gfQ
 gfQ
 gfQ
+fsz
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -61796,7 +61907,7 @@ aga
 nKc
 ahs
 kMo
-apq
+qzX
 ygB
 tll
 tll
@@ -61911,7 +62022,7 @@ bnA
 bnA
 bnA
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -62168,7 +62279,7 @@ jUQ
 jUQ
 bnA
 gfQ
-gfQ
+fFC
 gfQ
 gfQ
 gfQ
@@ -62418,14 +62529,14 @@ bnA
 bnA
 gfQ
 gfQ
-fsz
+joR
 bnA
 nXD
 jUQ
 wiH
 bnA
-fsz
-gfQ
+cES
+xlO
 gfQ
 gfQ
 gfQ
@@ -62592,7 +62703,7 @@ sdf
 bQE
 jes
 dEF
-cwX
+opY
 xCg
 ihX
 lEY
@@ -62675,14 +62786,14 @@ jHh
 clp
 gfQ
 gfQ
-fsz
+joR
 bnA
 aOX
 jUQ
 reV
 bnA
-fsz
-gfQ
+cES
+xlO
 gfQ
 gfQ
 gfQ
@@ -62895,7 +63006,7 @@ xGp
 spm
 xEh
 aVe
-aWN
+oCG
 aWN
 oCG
 aZb
@@ -62932,13 +63043,13 @@ bnA
 bnA
 gfQ
 gfQ
-fsz
+joR
 bnA
 odS
 eMT
 wcp
 bnA
-fsz
+cES
 gfQ
 gfQ
 gfQ
@@ -63189,14 +63300,14 @@ xzY
 bnA
 fsz
 gfQ
-sjm
+joR
 hEE
 kMd
 rHj
 kMd
 htU
-lhX
-gfQ
+cES
+xlO
 gfQ
 gfQ
 gfQ
@@ -63342,7 +63453,7 @@ apc
 oXQ
 xlD
 xlD
-gjB
+amM
 xlD
 xlD
 nrR
@@ -63446,15 +63557,15 @@ xzY
 bnA
 fsz
 fsz
-sjm
+joR
 xgH
 hug
 xgH
 hug
 xgH
-lhX
-gfQ
-gfQ
+cES
+xlO
+xlO
 gfQ
 gfQ
 gfQ
@@ -63703,14 +63814,14 @@ xzY
 bnA
 bnA
 bnA
-clp
-cti
-adz
+fsz
+fPo
+csg
 bXN
-lKx
-cti
-vzz
-scP
+sCk
+fPo
+fsz
+gfQ
 gfQ
 gfQ
 gfQ
@@ -63961,15 +64072,15 @@ qmq
 xzY
 vHn
 bnA
-bnA
-bnA
+rKZ
+rKZ
 rVf
-bnA
-bnA
+rKZ
+rKZ
 bnA
 bnA
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -64207,8 +64318,8 @@ ffW
 xzY
 elh
 eIX
-aYx
-aYx
+avK
+tNf
 xrE
 riF
 riF
@@ -64218,15 +64329,15 @@ dlD
 iuZ
 iuZ
 iuZ
-iRr
+cZH
 iQn
-iRr
+cZH
 gTe
-iQn
+cZH
 iRr
 bnA
-gfQ
-gfQ
+fsz
+xlO
 gfQ
 gfQ
 gfQ
@@ -64459,18 +64570,17 @@ tHy
 oMm
 xzY
 irn
-waO
-ffW
-xzY
-xzY
-xzY
-xtg
+vSI
+hKh
+wGl
+lrA
+wGl
+hud
 afo
-xzY
-xzY
-xzY
+wGl
+wGl
+fuX
 wOk
-xzY
 xzY
 xzY
 xzY
@@ -64479,11 +64589,12 @@ tnK
 bnA
 bnA
 bnA
+bnA
 xgH
-iRr
+cZH
 bnA
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -64716,37 +64827,37 @@ xzY
 xzY
 xzY
 irn
-vSI
-kDK
-ral
-hHX
+xzY
+ffW
+xzY
+xzY
 nZh
-hud
+xzY
 hTo
-wGl
-wGl
-fuX
+xXh
+fBy
+waO
 wOk
 rCg
 sCk
 fPo
 fPo
 fPo
-fsz
-fsz
-fsz
+fPo
+fPo
+csg
 bnA
 koB
-iRr
+cZH
 bnA
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+xlO
+xlO
+xlO
+fsz
+xlO
+xlO
 gfQ
 gfQ
 gfQ
@@ -64884,7 +64995,7 @@ jxE
 ygB
 alD
 jbw
-asf
+xlD
 amM
 xlD
 xlD
@@ -64979,9 +65090,9 @@ xzY
 elh
 oVR
 bwc
-xyN
-oML
-fBy
+xzY
+jdo
+xzY
 waO
 wOk
 xzY
@@ -64991,7 +65102,7 @@ vSM
 vSM
 vSM
 vSM
-fsz
+joR
 bnA
 oDA
 wjM
@@ -64999,12 +65110,12 @@ bnA
 gfQ
 gfQ
 gfQ
+fsz
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
+xlO
+xlO
 gfQ
 gfQ
 gfQ
@@ -65248,7 +65359,7 @@ bVR
 urS
 urS
 vSM
-fsz
+joR
 bnA
 bnA
 gTe
@@ -65261,7 +65372,7 @@ bnA
 bnA
 gfQ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -65505,10 +65616,10 @@ dgu
 hAD
 gKb
 vSM
-fsz
+joR
 bnA
 lOE
-iRr
+cZH
 nTe
 jUG
 xzY
@@ -65518,7 +65629,7 @@ cXs
 bnA
 bnA
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -65762,10 +65873,10 @@ rGH
 urS
 urS
 vSM
-fsz
+joR
 bnA
 qTW
-iRr
+cZH
 gIp
 xzY
 xzY
@@ -65774,8 +65885,8 @@ xzY
 xzY
 xzY
 rKZ
-gfQ
-gfQ
+fsz
+xlO
 gfQ
 gfQ
 gfQ
@@ -65975,7 +66086,7 @@ uFr
 jcZ
 bex
 jcZ
-hvm
+wVb
 bih
 uBW
 biL
@@ -66019,10 +66130,10 @@ vSM
 vSM
 vSM
 vSM
-fsz
+joR
 bnA
 dJu
-iRr
+cZH
 nhm
 xzY
 aQm
@@ -66032,7 +66143,7 @@ xzY
 xzY
 rKZ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -66276,10 +66387,10 @@ fsz
 fsz
 fsz
 fsz
-fsz
+joR
 bnA
 itf
-iRr
+cZH
 gIp
 xzY
 nDS
@@ -66289,7 +66400,7 @@ xzY
 xzY
 rKZ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -66533,10 +66644,10 @@ vSM
 vSM
 vSM
 vSM
-fsz
+joR
 bnA
 lZo
-iRr
+cZH
 nhm
 xzY
 rEm
@@ -66546,7 +66657,7 @@ xzY
 xzY
 rKZ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -66790,10 +66901,10 @@ gUx
 tJM
 tJM
 vSM
-fsz
+joR
 bnA
 ngV
-iRr
+cZH
 gIp
 xzY
 xzY
@@ -66802,8 +66913,8 @@ xzY
 xzY
 xzY
 rKZ
-gfQ
-gfQ
+fsz
+xlO
 gfQ
 gfQ
 gfQ
@@ -67047,7 +67158,7 @@ gjo
 iZs
 tvS
 vSM
-fsz
+joR
 bnA
 xsI
 qjj
@@ -67060,7 +67171,7 @@ rCg
 bnA
 bnA
 gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -67304,7 +67415,7 @@ fPN
 tJM
 tJM
 vSM
-fsz
+joR
 bnA
 bnA
 dJc
@@ -67317,7 +67428,7 @@ bnA
 bnA
 gfQ
 gfQ
-gfQ
+xlO
 gfQ
 gfQ
 gfQ
@@ -67535,7 +67646,7 @@ uOp
 biD
 wVb
 wTA
-pow
+jMO
 weO
 idL
 dtK
@@ -67549,8 +67660,8 @@ dGd
 dGd
 swN
 lJu
-fAP
-hyo
+ubG
+ubG
 soG
 eUn
 rYi
@@ -67561,20 +67672,20 @@ vSM
 vSM
 vSM
 vSM
-fsz
+joR
 bnA
 pZY
 das
 bnA
 tnB
 aUP
+fsz
+gfQ
+fsz
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+xlO
+xlO
 gfQ
 gfQ
 gfQ
@@ -67805,7 +67916,7 @@ xXh
 oCI
 xXh
 sNe
-sNe
+tBe
 aYp
 xXh
 xxC
@@ -67816,21 +67927,21 @@ mVJ
 lpf
 lpf
 lpf
-fsz
-fsz
-fsz
+lpf
+lpf
+nsx
 bnA
 kDr
-iRr
+cZH
 bnA
 aUP
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
-gfQ
+fsz
+xlO
+xlO
+xlO
+fsz
+xlO
+xlO
 gfQ
 gfQ
 gfQ
@@ -68061,19 +68172,19 @@ uPB
 wGl
 uye
 lfS
+wzZ
 lNY
-lNY
-hTo
+nCY
 rSV
 wGl
 lxn
 wOk
-coG
-xzY
+ubG
 xzY
 xzY
 xzY
 tnK
+bnA
 bnA
 bnA
 bnA
@@ -68320,22 +68431,22 @@ wlb
 cjL
 vPR
 eZw
-iMJ
+wlb
 tPW
 riF
 riF
 qXP
-coG
+ubG
 xwd
 xzY
 xzY
 bvo
 eAq
 mRy
-iRr
+cZH
 gTe
 tzS
-iRr
+cZH
 bnA
 aUP
 gfQ
@@ -68561,7 +68672,7 @@ aTy
 qQH
 wth
 wth
-bhs
+wth
 wth
 uHP
 kJd
@@ -68580,16 +68691,16 @@ vol
 trx
 kaC
 xAX
-bvo
+amY
 rwo
 gZh
-rwo
-rwo
+bvo
+bvo
 bvo
 cwg
 bnA
 bnA
-bnA
+rKZ
 bnA
 bnA
 xLM
@@ -68820,12 +68931,12 @@ wNg
 xQD
 xJL
 wth
-rqg
+hvG
 uYy
 wdH
 wUN
 hGI
-qaK
+dtS
 rgq
 wmq
 rgq
@@ -68839,7 +68950,7 @@ wmq
 rgq
 vZg
 xzY
-coG
+ubG
 jdo
 cuF
 xzY
@@ -69078,7 +69189,7 @@ fmE
 fPC
 wth
 sBb
-tRP
+uYy
 bnA
 gSq
 vSM
@@ -69592,7 +69703,7 @@ biy
 bio
 wth
 rqg
-tRP
+uYy
 bnA
 cES
 vSM
@@ -69610,16 +69721,16 @@ mML
 vSM
 joR
 rKZ
-oWd
+gmx
 tdK
 pYa
 qEB
-nqV
-qiS
-lws
+qUZ
+bzL
+kZr
 trF
-pYa
-pYa
+eju
+qID
 pYa
 pYa
 pYa
@@ -69849,7 +69960,7 @@ fmE
 fmE
 wth
 rqg
-tRP
+uYy
 bnA
 cES
 vSM
@@ -69867,7 +69978,7 @@ mML
 vSM
 joR
 rKZ
-huI
+gkd
 gkd
 sVz
 gAY
@@ -70106,7 +70217,7 @@ sWg
 wth
 wth
 dxC
-tRP
+uYy
 bnA
 cES
 vSM
@@ -70347,7 +70458,7 @@ xBz
 gfQ
 wVb
 bhC
-lPk
+cGZ
 lPk
 bhL
 nzd
@@ -70363,7 +70474,7 @@ inV
 lJm
 bMW
 eYL
-tRP
+uYy
 bnA
 nCj
 lpf
@@ -70385,7 +70496,7 @@ iJy
 igd
 pYa
 okP
-nqV
+fYm
 qiS
 ptu
 qoM
@@ -70604,7 +70715,7 @@ xBz
 gfQ
 wVb
 kFm
-uOp
+iFa
 rZu
 mDY
 rSO
@@ -70620,7 +70731,7 @@ qsa
 bnA
 sET
 cfC
-tRP
+uYy
 bnA
 bnA
 bnA
@@ -70639,15 +70750,15 @@ bnA
 bnA
 bnA
 uDH
-tdK
+tuj
 pYa
 vGF
-nqV
-nqV
-nqV
+pRH
+bdM
+pRH
 cOe
-pYa
-pYa
+uNX
+aGq
 pYa
 wPU
 pYa
@@ -71133,7 +71244,7 @@ pIn
 rqR
 bnA
 bnA
-kSV
+bnA
 ewM
 bnA
 bnA
@@ -71390,7 +71501,7 @@ pIn
 tkB
 vZs
 low
-fSo
+muZ
 muZ
 sxe
 sxe
@@ -79794,7 +79905,7 @@ cMq
 wYX
 wKh
 wYX
-oCD
+pfh
 ygg
 arN
 alb
@@ -80051,7 +80162,7 @@ bbc
 wYX
 nrY
 wYX
-oCD
+jPf
 ygg
 akh
 arN
@@ -80567,7 +80678,7 @@ gfQ
 gfQ
 gfQ
 wYX
-fWh
+nlE
 ygg
 qUs
 amg
@@ -80824,7 +80935,7 @@ gfQ
 gfQ
 gfQ
 wYX
-fWh
+jSH
 ygg
 qUs
 amg
@@ -81081,7 +81192,7 @@ gfQ
 gfQ
 gfQ
 wYX
-fWh
+vQF
 ygg
 qUs
 amg
@@ -81149,7 +81260,7 @@ vii
 xEd
 xEd
 xEd
-gkm
+eWh
 eAn
 gSu
 kGs
@@ -81338,7 +81449,7 @@ gfQ
 gfQ
 aig
 wYX
-fWh
+cJB
 ald
 qUs
 amh
@@ -81595,7 +81706,7 @@ gfQ
 gfQ
 gfQ
 wYX
-fWh
+hJO
 ygg
 qUs
 amg
@@ -81652,9 +81763,9 @@ kTF
 kTF
 bhh
 kTF
-dML
+kTF
 mVX
-fDD
+kTF
 kTF
 kTF
 kTF
@@ -81852,7 +81963,7 @@ gfQ
 gfQ
 gfQ
 wYX
-fWh
+lFI
 ygg
 qUs
 amg
@@ -82621,7 +82732,7 @@ mTe
 wYX
 nrY
 wYX
-oCD
+wuD
 ygg
 atK
 ygg
@@ -82878,7 +82989,7 @@ cMq
 wYX
 gLT
 wYX
-oCD
+gph
 ygg
 atK
 alm
@@ -83961,9 +84072,9 @@ vWk
 xoW
 mjV
 gXp
-qnO
+pJx
 hvU
-mjV
+ykd
 ryu
 xcl
 xNU
@@ -84497,7 +84608,7 @@ uio
 wmw
 cOX
 wmw
-tvz
+vPe
 naM
 tTH
 iVd
@@ -86562,7 +86673,7 @@ prw
 vxV
 cND
 qAe
-cND
+tYR
 tJB
 tJB
 tJB
@@ -88117,8 +88228,8 @@ hcN
 orD
 iHs
 lXm
-dZA
-dZA
+bHB
+bHB
 fsz
 gfQ
 gfQ
@@ -88375,7 +88486,7 @@ dvT
 vrT
 mLZ
 nfD
-dZA
+bHB
 gfQ
 gfQ
 gfQ
@@ -88632,7 +88743,7 @@ orD
 pHi
 rei
 ooP
-dZA
+bHB
 gfQ
 gfQ
 gfQ
@@ -88889,7 +89000,7 @@ orD
 pHi
 oUM
 eRN
-dZA
+bHB
 gfQ
 gfQ
 gfQ
@@ -89146,7 +89257,7 @@ orD
 rKi
 nIk
 oFA
-dZA
+bHB
 gfQ
 gfQ
 gfQ
@@ -90374,7 +90485,7 @@ juY
 kwf
 hwL
 aQa
-nIB
+pjB
 pcT
 hwL
 blb
@@ -90628,7 +90739,7 @@ aPm
 cnA
 dao
 juY
-kwD
+ezk
 hwL
 mPw
 lli
@@ -91146,7 +91257,7 @@ kxR
 mUs
 mUy
 nOj
-mUy
+juh
 mUs
 qVF
 rZI
@@ -93001,7 +93112,7 @@ xBZ
 gYL
 hLU
 iiy
-iiy
+fwg
 iiy
 eqS
 khn
@@ -94022,7 +94133,7 @@ xsd
 fsz
 gfQ
 gfQ
-xBZ
+gfQ
 xBZ
 xBZ
 xBZ
@@ -94032,7 +94143,7 @@ xBZ
 xBZ
 xBZ
 xBZ
-xBZ
+gfQ
 gfQ
 iQl
 iQl
@@ -94280,15 +94391,15 @@ fsz
 fsz
 gfQ
 xBZ
-mwm
+xBZ
 jMZ
 hTx
 thn
-wpL
+hLU
 wZb
 cBq
 lqV
-fBo
+xBZ
 xBZ
 gfQ
 iQl
@@ -95053,7 +95164,7 @@ gfQ
 xBZ
 rCW
 jMZ
-biV
+skG
 oiJ
 pWw
 oiJ
@@ -95317,7 +95428,7 @@ umy
 umy
 umy
 iOP
-xBZ
+iOP
 gfQ
 iQl
 iQl
@@ -95574,7 +95685,7 @@ aRr
 fnJ
 eCM
 sJn
-xBZ
+iOP
 gfQ
 iQl
 iQl
@@ -95831,7 +95942,7 @@ xPT
 fpc
 mdS
 hlT
-xBZ
+iOP
 gfQ
 iQl
 iQl
@@ -96088,7 +96199,7 @@ oxj
 iKS
 dsI
 fkd
-xBZ
+iOP
 gfQ
 iQl
 iQl
@@ -96345,7 +96456,7 @@ yjU
 iKS
 kPu
 gHt
-xBZ
+iOP
 gfQ
 gfQ
 iQl
@@ -96602,7 +96713,7 @@ nCU
 fbm
 vKQ
 den
-xBZ
+iOP
 gfQ
 gfQ
 iQl
@@ -96859,7 +96970,7 @@ krj
 arv
 dwV
 cSc
-xBZ
+iOP
 gfQ
 gfQ
 fUR
@@ -97108,15 +97219,15 @@ gfQ
 gfQ
 iOP
 iOP
+kby
+bmL
 iOP
 iOP
 iOP
+bmL
+kby
 iOP
 iOP
-iOP
-iOP
-iOP
-xBZ
 gfQ
 gfQ
 gfQ
@@ -97364,15 +97475,15 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-fsz
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
-gfQ
+iOP
+iOP
+iOP
+iOP
+iOP
+iOP
+iOP
+iOP
+iOP
 gfQ
 gfQ
 gfQ
@@ -97619,18 +97730,18 @@ gfQ
 gfQ
 gfQ
 gfQ
+gfQ
+gfQ
+gfQ
+gfQ
 fsz
-sHc
-sHc
-sHc
-sHc
-sHc
-sHc
-sHc
-sHc
-sHc
-sHc
-sHc
+gfQ
+gfQ
+gfQ
+gfQ
+fsz
+gfQ
+gfQ
 fsz
 fsz
 sHc
@@ -97876,18 +97987,18 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
-gfQ
-gfQ
 fsz
-gfQ
-gfQ
-gfQ
-gfQ
-fsz
-gfQ
-gfQ
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
+sHc
 gfQ
 gfQ
 gfQ
@@ -98137,12 +98248,12 @@ gfQ
 gfQ
 gfQ
 gfQ
+fsz
 gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+fsz
 gfQ
 gfQ
 gfQ
@@ -99396,21 +99507,21 @@ fsz
 fsz
 fsz
 gfQ
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 tSb
 gfQ
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 rpu
 fsz
 gfQ
@@ -99910,20 +100021,20 @@ gfQ
 gfQ
 fsz
 gfQ
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 tSb
 gfQ
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
 iza
 gfQ
 fsz
@@ -100424,21 +100535,21 @@ gfQ
 gfQ
 fsz
 rpu
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 tSb
 gfQ
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 fsz
 gfQ
@@ -100938,21 +101049,21 @@ gfQ
 gfQ
 fsz
 rpu
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 tSb
 gfQ
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 rpu
 fsz
 fsz
@@ -101452,21 +101563,21 @@ gfQ
 fsz
 fsz
 rpu
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 tSb
 gfQ
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 fsz
 gfQ
@@ -101966,21 +102077,21 @@ gfQ
 gfQ
 fsz
 gfQ
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 tSb
 gfQ
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 rpu
 fsz
 fsz
@@ -102480,21 +102591,21 @@ fsz
 fsz
 fsz
 gfQ
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 tSb
 gfQ
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 rpu
 fsz
 fsz
@@ -102994,21 +103105,21 @@ gfQ
 gfQ
 fsz
 rpu
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 tSb
 gfQ
 qms
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
 rpu
 fsz
 fsz
@@ -103508,21 +103619,21 @@ fsz
 fsz
 fsz
 rpu
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 tSb
 gfQ
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 rpu
 fsz
 gfQ
@@ -104022,21 +104133,21 @@ gfQ
 gfQ
 fsz
 rpu
-iza
-iza
-iza
-iza
-iza
-iza
+iUi
+iUi
+iUi
+iUi
+iUi
+iUi
 gfQ
 tSb
 gfQ
-iza
-iza
-iza
+iUi
+iUi
+iUi
 qms
-iza
-iza
+iUi
+iUi
 rpu
 fsz
 fsz

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -1117,10 +1117,8 @@
 	dir = 8;
 	network = list("ss13","rd")
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/machinery/newscaster/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "ahR" = (
@@ -3976,6 +3974,15 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"aGv" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Fitness"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "aGw" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -6504,6 +6511,7 @@
 /area/commons/dorms)
 "aZZ" = (
 /obj/structure/closet/boxinggloves,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "baa" = (
@@ -6914,7 +6922,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bdP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "bdR" = (
@@ -7024,7 +7034,6 @@
 	name = "Gravity Generator";
 	req_access_txt = "11"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -8076,9 +8085,9 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bmR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/stairs/left{
+	dir = 1
+	},
 /area/commons/fitness/recreation)
 "bnh" = (
 /obj/structure/window{
@@ -8626,6 +8635,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"bxo" = (
+/turf/open/floor/iron/stairs/right{
+	dir = 1
+	},
+/area/commons/fitness/recreation)
 "bxt" = (
 /obj/machinery/vending/modularpc,
 /obj/machinery/light{
@@ -8724,6 +8738,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
+"bAg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/commons/fitness/recreation)
 "bAi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -9114,6 +9134,7 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "bRe" = (
@@ -10640,15 +10661,6 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
-"cQB" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Fitness"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "cQC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12041,13 +12053,11 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	name = "bar sorting disposal pipe";
-	sortType = 19
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dBt" = (
@@ -17257,7 +17267,6 @@
 	req_access_txt = "4"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21006,14 +21015,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
-"iza" = (
-/obj/machinery/power/solar{
-	id = "starboardsolar";
-	name = "Starboard Solar Array"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/solarpanel,
-/area/solars/starboard/aft)
 "izR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22384,6 +22385,7 @@
 	pixel_x = 29
 	},
 /obj/item/crowbar,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "jtk" = (
@@ -22526,6 +22528,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -24696,6 +24699,17 @@
 	dir = 4
 	},
 /area/hallway/secondary/entry)
+"kIg" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "kIs" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/reagent_dispensers/watertank,
@@ -25356,6 +25370,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"lfg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/stairs/right{
+	dir = 4
+	},
+/area/commons/dorms)
 "lfu" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -27031,7 +27053,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/fore)
 "mbP" = (
 /obj/structure/cable,
@@ -27183,6 +27205,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "mfn" = (
@@ -30093,7 +30116,11 @@
 /area/security/prison/safe)
 "nJJ" = (
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/stairs/right{
+	dir = 1
+	},
 /area/commons/fitness/recreation)
 "nJO" = (
 /obj/effect/landmark/event_spawn,
@@ -31210,6 +31237,7 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
 "ooZ" = (
@@ -32453,6 +32481,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
+"pan" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/stairs{
+	dir = 1
+	},
+/area/maintenance/fore)
 "pay" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -36863,13 +36899,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/nanite)
-"rML" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/fore)
 "rNp" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/door/window/eastleft{
@@ -38697,6 +38726,7 @@
 /area/science/test_area)
 "sLV" = (
 /obj/machinery/bounty_board/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "sMi" = (
@@ -38812,6 +38842,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
+"sON" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/maintenance/fore)
 "sOO" = (
 /obj/machinery/light/built,
 /turf/open/floor/wood{
@@ -39714,7 +39750,6 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/structure/cable,
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
 /turf/open/floor/circuit,
@@ -42454,6 +42489,10 @@
 "uIx" = (
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"uIK" = (
+/obj/structure/cable,
+/turf/open/floor/iron/edge,
+/area/engineering/main)
 "uJa" = (
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -44159,10 +44198,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "vzP" = (
@@ -44336,6 +44374,11 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"vDU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "vEc" = (
 /turf/open/floor/iron/smooth_corner,
 /area/engineering/gravity_generator)
@@ -44753,6 +44796,7 @@
 	name = "Ian's Room APC";
 	pixel_x = 24
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "vPD" = (
@@ -47229,6 +47273,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"xfS" = (
+/turf/open/floor/iron/stairs/left{
+	dir = 4
+	},
+/area/commons/dorms)
 "xgn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -47907,6 +47956,13 @@
 "xvi" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/fore)
+"xvq" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "xvt" = (
 /turf/closed/wall,
 /area/service/kitchen)
@@ -48661,7 +48717,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/stairs/left{
+	dir = 1
+	},
 /area/commons/fitness/recreation)
 "xSz" = (
 /turf/open/floor/carpet/cyan,
@@ -48728,7 +48786,6 @@
 "xUG" = (
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
-/obj/structure/cable,
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/circuit,
@@ -68904,8 +68961,8 @@ iPv
 iPv
 eSq
 vvx
-uOp
-xWP
+ibM
+uIK
 jvy
 aTA
 szL
@@ -82744,8 +82801,8 @@ btv
 brB
 hzP
 xNm
-aZT
-ivy
+lfg
+xfS
 tGp
 boH
 bJY
@@ -84849,11 +84906,11 @@ aKO
 pnn
 jJn
 rLe
-uio
+kIg
 bQI
-yal
-yal
-yal
+mJQ
+mJQ
+mJQ
 dxv
 tTH
 tTH
@@ -86089,8 +86146,8 @@ aZk
 ePY
 uJv
 uJv
-uJv
 aJG
+bxo
 bdj
 ybn
 bjU
@@ -86590,10 +86647,10 @@ ybK
 auJ
 okv
 okv
-rML
+uvI
 pxw
-uvI
-uvI
+pan
+sON
 etj
 xrI
 xrI
@@ -86849,8 +86906,8 @@ ybK
 ybK
 hIq
 kbg
-yiQ
-yiQ
+xvq
+xvq
 etj
 xrI
 xrI
@@ -89170,13 +89227,13 @@ aMz
 aMJ
 uJv
 bdP
-bdP
-bdP
-bdP
+uJv
+uJv
+uJv
+bAg
 bmR
-bmR
-cQB
-fiL
+bdj
+ybn
 dBp
 dYP
 pnn
@@ -89432,8 +89489,8 @@ jtc
 sLV
 vzM
 nJJ
-bdj
-uWM
+aGv
+vDU
 dCM
 uWM
 eCI
@@ -100537,7 +100594,7 @@ iUi
 iUi
 iUi
 iUi
-iza
+iUi
 gfQ
 fsz
 gfQ

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -9324,7 +9324,6 @@
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/security/prison/rec)
 "bRx" = (
@@ -14873,7 +14872,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "eRN" = (
-/obj/structure/transit_tube/station/dispenser/flipped,
+/obj/structure/transit_tube/station/dispenser/reverse/flipped,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
 "eSn" = (
@@ -20987,9 +20986,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
 /turf/open/floor/iron,
 /area/command/bridge)
 "ieR" = (
@@ -26511,6 +26507,7 @@
 /area/hallway/primary/starboard)
 "lkI" = (
 /obj/machinery/light,
+/obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron,
 /area/command/bridge)
 "lkK" = (
@@ -31228,6 +31225,15 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"nNX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/command/bridge)
 "nOj" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -33000,6 +33006,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/iron,
 /area/command/bridge)
 "oJq" = (
@@ -42084,12 +42093,6 @@
 "tJp" = (
 /turf/closed/wall,
 /area/command/heads_quarters/rd)
-"tJq" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblue,
-/area/command/bridge)
 "tJA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44609,7 +44612,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/westleft{
 	dir = 4;
-	name = "Hydroponics Desk";
+	name = "Hydroponics Biogenerator";
 	req_one_access_txt = "30;35"
 	},
 /obj/structure/window{
@@ -50295,6 +50298,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"xMl" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/command/bridge)
 "xMu" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -86156,7 +86166,7 @@ rLe
 uio
 aob
 tjx
-buL
+xMl
 jje
 buL
 ljl
@@ -87194,7 +87204,7 @@ pyp
 tTH
 cND
 qAe
-cND
+blU
 tJB
 fun
 gCI
@@ -90789,13 +90799,13 @@ gQg
 cKk
 qAe
 ieQ
-qAe
+nNX
 qAe
 qAe
 cND
 ezH
 erg
-tJq
+jaa
 dIV
 jaa
 dfA

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -882,6 +882,7 @@
 /area/space/nearstation)
 "afS" = (
 /obj/machinery/vending/cigarette,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/wood,
 /area/service/bar)
 "afW" = (
@@ -1200,7 +1201,9 @@
 	dir = 8;
 	name = "plush sofa"
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
 /turf/open/floor/wood,
 /area/service/bar)
 "aiH" = (
@@ -2517,6 +2520,7 @@
 "asl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "asm" = (
@@ -4449,7 +4453,8 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/newscaster/directional/west,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aKd" = (
@@ -5380,7 +5385,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/radio/intercom/directional/east,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
 "aRD" = (
@@ -5427,6 +5432,7 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood,
 /area/service/bar)
 "aRH" = (
@@ -5601,6 +5607,14 @@
 /obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"aTr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/light,
+/turf/open/floor/iron/white,
+/area/science/research)
 "aTu" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -7486,6 +7500,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bhj" = (
@@ -7577,6 +7594,7 @@
 /area/engineering/break_room)
 "bhR" = (
 /obj/structure/chair/stool/bar,
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/wood,
 /area/service/bar)
 "bhS" = (
@@ -8311,6 +8329,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/ai_upload)
+"bpn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "bpv" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
@@ -9887,7 +9915,6 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "cgN" = (
-/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
 "cgS" = (
@@ -10070,6 +10097,7 @@
 	},
 /obj/structure/table,
 /obj/item/trash/can/food/beans,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cma" = (
@@ -10782,6 +10810,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/storage/art)
 "cMM" = (
@@ -13082,6 +13111,7 @@
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/service,
 /obj/machinery/light/cold/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "dRO" = (
@@ -14122,6 +14152,17 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"ewH" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "ewM" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance";
@@ -14938,7 +14979,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/tank_holder/oxygen,
 /turf/open/floor/iron/showroomfloor,
-/area/science/mixing)
+/area/science/mixing/chamber)
 "eVc" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen";
@@ -15176,7 +15217,7 @@
 /obj/structure/chair/sofa/corner{
 	name = "plush sofa"
 	},
-/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/bounty_board/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
 "fcB" = (
@@ -15196,13 +15237,11 @@
 /obj/structure/chair/sofa/corner{
 	name = "plush sofa"
 	},
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
 /obj/machinery/camera{
 	c_tag = "Service - Bar Lounge";
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
 "fcJ" = (
@@ -15572,6 +15611,19 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/iron,
 /area/science/storage)
+"fiZ" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "fjg" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -15893,6 +15945,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/main)
+"frf" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "fri" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -17098,6 +17157,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
 "fYm" = (
@@ -17144,6 +17204,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
 "fZM" = (
@@ -17205,6 +17266,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "gay" = (
@@ -18862,6 +18924,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "gVf" = (
@@ -20166,6 +20229,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"hHH" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "hHQ" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder{
@@ -20329,6 +20398,12 @@
 /obj/machinery/telecomms/hub/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"hLu" = (
+/obj/structure/sign/poster/random{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "hLE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20692,6 +20767,12 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"hYR" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "hZo" = (
 /obj/structure/lattice,
 /obj/structure/marker_beacon/burgundy,
@@ -22421,6 +22502,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "iYj" = (
@@ -24629,6 +24711,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"kmQ" = (
+/obj/machinery/deepfryer,
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_x = -32
+	},
+/turf/open/floor/iron/dark,
+/area/service/kitchen)
 "kmZ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/door/firedoor,
@@ -24654,6 +24743,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"knN" = (
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "knV" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/iron/white,
@@ -24906,6 +24999,12 @@
 /obj/machinery/light,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
+"ktF" = (
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "kub" = (
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
@@ -24944,6 +25043,7 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "kvt" = (
@@ -25259,6 +25359,10 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "kEt" = (
@@ -25755,12 +25859,6 @@
 "kNU" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	id = "rabbitcontainment";
-	name = "Space Shutters Control";
-	pixel_x = -26;
-	pixel_y = 30
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
@@ -26540,6 +26638,7 @@
 	name = "Medbay RC";
 	pixel_y = -30
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "lok" = (
@@ -29398,6 +29497,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
 "mRm" = (
@@ -29546,7 +29646,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/iron/white,
+/turf/open/floor/iron/white/textured,
 /area/medical/cryo)
 "mUl" = (
 /obj/effect/spawner/bundle/moisture_trap,
@@ -30805,6 +30905,9 @@
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "nDC" = (
@@ -31490,7 +31593,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/science/mixing)
 "nXh" = (
@@ -31599,6 +31702,10 @@
 /area/engineering/main)
 "nYN" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "nYX" = (
@@ -32927,6 +33034,12 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
+"oKu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/beacon,
+/turf/open/floor/iron/showroomfloor,
+/area/science/lab)
 "oKE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -33646,10 +33759,6 @@
 	},
 /area/hallway/secondary/entry)
 "pfj" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -35239,7 +35348,6 @@
 	dir = 8;
 	name = "plush sofa"
 	},
-/obj/machinery/bounty_board/directional/east,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
@@ -37100,9 +37208,6 @@
 /obj/item/radio/intercom{
 	pixel_y = 37
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Science - Toxins Launch Chamber";
 	dir = 4;
@@ -37115,6 +37220,7 @@
 /obj/machinery/computer/pod/old/mass_driver_controller/toxinsdriver{
 	pixel_y = 26
 	},
+/obj/machinery/light/cold/directional/west,
 /turf/open/floor/iron,
 /area/science/mixing)
 "rhh" = (
@@ -37564,7 +37670,6 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "ruP" = (
-/obj/machinery/door/firedoor/heavy,
 /obj/machinery/airalarm/mixingchamber{
 	dir = 4;
 	pixel_x = -24
@@ -38036,7 +38141,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera{
 	c_tag = "Cargo - Shuttle Exterior";
-	dir = 4
+	dir = 4;
+	network = list("ss13","qm")
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -38597,6 +38703,7 @@
 "sbk" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "sbx" = (
@@ -40079,6 +40186,12 @@
 	pixel_x = -8;
 	pixel_y = 24
 	},
+/obj/machinery/button/door{
+	id = "rabbitcontainment";
+	name = "Privacy Shutters Control";
+	pixel_x = -8;
+	pixel_y = 35
+	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "sOv" = (
@@ -40431,6 +40544,10 @@
 "sWg" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "sWt" = (
@@ -40450,6 +40567,7 @@
 /area/hallway/primary/starboard)
 "sWN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "sXk" = (
@@ -40930,10 +41048,6 @@
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Security";
 	req_access_txt = "58"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "rabbitcontainment";
-	name = "privacy shutter"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42722,6 +42836,7 @@
 "uea" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "uei" = (
@@ -44954,8 +45069,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vla" = (
-/obj/structure/bed/dogbed/lia,
+/obj/structure/bed/dogbed/lia{
+	desc = "Seems kind of... fishy. It's very small, like it was designed for a rodent or rabbit."
+	},
 /mob/living/simple_animal/hostile/carp/lia,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "vlz" = (
@@ -45039,6 +45157,10 @@
 	c_tag = "Aft Hallway - Custodial Closet";
 	dir = 1;
 	view_range = 10
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -46057,6 +46179,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/security/prison)
 "vIc" = (
@@ -47040,11 +47163,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/upper)
-"wjE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/bounty_board/directional/west,
-/turf/open/floor/wood,
-/area/service/bar)
 "wjH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow{
@@ -47087,6 +47205,13 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"wkN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/plaque/static_plaque/golden/commission/lima,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "wkU" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -47527,13 +47652,12 @@
 "wyS" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
 "wyW" = (
 /obj/machinery/icecream_vat,
 /obj/machinery/newscaster/directional/west,
-/obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
 "wyY" = (
@@ -48279,6 +48403,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
 "wSA" = (
@@ -48474,12 +48599,16 @@
 /area/science/xenobiology)
 "wWM" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/engineering{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/engineering/glass{
 	name = "Tech Storage";
 	req_access_txt = "23"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "wXl" = (
@@ -48679,6 +48808,11 @@
 /area/cargo/storage)
 "xbI" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "xbN" = (
@@ -48823,6 +48957,10 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"xet" = (
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "xeJ" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/wrench,
@@ -48929,12 +49067,12 @@
 /turf/open/floor/carpet/black,
 /area/security/prison/workout)
 "xih" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/duct,
+/obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8;
 	name = "Supplementary Air Supply";
 	piping_layer = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "xiq" = (
@@ -49316,7 +49454,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "xsd" = (
 /turf/closed/wall,
@@ -50727,6 +50865,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ydc" = (
@@ -50737,9 +50876,7 @@
 /area/medical/pharmacy)
 "ydf" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/structure/sign/poster/official/cleanliness{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "ydj" = (
@@ -50939,10 +51076,6 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "ygm" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "camdola_containment";
-	name = "Privacy Shutters"
-	},
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Medical Officer";
 	req_access_txt = "40"
@@ -80842,8 +80975,8 @@ hBV
 jUZ
 dUu
 xvt
-aJf
-gbO
+kmQ
+bpn
 aKb
 ydf
 oAV
@@ -82410,7 +82543,7 @@ adG
 yfY
 afS
 kEX
-wjE
+bhX
 pxG
 hOZ
 hti
@@ -83394,7 +83527,7 @@ ygg
 ygg
 urp
 php
-ybn
+hYR
 ybn
 ybn
 jyG
@@ -83646,7 +83779,7 @@ apo
 oBJ
 arV
 atL
-agj
+wkN
 dzZ
 agj
 bcB
@@ -83907,18 +84040,18 @@ ygg
 ygg
 ygg
 urp
-php
+frf
 ybn
 bjx
 bdu
 aUa
 ybn
 aWP
-ybn
+xet
 jyG
 ybn
 bjx
-ybn
+hHH
 ybn
 ybn
 php
@@ -83955,9 +84088,9 @@ mVX
 kTF
 kTF
 kTF
-kTF
+ewH
 har
-kTF
+fiZ
 hfN
 lWC
 sGz
@@ -84695,7 +84828,7 @@ dVA
 tGp
 bjJ
 bjU
-ybn
+knN
 ozS
 fda
 agq
@@ -85466,7 +85599,7 @@ ceX
 tGp
 ybn
 bjU
-ybn
+hLu
 ozS
 jgR
 get
@@ -87006,7 +87139,7 @@ btD
 aJy
 aJy
 tGp
-ybn
+ktF
 bjU
 aei
 vqN
@@ -88044,9 +88177,9 @@ hhL
 uby
 jip
 khQ
-qnO
+pJx
 mRi
-nBH
+tpF
 eRz
 pTu
 qQD
@@ -88301,9 +88434,9 @@ hiv
 isb
 jiQ
 kjT
-qnO
+pJx
 mRb
-nBH
+tpF
 abD
 pTu
 nFu
@@ -88558,9 +88691,9 @@ hiA
 taa
 jip
 dVq
-qnO
+pJx
 mRb
-nBH
+tpF
 iie
 fTr
 nFu
@@ -93954,7 +94087,7 @@ gqN
 lNt
 lNt
 jyy
-ezk
+oKu
 wRL
 oeI
 vyS
@@ -94476,7 +94609,7 @@ tJp
 tJp
 tJp
 uAk
-tvm
+aTr
 pgy
 vpQ
 wsh
@@ -97560,7 +97693,7 @@ pqA
 qkf
 kGJ
 uAk
-tvm
+aTr
 uVM
 lMh
 wyS

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -2,6 +2,10 @@
 "aab" = (
 /turf/closed/wall/r_wall/rust,
 /area/space/nearstation)
+"aac" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "aad" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -113,12 +117,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"aaT" = (
-/obj/structure/tank_dispenser{
-	pixel_x = -1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/break_room)
 "aaV" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -190,9 +188,6 @@
 "abB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -276,6 +271,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
+"aca" = (
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "acb" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -339,9 +338,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "acp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -353,14 +354,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "act" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance";
-	req_access_txt = "31"
-	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/vehicle/sealed/mecha/working/ripley/cargo,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/cargo/storage)
 "acw" = (
 /obj/structure/window{
 	dir = 8
@@ -373,17 +370,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/cargo/office)
-"acx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "acy" = (
 /obj/machinery/light{
 	dir = 1
@@ -402,14 +388,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"acB" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "acC" = (
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
@@ -546,6 +524,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/east,
+/obj/machinery/computer/cargo/request{
+	dir = 8
+	},
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "adD" = (
@@ -565,7 +546,8 @@
 /area/hallway/secondary/entry)
 "adG" = (
 /obj/machinery/light,
-/turf/open/floor/iron,
+/obj/structure/closet/secure_closet/hydroponics,
+/turf/open/floor/iron/half,
 /area/service/hydroponics)
 "adH" = (
 /obj/machinery/camera{
@@ -608,6 +590,10 @@
 /area/maintenance/port/fore)
 "adP" = (
 /obj/item/trash/candy,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"adS" = (
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "adU" = (
@@ -778,6 +764,14 @@
 /area/commons/dorms)
 "aeO" = (
 /obj/structure/cable,
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/plasteel{
+	amount = 15
+	},
+/obj/item/screwdriver,
+/obj/item/weldingtool,
+/obj/item/wrench,
+/obj/item/crowbar,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "aeS" = (
@@ -961,7 +955,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/closet/emcloset/anchored,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "agj" = (
@@ -1051,6 +1045,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "agJ" = (
@@ -1222,6 +1217,7 @@
 	dir = 8;
 	name = "plush sofa"
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
 "aiH" = (
@@ -1234,7 +1230,7 @@
 "aiQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/engineering/break_room)
 "aiR" = (
 /obj/effect/spawner/structure/window,
@@ -1465,12 +1461,14 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "akR" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Recreation"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "akV" = (
@@ -1515,10 +1513,9 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "alh" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/central)
+/obj/machinery/vending/games,
+/turf/open/floor/wood/large,
+/area/service/library)
 "ali" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1616,6 +1613,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "alO" = (
@@ -1641,6 +1639,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "amd" = (
@@ -1665,6 +1664,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/item/crowbar,
 /turf/open/floor/plating,
 /area/security/checkpoint/auxiliary)
 "amj" = (
@@ -1942,7 +1942,7 @@
 "anu" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/engineering/break_room)
 "anz" = (
 /obj/machinery/door/firedoor,
@@ -2228,6 +2228,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "apC" = (
@@ -2344,6 +2345,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "arv" = (
@@ -2473,10 +2475,8 @@
 /area/hallway/secondary/entry)
 "ash" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "asi" = (
@@ -2560,6 +2560,7 @@
 	name = "Firing Range";
 	req_one_access_txt = "1;4"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "asK" = (
@@ -2575,6 +2576,7 @@
 /obj/machinery/door/airlock/security{
 	name = "Perma Brig"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "asN" = (
@@ -2837,13 +2839,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "auJ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "auR" = (
@@ -2853,9 +2853,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "auV" = (
-/obj/machinery/status_display/evac{
-	pixel_x = 32
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "avb" = (
@@ -3042,6 +3043,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
+"awt" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "awu" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
@@ -3051,6 +3056,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "awD" = (
@@ -3317,7 +3323,7 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "ayE" = (
-/obj/structure/moisture_trap,
+/obj/effect/spawner/bundle/moisture_trap,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ayF" = (
@@ -3340,6 +3346,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "ayK" = (
@@ -3359,7 +3366,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/commons/dorms)
 "azd" = (
 /obj/machinery/door/airlock{
@@ -3368,7 +3375,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/commons/dorms)
 "azg" = (
 /obj/structure/closet/emcloset,
@@ -3467,12 +3474,15 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "azZ" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/disposal/bin,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/commons/dorms)
 "aAa" = (
 /obj/structure/closet,
@@ -3542,26 +3552,18 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "aAM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
-/area/commons/dorms)
-"aAN" = (
-/obj/machinery/door/airlock{
-	id_tag = "Dorm2";
-	name = "Dorm 2"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
 /area/commons/dorms)
 "aAS" = (
 /obj/machinery/door/airlock/maintenance{
@@ -3575,6 +3577,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aAZ" = (
@@ -3598,14 +3601,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aBn" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/vending/clothing,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
 /area/commons/dorms)
 "aBo" = (
 /obj/effect/turf_decal/tile/blue{
@@ -3614,10 +3612,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/wardrobe/white,
+/obj/machinery/status_display/evac/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
 "aBp" = (
@@ -3625,16 +3623,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"aBx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/closet/wardrobe/pjs,
-/turf/open/floor/iron/cafeteria,
-/area/commons/dorms)
 "aBz" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -3740,6 +3728,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"aCU" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "aCY" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -3785,8 +3777,13 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/service/library)
+"aDS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "aDT" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -3797,6 +3794,7 @@
 /obj/item/paper_bin,
 /obj/item/paper_bin,
 /obj/item/paper_bin,
+/obj/item/crowbar,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "aDZ" = (
@@ -4003,6 +4001,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"aGw" = (
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aGy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4078,12 +4080,15 @@
 	pixel_x = -20;
 	pixel_y = 11
 	},
+/obj/item/dest_tagger,
+/obj/item/crowbar,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "aHo" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
+/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "aHw" = (
@@ -4407,6 +4412,7 @@
 	pixel_y = 4
 	},
 /obj/item/pen,
+/obj/item/crowbar,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "aKv" = (
@@ -4473,13 +4479,14 @@
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
 "aLi" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/commons/dorms)
 "aLn" = (
 /obj/machinery/bookbinder,
+/obj/machinery/light/warm/directional/south,
 /turf/open/floor/wood/large,
 /area/service/library)
 "aLr" = (
@@ -4511,11 +4518,12 @@
 	},
 /area/maintenance/fore)
 "aLJ" = (
-/obj/structure/table/wood/fancy/red,
+/obj/structure/altar_of_gods,
 /turf/open/floor/carpet/red,
 /area/service/chapel/main)
 "aLK" = (
 /obj/effect/landmark/start/assistant,
+/obj/machinery/duct,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "aLT" = (
@@ -4540,23 +4548,49 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Fitness"
+/obj/machinery/cryopod{
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/commons/dorms)
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
 "aMp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/iron,
-/area/commons/fitness)
-"aMq" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
-/turf/open/floor/iron,
-/area/commons/fitness)
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
+"aMq" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
 "aMz" = (
 /obj/structure/sink{
 	dir = 4;
@@ -4671,6 +4705,10 @@
 /obj/structure/table_frame,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"aNq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "aNs" = (
 /obj/structure/grille,
 /obj/structure/cable,
@@ -4853,6 +4891,7 @@
 /area/medical/psychology)
 "aOR" = (
 /obj/structure/chair/sofa,
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
 "aOT" = (
@@ -4889,15 +4928,13 @@
 /area/science/lab)
 "aPn" = (
 /obj/machinery/iv_drip,
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "aPu" = (
@@ -5065,7 +5102,7 @@
 	id = "Robotics Belt A";
 	name = "Robotics Conveyor"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/science/robotics/lab)
 "aQr" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5248,6 +5285,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
 "aRE" = (
@@ -5319,6 +5357,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"aRT" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "aRW" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -5329,6 +5379,10 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"aSh" = (
+/obj/structure/closet/crate/trashcart/filled,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aSi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5352,6 +5406,7 @@
 	pixel_x = 1;
 	pixel_y = 6
 	},
+/obj/item/crowbar,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "aSD" = (
@@ -5470,6 +5525,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
+"aTA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/radio/off{
+	pixel_x = 6
+	},
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "aTD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -5559,11 +5625,12 @@
 "aUg" = (
 /obj/structure/table/wood,
 /obj/item/storage/crayons,
+/obj/item/storage/crayons,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "aUh" = (
 /obj/structure/table/wood,
-/obj/item/paicard,
+/obj/item/flashlight/lamp,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "aUj" = (
@@ -5729,8 +5796,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aVr" = (
@@ -5741,12 +5809,13 @@
 /area/engineering/atmos)
 "aVu" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "aVw" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/main)
 "aVz" = (
@@ -5779,6 +5848,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aVK" = (
@@ -5811,6 +5884,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aVQ" = (
+/obj/machinery/duct,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "aVW" = (
@@ -5846,6 +5920,7 @@
 	dir = 4;
 	filter_type = "n2"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aWk" = (
@@ -5883,6 +5958,15 @@
 /obj/structure/sign/warning/fire,
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
+"aWC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "aWG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5952,7 +6036,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aWU" = (
-/obj/structure/moisture_trap,
+/obj/effect/spawner/bundle/moisture_trap,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aWX" = (
@@ -5992,6 +6076,7 @@
 	dir = 4;
 	name = "Cold Loop Bypass"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aXp" = (
@@ -6012,8 +6097,6 @@
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "aXG" = (
@@ -6039,18 +6122,15 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aYb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/engineering/atmos)
-"aYe" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "aYg" = (
 /obj/effect/spawner/structure/window,
@@ -6060,7 +6140,6 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
@@ -6083,12 +6162,12 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aYz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/main)
 "aYB" = (
@@ -6122,17 +6201,6 @@
 "aYI" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/carpet/black,
-/area/commons/dorms)
-"aYJ" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/stripes/box,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/turf/open/floor/iron/dark,
 /area/commons/dorms)
 "aYK" = (
 /obj/structure/table_frame,
@@ -6192,6 +6260,8 @@
 	c_tag = "Security - EVA Storage";
 	dir = 10
 	},
+/obj/machinery/suit_storage_unit/security,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "aYR" = (
@@ -6286,6 +6356,9 @@
 /obj/machinery/computer/holodeck{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/commons/fitness)
 "aZl" = (
@@ -6353,6 +6426,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "aZG" = (
@@ -6369,9 +6443,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/security/brig)
@@ -6416,7 +6487,8 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aZS" = (
-/obj/machinery/light,
+/obj/machinery/bounty_board/directional/south,
+/obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aZT" = (
@@ -6556,11 +6628,13 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bbq" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/landmark/secequipment,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/modular_computer/console/preset/cargochat/security{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bbt" = (
@@ -6695,6 +6769,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
+/obj/item/flashlight/seclite,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bcv" = (
@@ -6755,12 +6830,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
-"bcV" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/dorms)
 "bcX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -6772,6 +6841,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"bdd" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard/aft)
 "bdj" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Fitness"
@@ -6798,6 +6873,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
+"bdz" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/security/office)
 "bdG" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/cable,
@@ -6828,6 +6909,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "bdO" = (
@@ -6932,6 +7014,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/modular_computer/console/preset/cargochat/medical{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bex" = (
@@ -7002,12 +7087,15 @@
 /area/medical/psychology)
 "beP" = (
 /obj/structure/table/wood,
-/obj/item/toy/plush/slimeplushie,
 /obj/machinery/requests_console{
 	name = "Psychology RC";
 	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/computer/med_data/laptop{
+	dir = 1;
+	pixel_y = 4
+	},
 /turf/open/floor/wood,
 /area/medical/psychology)
 "beV" = (
@@ -7085,12 +7173,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bfH" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	name = "engineering sorting disposal pipe";
-	sortType = 4
-	},
 /obj/structure/cable,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bfL" = (
@@ -7224,6 +7310,16 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"bgU" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Warehouse Maintenance";
+	req_access_txt = "31"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/maintenance/port/aft)
 "bgV" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
@@ -7323,6 +7419,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/engineering/main)
 "bhD" = (
@@ -7344,7 +7441,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "bhL" = (
 /obj/machinery/door/airlock/engineering{
@@ -7354,6 +7451,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "bhR" = (
@@ -7368,7 +7466,9 @@
 	pixel_y = 11
 	},
 /obj/machinery/power/apc/auto_name/west,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/engineering/break_room)
 "bhT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -7386,7 +7486,9 @@
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/engineering/break_room)
 "bhX" = (
 /obj/structure/disposalpipe/segment,
@@ -7400,12 +7502,24 @@
 	dir = 4;
 	network = list("ss13","engine")
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/bounty_board/directional/west,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/engineering/break_room)
 "bih" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
+/area/engineering/main)
+"bij" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
 /area/engineering/main)
 "bim" = (
 /obj/machinery/light{
@@ -7545,6 +7659,13 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/button/door{
+	id = "bathroom2";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	specialfunctions = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "bjn" = (
@@ -7590,6 +7711,7 @@
 /obj/item/assembly/signaler,
 /obj/item/assembly/signaler,
 /obj/machinery/power/apc/auto_name/south,
+/obj/item/assembly/signaler,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "bjA" = (
@@ -7831,6 +7953,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"bkS" = (
+/obj/machinery/computer/cargo/request{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "bkU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -7859,7 +7988,7 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
 /obj/item/assembly/flash/handheld,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "blc" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -7908,6 +8037,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "blq" = (
@@ -7962,6 +8092,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"bmH" = (
+/obj/structure/rack,
+/obj/item/fuel_pellet,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/iron,
+/area/cargo/drone_boy)
 "bmR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8036,13 +8174,20 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "bpd" = (
-/obj/structure/urinal{
-	pixel_y = 32
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/structure/toilet{
+	pixel_y = 8
+	},
+/obj/machinery/button/door{
+	id = "bathroom1";
+	name = "Lock Control";
+	normaldoorcontrol = 1;
+	pixel_x = 24;
+	specialfunctions = 4
+	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "bpf" = (
@@ -8054,6 +8199,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/security/brig)
+"bpE" = (
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "bqb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8074,10 +8223,11 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "bqU" = (
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/urinal/directional/west,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "bqY" = (
@@ -8106,6 +8256,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
+/obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "brg" = (
@@ -8167,6 +8318,7 @@
 /area/service/hydroponics/garden)
 "brH" = (
 /obj/machinery/door/airlock{
+	id_tag = "bathroom1";
 	name = "Unit 1"
 	},
 /turf/open/floor/iron/freezer,
@@ -8192,16 +8344,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/airless,
 /area/medical/virology)
-"brU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/vending/autodrobe/all_access,
-/turf/open/floor/iron/cafeteria,
-/area/commons/dorms)
 "brX" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel Viewing Room"
@@ -8247,7 +8389,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/wood,
 /area/commons/dorms)
 "bsy" = (
 /obj/machinery/firealarm{
@@ -8260,6 +8402,7 @@
 /area/commons/dorms)
 "bsI" = (
 /obj/structure/chair,
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "bsK" = (
@@ -8295,12 +8438,14 @@
 "btv" = (
 /obj/structure/table/wood,
 /obj/effect/landmark/start/hangover,
+/obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "btz" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "btB" = (
@@ -8331,12 +8476,11 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "btN" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/light/directional/south,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron,
 /area/engineering/main)
 "btT" = (
@@ -8352,6 +8496,7 @@
 "bux" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "buH" = (
@@ -8432,6 +8577,14 @@
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"bwg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/engineering/main)
 "bwh" = (
 /obj/structure/cable,
 /obj/machinery/camera{
@@ -8534,7 +8687,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "bzt" = (
 /obj/machinery/door/airlock/maintenance{
@@ -8560,6 +8713,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "bAf" = (
@@ -8734,6 +8888,9 @@
 	},
 /turf/open/floor/iron,
 /area/science/xenobiology)
+"bHS" = (
+/turf/open/floor/iron/smooth,
+/area/cargo/drone_boy)
 "bIa" = (
 /obj/machinery/light{
 	dir = 1
@@ -8783,6 +8940,15 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/commons/storage/art)
+"bJz" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office";
+	req_one_access_txt = "1;4"
+	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "bJA" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/airalarm{
@@ -8798,9 +8964,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/storage/toolbox/mechanical{
-	pixel_x = -2;
 	pixel_y = -1
 	},
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "bJY" = (
@@ -8811,6 +8977,7 @@
 /area/commons/toilet)
 "bKk" = (
 /obj/machinery/door/airlock{
+	id_tag = "bathroom2";
 	name = "Unit 2"
 	},
 /turf/open/floor/iron/freezer,
@@ -8823,8 +8990,26 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/urinal/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"bKq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/machinery/bounty_board/directional/west,
+/turf/open/floor/iron,
+/area/service/hydroponics/garden)
 "bKt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
@@ -8846,6 +9031,7 @@
 "bLd" = (
 /obj/item/soap/deluxe,
 /obj/item/bikehorn/rubberducky,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "bMD" = (
@@ -8994,6 +9180,7 @@
 /obj/machinery/microwave{
 	pixel_y = 4
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bSQ" = (
@@ -9027,6 +9214,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "bTW" = (
@@ -9034,6 +9222,18 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"bUl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd2";
+	name = "research lab shutters"
+	},
+/obj/machinery/bounty_board/directional/west,
+/turf/open/floor/iron/white,
+/area/science/research)
 "bUm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -9043,8 +9243,9 @@
 	},
 /area/maintenance/port/aft)
 "bUD" = (
-/obj/structure/tank_dispenser/oxygen,
 /obj/machinery/light,
+/obj/machinery/suit_storage_unit/security,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "bUU" = (
@@ -9070,6 +9271,18 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
+"bWb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/engineering/atmos)
+"bWe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "bWA" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -9079,6 +9292,9 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "bWS" = (
@@ -9190,6 +9406,11 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"caA" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/bundle/hobo_squat,
+/turf/open/floor/wood,
+/area/maintenance/starboard/aft)
 "caO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
@@ -9238,6 +9459,13 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24
+	},
+/obj/structure/table,
+/obj/machinery/firealarm/directional/north,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = -1;
+	pixel_y = -3
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -9332,6 +9560,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/command)
 "cdD" = (
@@ -9388,6 +9617,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "ceX" = (
@@ -9439,6 +9669,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "cgp" = (
@@ -9499,10 +9732,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
 "cgS" = (
-/obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/duct,
+/obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "chj" = (
@@ -9514,10 +9748,20 @@
 /area/command/gateway)
 "chl" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_large,
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
 /area/engineering/main)
+"cil" = (
+/obj/machinery/light/warm/directional/east,
+/obj/structure/sign/poster/official/no_erp{
+	pixel_x = 32
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "cir" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -9700,6 +9944,12 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/iron,
 /area/medical/exam_room)
+"cnA" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/science/lab)
 "cof" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -9737,9 +9987,9 @@
 /area/maintenance/starboard)
 "csh" = (
 /obj/machinery/conveyor{
-	dir = 8;
-	id = "Cargo Belt";
-	name = "Cargo Belt 2"
+	dir = 10;
+	id = "cargodelivery2";
+	name = "Cargo Belt"
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
@@ -9946,18 +10196,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"cyQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "czj" = (
 /obj/structure/cable,
 /obj/structure/chair/office,
@@ -10010,6 +10248,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"cAK" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "cAP" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Xenobiology Maintenance";
@@ -10026,6 +10270,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
+"cBK" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "cBO" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -10048,6 +10296,7 @@
 	req_access_txt = "41"
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "cCs" = (
@@ -10058,6 +10307,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "cDu" = (
@@ -10085,6 +10335,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/sign/poster/ripped{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cEi" = (
@@ -10117,6 +10370,14 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"cGr" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "cGO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -10135,11 +10396,18 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "cHu" = (
-/obj/structure/closet/radiation,
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 2
+	},
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
 /area/engineering/main)
 "cIR" = (
 /obj/structure/chair/pew/left{
@@ -10180,16 +10448,6 @@
 /obj/item/storage/box/prisoner,
 /turf/open/floor/iron,
 /area/security/prison)
-"cKN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/engineering/main)
 "cKZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
@@ -10333,6 +10591,7 @@
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
 "cQB" = (
@@ -10353,11 +10612,22 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
-"cQM" = (
-/obj/machinery/light/directional/south,
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/wood/tile,
-/area/service/library)
+"cQK" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
 "cQP" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Fitness"
@@ -10506,7 +10776,8 @@
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "cUt" = (
-/obj/structure/closet/secure_closet/engineering_personal,
+/obj/structure/closet/radiation,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/engineering/main)
 "cUu" = (
@@ -10541,6 +10812,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cVR" = (
@@ -10617,6 +10889,11 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"cYg" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "cYp" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -10667,6 +10944,8 @@
 	pixel_y = 6
 	},
 /obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "das" = (
@@ -10758,7 +11037,7 @@
 /obj/structure/table,
 /obj/item/paper/guides/jobs/engi/gravity_gen,
 /obj/item/pen/blue,
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured_half,
 /area/engineering/gravity_generator)
 "dcp" = (
 /obj/machinery/processor,
@@ -10879,6 +11158,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "dfb" = (
@@ -10998,6 +11278,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dii" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron,
+/area/security/brig)
 "diO" = (
 /obj/structure/sink{
 	dir = 8;
@@ -11018,6 +11308,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/maintenance/starboard)
+"djN" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "djP" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -11097,6 +11393,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"dmq" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "dmt" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/iron/dark,
@@ -11127,6 +11435,7 @@
 	},
 /obj/item/radio/off,
 /obj/item/paper/pamphlet/gateway,
+/obj/item/crowbar,
 /turf/open/floor/iron/dark,
 /area/command/gateway)
 "dmW" = (
@@ -11173,6 +11482,7 @@
 /area/maintenance/disposal)
 "doY" = (
 /obj/structure/closet/secure_closet/atmospherics,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "dpz" = (
@@ -11190,18 +11500,6 @@
 /obj/effect/landmark/start/captain,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"dpX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "dqJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -11266,6 +11564,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/wood,
 /area/service/bar)
 "drZ" = (
@@ -11391,8 +11690,15 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/command/heads_quarters/ce)
+"dvj" = (
+/obj/item/radio/intercom/directional/east,
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/iron,
+/area/cargo/drone_boy)
 "dvT" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Telecomms and AI";
@@ -11447,9 +11753,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/structure/closet/emcloset{
-	anchored = 1
-	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "dwA" = (
@@ -11512,6 +11816,7 @@
 	dir = 4
 	},
 /obj/item/pen,
+/obj/item/crowbar,
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "dxC" = (
@@ -11565,6 +11870,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
 "dze" = (
@@ -11831,8 +12137,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dDP" = (
@@ -11939,6 +12243,8 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/structure/table/glass,
+/obj/item/experi_scanner,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "dFV" = (
@@ -12023,7 +12329,7 @@
 "dIV" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/large,
 /area/command)
 "dJa" = (
 /obj/structure/closet/emcloset{
@@ -12055,6 +12361,10 @@
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Loop to Freezers"
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "dKw" = (
@@ -12196,13 +12506,13 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "dMc" = (
-/obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
 	name = "Cargo Bay RC";
 	pixel_y = 30
 	},
+/obj/structure/table,
 /obj/item/clipboard,
 /obj/item/paper_bin,
 /obj/item/pen/red,
@@ -12232,12 +12542,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/effect/landmark/start/head_of_security,
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/office)
 "dME" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "dML" = (
@@ -12367,6 +12676,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "dPh" = (
@@ -12461,6 +12771,8 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargodelivery2"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "dRA" = (
@@ -12539,6 +12851,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"dTx" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "dUr" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_candy,
@@ -12546,9 +12862,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dUu" = (
-/obj/structure/closet/emcloset{
-	anchored = 1
-	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dUI" = (
@@ -12559,6 +12873,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "dVp" = (
@@ -12593,6 +12908,11 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"dVD" = (
+/obj/structure/cable,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dVG" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Escape Airlock";
@@ -12609,12 +12929,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dWa" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/security/sec,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "dWq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"dWv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/engine_smes)
 "dWD" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -12654,6 +12988,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard/aft)
+"dYb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/office/light,
+/turf/open/floor/iron,
+/area/engineering/gravity_generator)
 "dYg" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -12731,16 +13071,16 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "eac" = (
-/obj/machinery/computer/atmos_alert{
-	dir = 1
-	},
 /obj/machinery/requests_console{
 	department = "Engineering";
 	departmentType = 3;
 	name = "Engineering RC";
 	pixel_y = -30
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/modular_computer/console/preset/cargochat/engineering{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "eai" = (
 /obj/effect/turf_decal/tile/purple{
@@ -12757,6 +13097,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/table/glass,
+/obj/item/experi_scanner,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "eaj" = (
@@ -12767,6 +13109,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"eaG" = (
+/obj/machinery/holopad,
+/turf/open/floor/iron/large,
+/area/engineering/main)
 "eaJ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/purple{
@@ -12832,6 +13178,7 @@
 "edi" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
+/obj/item/crowbar,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -12859,6 +13206,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eeo" = (
@@ -12874,6 +13228,11 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
+"eeS" = (
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "eeY" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -12889,6 +13248,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/structure/chair{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
@@ -12993,6 +13355,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "ejv" = (
@@ -13068,6 +13431,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/bounty_board/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "enk" = (
@@ -13153,6 +13517,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "eqS" = (
@@ -13276,6 +13641,11 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
+"etH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "eui" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass{
@@ -13383,16 +13753,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
-"evw" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Warehouse Maintenance";
-	req_access_txt = "31"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"evz" = (
+/obj/structure/chair,
+/obj/structure/window,
 /turf/open/floor/iron,
-/area/maintenance/port/aft)
+/area/security/courtroom)
 "evM" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -13486,6 +13851,7 @@
 /area/medical/medbay/central)
 "ezE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/main)
 "ezH" = (
@@ -13559,6 +13925,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"eAI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/science/explab)
 "eBc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue{
@@ -13572,11 +13942,15 @@
 /area/hallway/primary/fore)
 "eBg" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/closet/emcloset{
-	anchored = 1
-	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"eBi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/trashcart/filled,
+/obj/effect/spawner/lootdrop/maint_drugs,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "eBv" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/window/southleft{
@@ -13588,14 +13962,14 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "eBB" = (
-/obj/machinery/computer/station_alert{
-	dir = 1
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/computer/cargo/request{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "eBT" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -13692,6 +14066,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"eEl" = (
+/obj/machinery/photocopier,
+/turf/open/floor/iron,
+/area/cargo/office)
 "eEE" = (
 /obj/structure/chair{
 	dir = 1
@@ -13757,6 +14135,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
+	},
+/obj/structure/showcase/cyborg/old{
+	pixel_y = 17
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -13923,6 +14304,13 @@
 	dir = 8
 	},
 /obj/structure/table,
+/obj/item/clothing/gloves/cargo_gauntlet{
+	pixel_y = -3
+	},
+/obj/item/clothing/gloves/cargo_gauntlet,
+/obj/item/clothing/gloves/cargo_gauntlet{
+	pixel_y = 3
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "eNb" = (
@@ -13931,6 +14319,7 @@
 	dir = 4
 	},
 /obj/structure/microscope,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "eNh" = (
@@ -13979,6 +14368,7 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "ePD" = (
@@ -14032,6 +14422,7 @@
 "eQR" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/four,
+/obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "eQS" = (
@@ -14145,6 +14536,7 @@
 /area/maintenance/solars/port/fore)
 "eUg" = (
 /obj/item/book/random,
+/obj/item/crowbar,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "eUk" = (
@@ -14357,11 +14749,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"fbo" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/service/library)
 "fbI" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -14375,6 +14762,18 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
+"fch" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "qm_warehouse";
+	name = "warehouse shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "fco" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14455,6 +14854,36 @@
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/iron/grimy,
 /area/security/prison)
+"fdw" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/bounty_board/directional/north,
+/turf/open/floor/iron,
+/area/engineering/main)
+"fdD" = (
+/obj/structure/table,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/obj/item/pushbroom,
+/obj/item/radio{
+	desc = "An old handheld radio. You could use it, if you really wanted to.";
+	icon_state = "radio";
+	name = "old radio";
+	pixel_y = 7
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fdK" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -14533,6 +14962,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"feW" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/commons/dorms)
+"ffH" = (
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/cargo/drone_boy)
 "ffN" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -14551,8 +14990,19 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"fgB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/peppertank/directional/north,
+/turf/open/floor/iron,
+/area/security/brig)
 "fgQ" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fgY" = (
@@ -14561,6 +15011,14 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
+"fhd" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 8
+	},
+/area/cargo/drone_boy)
 "fhg" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -14610,7 +15068,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/security/execution/education)
 "fhB" = (
 /obj/structure/window/reinforced,
@@ -14703,12 +15163,25 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/iron,
 /area/science/storage)
+"fjg" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/security/warden)
 "fjm" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/bounty_board/directional/north,
 /turf/open/floor/iron,
 /area/command)
 "fjt" = (
@@ -14746,6 +15219,10 @@
 "fjO" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
 /turf/open/floor/plating,
 /area/engineering/storage/tech)
 "fjP" = (
@@ -14853,11 +15330,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "fnb" = (
 /obj/structure/bed,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/execution/education)
 "fng" = (
 /obj/structure/chair/sofa/right,
@@ -14891,6 +15369,7 @@
 "foq" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/maint_drugs,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "foE" = (
@@ -14905,8 +15384,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "foP" = (
@@ -14917,6 +15394,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"foU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/security/brig)
 "fpc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -14964,6 +15455,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"fqT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/engine,
+/area/engineering/main)
 "fri" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -15020,6 +15517,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
+"fsX" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/large,
+/area/engineering/main)
 "ftA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -15076,6 +15578,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/science/nanite)
+"fuI" = (
+/obj/structure/cable,
+/obj/effect/loot_site_spawner,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fuO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -15090,6 +15597,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/engineering/main)
 "fuX" = (
@@ -15098,6 +15606,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"fve" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "fvi" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -15218,6 +15734,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"fxT" = (
+/obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/showroomfloor,
+/area/tcommsat/computer)
 "fxU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -15243,12 +15766,17 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/modular_computer/console/preset/cargochat/cargo,
 /turf/open/floor/iron,
 /area/cargo/office)
 "fye" = (
 /obj/structure/table,
-/obj/machinery/light,
-/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser{
+	pixel_y = 6
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = -2
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "fyr" = (
@@ -15380,6 +15908,7 @@
 "fBW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/five,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/iron,
 /area/maintenance/central)
 "fCn" = (
@@ -15454,6 +15983,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/wood,
 /area/service/bar)
 "fFC" = (
@@ -15465,6 +15995,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
+"fGy" = (
+/obj/effect/spawner/lootdrop/maintenance_carpet,
+/obj/effect/spawner/lootdrop/maintenance_carpet,
+/obj/structure/closet/crate/wooden,
+/obj/effect/spawner/lootdrop/maintenance_carpet,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "fGK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -15484,6 +16021,13 @@
 /obj/item/reagent_containers/pill/patch/aiuri,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
+"fHL" = (
+/obj/machinery/duct,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/black,
+/area/commons/dorms)
 "fHM" = (
 /obj/machinery/button/door{
 	id = "xenobio7";
@@ -15577,7 +16121,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/engine,
 /area/engineering/main)
 "fLF" = (
@@ -15596,6 +16139,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"fLG" = (
+/obj/structure/closet/secure_closet/atmospherics,
+/obj/item/grenade/chem_grenade/smart_metal_foam,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/engineering/atmos)
 "fMo" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/brown{
@@ -15706,11 +16256,12 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "fPF" = (
-/obj/effect/landmark/start/station_engineer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
 /area/engineering/main)
 "fPI" = (
 /obj/structure/cable,
@@ -15737,8 +16288,8 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
 "fQu" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/structure/closet/firecloset{
+	anchored = 1
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
@@ -15752,6 +16303,7 @@
 "fRs" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/minor/beret_or_rabbitears,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fRw" = (
@@ -15803,6 +16355,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/newscaster/security_unit/directional/west,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "fSL" = (
@@ -15812,7 +16365,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/engineering/storage/tech)
 "fSP" = (
 /obj/structure/disposalpipe/segment,
@@ -15826,12 +16379,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "fTj" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
+/obj/machinery/light/warm/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
 "fTr" = (
@@ -15854,9 +16405,13 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "fUj" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/computer/exodrone_control_console{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/edge,
+/area/cargo/drone_boy)
 "fUR" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Fore Starboard";
@@ -15902,6 +16457,13 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"fVR" = (
+/obj/structure/cable,
+/obj/structure/closet/crate/trashcart/filled,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/fore)
 "fVV" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating{
@@ -15940,6 +16502,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"fWB" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "fWC" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -15952,6 +16519,18 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"fWJ" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/start/cyborg,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/storage/satellite)
+"fWK" = (
+/obj/machinery/light/warm/directional/east,
+/turf/open/floor/wood,
+/area/service/library)
 "fWR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16001,6 +16580,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"fXr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "fXy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16019,6 +16604,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "fYi" = (
@@ -16126,14 +16714,14 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"gaE" = (
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plating,
+/area/engineering/main)
 "gaU" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"gbh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/warden)
 "gbr" = (
 /obj/structure/rack,
 /obj/item/aicard,
@@ -16233,6 +16821,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
+"ger" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "get" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16270,18 +16869,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
-"gfa" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gft" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -16289,6 +16876,10 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron,
 /area/engineering/main)
 "gfP" = (
@@ -16355,22 +16946,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ghJ" = (
-/obj/machinery/requests_console{
-	department = "Atmospherics";
-	departmentType = 3;
-	name = "Atmos RC";
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/rack,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "ghX" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -16400,7 +16979,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/half,
 /area/science/robotics/mechbay)
 "gjo" = (
 /obj/machinery/air_sensor/atmos/toxin_tank,
@@ -16573,19 +17152,28 @@
 	id = "rnd";
 	name = "Shutters Control Button";
 	pixel_x = -6;
-	pixel_y = -24;
+	pixel_y = -30;
 	req_access_txt = "47"
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/science/lab)
+"goW" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/bounty_board/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "gpl" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ai_monitored/command/storage/eva)
 "gpP" = (
-/turf/closed/wall,
+/obj/machinery/conveyor{
+	id = "cargodelivery2";
+	name = "Cargo Belt"
+	},
+/turf/open/floor/iron/dark,
 /area/cargo/storage)
 "gpV" = (
 /obj/effect/turf_decal/bot,
@@ -16595,6 +17183,7 @@
 	dir = 4;
 	network = list("ss13","prison")
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "gqf" = (
@@ -16645,19 +17234,6 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
-"grI" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/main)
 "grK" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/computer/nanite_chamber_control{
@@ -16665,6 +17241,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/nanite)
+"grL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2;
+	name = "qm sorting disposal pipe";
+	sortType = 3
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gtj" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -16693,6 +17279,7 @@
 /obj/item/stack/spacecash/c200,
 /obj/item/stack/spacecash/c20,
 /obj/machinery/light,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "gts" = (
@@ -16731,6 +17318,9 @@
 	pixel_y = 3
 	},
 /obj/item/book/manual/wiki/engineering_singulo_tesla,
+/obj/item/radio/off{
+	pixel_x = 6
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "guc" = (
@@ -16867,6 +17457,7 @@
 /obj/structure/window/plasma/reinforced,
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "gxw" = (
@@ -16888,6 +17479,10 @@
 	pixel_x = -1;
 	pixel_y = -24;
 	req_access_txt = "31"
+	},
+/obj/item/clothing/shoes/wheelys/rollerskates,
+/obj/item/clothing/shoes/wheelys/rollerskates{
+	pixel_y = 5
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -16967,6 +17562,14 @@
 /obj/item/flashlight/seclite,
 /obj/item/storage/box/firingpins,
 /obj/item/storage/box/firingpins,
+/obj/item/clothing/glasses/hud/security/sunglasses{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/clothing/glasses/hud/security/sunglasses{
+	pixel_x = -3;
+	pixel_y = 2
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
 "gzu" = (
@@ -17101,6 +17704,7 @@
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
+/obj/structure/window,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "gEt" = (
@@ -17142,14 +17746,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/stack/sheet/iron/fifty,
 /obj/item/book/manual/wiki/research_and_development,
 /obj/item/paicard,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/machinery/bounty_board/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "gFZ" = (
@@ -17170,10 +17772,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/window,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "gGu" = (
-/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "gGI" = (
@@ -17230,12 +17834,12 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "gIl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/conveyor_switch/oneway{
 	id = "Cargo Belt";
 	name = "CargoLoading"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -17252,15 +17856,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
-"gID" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
-"gJv" = (
-/obj/machinery/ore_silo,
-/turf/open/floor/vault,
-/area/ai_monitored/command/nuke_storage)
 "gJw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -17269,7 +17864,7 @@
 /area/science/storage)
 "gJK" = (
 /obj/machinery/suit_storage_unit/ce,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "gKa" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -17282,6 +17877,15 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
+"gKd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gKI" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable,
@@ -17315,15 +17919,6 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"gLx" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/security/brig)
 "gLT" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -17335,8 +17930,9 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "gMq" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance/three,
+/obj/structure/chair/plastic{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "gMI" = (
@@ -17374,8 +17970,17 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"gOm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/security/office)
 "gOn" = (
 /obj/item/kirbyplants/random,
 /obj/structure/sign/poster/official/random{
@@ -17388,6 +17993,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/window,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "gPg" = (
@@ -17399,6 +18005,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
+/obj/structure/window,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "gPL" = (
@@ -17508,6 +18115,9 @@
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/space/basic,
 /area/engineering/atmos)
 "gSu" = (
@@ -17647,6 +18257,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"gUA" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
 "gUG" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -17676,7 +18298,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "gVQ" = (
 /obj/structure/cable,
@@ -17711,6 +18333,10 @@
 	pixel_y = 32
 	},
 /obj/item/book/manual/wiki/atmospherics,
+/obj/item/t_scanner,
+/obj/structure/sign/poster/official/safety_internals{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "gXl" = (
@@ -17842,15 +18468,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"haH" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth_half{
-	dir = 4
-	},
-/area/engineering/main)
 "haO" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Firefighting Equipment";
@@ -17887,6 +18504,12 @@
 /obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engineering/main)
+"hbZ" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "hci" = (
 /obj/structure/table,
 /obj/machinery/door/window/eastright{
@@ -17900,6 +18523,11 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "pharmecyshutters"
 	},
+/obj/item/reagent_containers/glass/bottle/multiver,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/syringe,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "hcN" = (
@@ -17979,10 +18607,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"hfJ" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/iron,
-/area/engineering/main)
 "hfN" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/blue{
@@ -18022,6 +18646,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "hhi" = (
@@ -18032,6 +18657,7 @@
 	pixel_x = 29
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/toy/plush/slimeplushie,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "hhu" = (
@@ -18060,6 +18686,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron,
 /area/command)
 "hhU" = (
@@ -18069,6 +18696,10 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "hid" = (
@@ -18121,6 +18752,7 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "hjK" = (
@@ -18180,22 +18812,11 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/captain)
 "hlP" = (
-/obj/structure/table,
-/obj/item/dest_tagger,
-/obj/item/hand_labeler{
-	pixel_y = 8
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/requests_console{
-	department = "Cargo Bay";
-	departmentType = 2;
-	name = "Cargo Bay RC";
-	pixel_x = -30
-	},
-/turf/open/floor/iron,
+/turf/closed/wall,
 /area/cargo/sorting)
 "hlR" = (
 /obj/item/trash/raisins,
@@ -18232,10 +18853,9 @@
 /area/security/prison)
 "hmI" = (
 /obj/structure/table,
-/obj/item/reagent_containers/dropper,
 /obj/machinery/recharger{
-	pixel_x = 4;
-	pixel_y = 8
+	pixel_x = 5;
+	pixel_y = 3
 	},
 /turf/open/floor/iron/dark,
 /area/science/lab)
@@ -18260,11 +18880,13 @@
 	pixel_y = 20
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "hnF" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/table,
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "hnG" = (
@@ -18288,6 +18910,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "hou" = (
@@ -18360,6 +18983,9 @@
 /obj/machinery/camera{
 	c_tag = "Escape Sec Checkpoint"
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
 "hqF" = (
@@ -18428,6 +19054,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/cargo/office)
 "htz" = (
@@ -18541,6 +19168,17 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"hwI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark/smooth_half,
+/area/security/office)
 "hwL" = (
 /turf/closed/wall/r_wall,
 /area/science/research)
@@ -18556,6 +19194,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/bounty_board/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "hxs" = (
@@ -18577,6 +19216,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/science/explab)
+"hyd" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "hyg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -18593,6 +19237,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"hze" = (
+/obj/machinery/bounty_board/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "hzP" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
@@ -18622,7 +19270,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/command/heads_quarters/ce)
 "hAK" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
@@ -18738,17 +19388,17 @@
 /turf/open/floor/iron,
 /area/command)
 "hDu" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
+"hEh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hEx" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -18811,6 +19461,11 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
+"hGk" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "hGr" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/requests_console{
@@ -18863,11 +19518,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hHv" = (
-/obj/structure/cable,
+/obj/effect/landmark/start/librarian,
 /turf/open/floor/wood/large,
 /area/service/library)
 "hHw" = (
 /obj/machinery/telecomms/processor/preset_four,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "hHQ" = (
@@ -18917,6 +19573,10 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
+"hJJ" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "hJP" = (
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -18981,6 +19641,7 @@
 	},
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "hLt" = (
@@ -19015,6 +19676,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
 "hMX" = (
@@ -19146,6 +19808,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "hTE" = (
@@ -19169,6 +19832,19 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"hUx" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
 "hUH" = (
 /obj/machinery/atmospherics/miner/n2o,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -19214,6 +19890,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/range)
+"hWw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/engine,
+/area/engineering/main)
 "hWE" = (
 /obj/structure/window{
 	dir = 1
@@ -19234,6 +19917,9 @@
 	},
 /obj/machinery/camera{
 	c_tag = "East Hallway - Sec"
+	},
+/obj/structure/chair{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -19262,16 +19948,20 @@
 /area/space/nearstation)
 "hXX" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 9
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "hYd" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/area/maintenance/port/aft)
+/obj/machinery/status_display/supply{
+	pixel_y = 30
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "hYH" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -19292,6 +19982,7 @@
 	pixel_x = -10;
 	pixel_y = -22
 	},
+/obj/machinery/light/warm/directional/south,
 /turf/open/floor/wood/large,
 /area/service/library)
 "hZL" = (
@@ -19475,6 +20166,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ifc" = (
@@ -19645,6 +20337,7 @@
 /obj/item/paper_bin{
 	pixel_y = 3
 	},
+/obj/item/crowbar,
 /turf/open/floor/carpet/royalblue,
 /area/command)
 "ilZ" = (
@@ -19681,12 +20374,20 @@
 /obj/item/pipe_dispenser,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"imH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/main)
 "imL" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Laundry"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "imN" = (
@@ -19765,6 +20466,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"ipf" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "ipn" = (
 /obj/structure/bookcase/random/reference,
 /obj/machinery/camera{
@@ -20028,11 +20736,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
-"iwq" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet,
-/turf/open/floor/iron,
-/area/engineering/main)
 "iwr" = (
 /obj/structure/chair{
 	dir = 4
@@ -20062,6 +20765,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/main)
 "iwW" = (
@@ -20138,15 +20842,11 @@
 /turf/open/floor/iron,
 /area/command)
 "izR" = (
-/obj/machinery/button/door{
-	id = "SupermatterExternal";
-	name = "Shutters Control";
-	pixel_y = 24;
-	req_access_txt = "11"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/light/directional/north,
+/obj/machinery/bounty_board/directional/north,
 /turf/open/floor/iron,
 /area/engineering/main)
 "izW" = (
@@ -20217,6 +20917,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"iDa" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "iDj" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20269,7 +20984,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "iFa" = (
-/obj/effect/landmark/start/station_engineer,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/engineering/main)
 "iFd" = (
@@ -20280,16 +20995,41 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/command)
+"iId" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "iIf" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"iIG" = (
+/obj/machinery/duct,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "iIJ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Equipment Room";
+	req_access_txt = "11"
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
 /area/engineering/main)
 "iJd" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -20297,14 +21037,6 @@
 /area/engineering/atmos)
 "iJf" = (
 /obj/structure/table,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/clothing/ears/earmuffs{
 	pixel_x = -3;
 	pixel_y = -2
@@ -20320,8 +21052,21 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/item/hand_labeler{
+	pixel_y = 8
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"iJh" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/loot_site_spawner,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "iJy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -20461,6 +21206,7 @@
 /area/service/library)
 "iNx" = (
 /obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers,
 /turf/open/space/basic,
 /area/maintenance/disposal/incinerator)
 "iNF" = (
@@ -20478,6 +21224,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
+"iNY" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "iOh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
@@ -20498,6 +21256,14 @@
 "iOP" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
+"iOT" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/bounty_board/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "iPn" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -20574,6 +21340,7 @@
 /obj/structure/table/wood,
 /obj/item/folder/yellow,
 /obj/item/pen,
+/obj/item/camera,
 /turf/open/floor/wood/large,
 /area/service/library)
 "iRr" = (
@@ -20597,8 +21364,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iSn" = (
@@ -20650,6 +21415,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"iTS" = (
+/obj/effect/spawner/lootdrop/crate_spawner,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iUd" = (
 /obj/structure/plasticflaps/opaque,
 /obj/effect/turf_decal/delivery,
@@ -20662,11 +21432,13 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "iUe" = (
-/obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "iUh" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
@@ -20931,8 +21703,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"jav" = (
+/obj/structure/sign/warning{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/open/floor/iron/smooth,
+/area/cargo/drone_boy)
 "jaR" = (
-/obj/structure/filingcabinet/medical,
+/obj/machinery/ore_silo,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "jbn" = (
@@ -20954,6 +21734,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"jbC" = (
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "jbF" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -20967,8 +21751,8 @@
 /area/hallway/primary/starboard)
 "jbL" = (
 /obj/structure/table/reinforced,
-/obj/item/folder/red,
 /obj/item/storage/secure/briefcase,
+/obj/item/crowbar,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "jbR" = (
@@ -21105,14 +21889,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/structure/showcase/cyborg/old{
+	pixel_y = 17
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"jhE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Freezer Bypass"
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "jhM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -21175,6 +21956,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "jjB" = (
@@ -21284,6 +22066,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"jne" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jnC" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
@@ -21355,6 +22145,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/modular_computer/console/preset/cargochat/science{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "jqG" = (
@@ -21368,6 +22161,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"jrE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/light/directional/south,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "jrJ" = (
 /obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom{
@@ -21409,6 +22210,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
+/obj/item/crowbar,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "jtk" = (
@@ -21448,6 +22250,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
+"jtG" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/cargo/drone_boy)
 "jtJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -21518,6 +22328,9 @@
 "jvd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "jvy" = (
@@ -21536,7 +22349,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
 /area/engineering/main)
 "jvA" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -21607,6 +22422,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
 "jyS" = (
@@ -21621,6 +22438,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"jzd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/medical,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "jzk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -21633,6 +22457,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
+"jzs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/iron/edge,
+/area/cargo/drone_boy)
 "jzy" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/brown,
@@ -21690,8 +22520,6 @@
 	name = "warehouse shutters"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "jAG" = (
@@ -21711,7 +22539,7 @@
 /obj/machinery/computer/security/telescreen/ce{
 	pixel_y = 28
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "jAT" = (
 /obj/structure/window{
@@ -21767,13 +22595,13 @@
 /area/service/bar)
 "jCe" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/secure_closet/security/sec,
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "jCj" = (
@@ -21811,7 +22639,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "jEw" = (
 /obj/machinery/computer/telecomms/monitor,
@@ -21826,16 +22654,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"jEP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Freezers to Loop"
-	},
-/turf/open/floor/engine,
-/area/engineering/main)
 "jFn" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
@@ -21893,9 +22711,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet/emcloset{
-	anchored = 1
-	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "jGM" = (
@@ -21917,6 +22733,8 @@
 "jHw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
 "jHD" = (
@@ -21936,6 +22754,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/fore)
+"jHO" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/wood,
+/area/service/bar)
 "jIE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -22065,6 +22890,10 @@
 /obj/item/stack/license_plates/empty/fifty,
 /turf/open/floor/plating,
 /area/security/prison/safe)
+"jMZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/tcommsat/computer)
 "jNn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -22097,6 +22926,10 @@
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/security/courtroom)
@@ -22137,6 +22970,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"jQl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/cargo/drone_boy)
 "jQE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -22145,6 +22982,11 @@
 	name = "black plastitanium floor"
 	},
 /area/service/bar)
+"jQG" = (
+/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/obj/effect/spawner/lootdrop/maint_drugs,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jQH" = (
 /obj/machinery/pdapainter,
 /obj/machinery/keycard_auth{
@@ -22157,12 +22999,6 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
-"jRu" = (
-/obj/structure/cable,
-/obj/effect/spawner/lootdrop/maintenance/three,
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "jRI" = (
 /obj/structure/sink{
 	dir = 4;
@@ -22178,6 +23014,9 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
+"jSi" = (
+/turf/closed/wall,
+/area/commons/cryopods)
 "jSp" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /obj/effect/turf_decal/tile/yellow{
@@ -22329,6 +23168,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "jVV" = (
@@ -22345,7 +23187,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/command/gateway)
 "jWx" = (
 /obj/machinery/door/window/northleft{
@@ -22373,6 +23217,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"jXO" = (
+/obj/structure/cable,
+/obj/structure/cable/layer3,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/command/storage/satellite)
 "jXT" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -22417,6 +23269,7 @@
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "jYL" = (
@@ -22517,6 +23370,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"kdl" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "kdz" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -22544,6 +23401,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "keU" = (
@@ -22588,7 +23447,7 @@
 /area/hallway/secondary/entry)
 "kga" = (
 /obj/effect/decal/cleanable/generic,
-/obj/structure/moisture_trap,
+/obj/effect/spawner/bundle/moisture_trap,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "kgG" = (
@@ -22605,7 +23464,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/start/station_engineer,
+/obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
 "kgY" = (
@@ -22676,7 +23535,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "kiF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22776,6 +23635,7 @@
 "kkt" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
 "kkz" = (
@@ -22789,6 +23649,13 @@
 "klb" = (
 /obj/structure/reflector/single/anchored{
 	dir = 9
+	},
+/obj/machinery/button/door{
+	id = "SupermatterExternal";
+	name = "Shutters Control";
+	pixel_x = 24;
+	pixel_y = null;
+	req_access_txt = "11"
 	},
 /turf/open/floor/plating,
 /area/engineering/main)
@@ -22926,11 +23793,13 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "koC" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/checker,
 /area/science/robotics/lab)
 "koO" = (
 /obj/structure/cable,
-/obj/structure/closet/crate/solarpanel_small,
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/belt/utility,
 /turf/open/floor/iron,
 /area/engineering/main)
 "kpz" = (
@@ -22946,6 +23815,8 @@
 /obj/item/stock_parts/capacitor,
 /obj/item/stock_parts/capacitor,
 /obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "kqd" = (
@@ -22955,6 +23826,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
+"kqh" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/dark,
+/area/engineering/main)
 "kqr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23032,7 +23907,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_half{
-	dir = 1
+	dir = 4
 	},
 /area/engineering/main)
 "ksd" = (
@@ -23050,6 +23925,9 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
+	},
+/obj/machinery/computer/cargo/request{
+	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
@@ -23105,6 +23983,9 @@
 "ktb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/office{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "ktq" = (
@@ -23148,10 +24029,10 @@
 /turf/open/floor/iron/grimy,
 /area/commons/vacant_room/office)
 "kvM" = (
-/obj/structure/closet/emcloset,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "kwa" = (
@@ -23176,6 +24057,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
+"kwm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "kws" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -23220,7 +24113,9 @@
 /area/science/lab)
 "kxW" = (
 /obj/effect/landmark/start/roboticist,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/science/robotics/lab)
 "kxY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -23281,6 +24176,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
+"kyY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/lootdrop/garbage_spawner,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kzh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23386,7 +24286,6 @@
 /area/service/library)
 "kDr" = (
 /obj/structure/closet/emcloset/anchored,
-/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "kDD" = (
@@ -23478,6 +24377,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/engineering/main)
 "kFX" = (
@@ -23531,6 +24431,16 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"kGC" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
 "kGJ" = (
 /turf/closed/wall/r_wall,
 /area/science/genetics)
@@ -23549,12 +24459,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kHB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance_carpet,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "kHC" = (
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
 	},
 /obj/item/surgical_drapes,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/science/robotics/lab)
 "kHI" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -23566,6 +24482,7 @@
 	name = "Secure Documents Cabinet"
 	},
 /obj/item/folder/documents,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "kIa" = (
@@ -23711,6 +24628,8 @@
 /area/maintenance/disposal/incinerator)
 "kKY" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/cigbutt,
+/obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -23863,6 +24782,17 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
+"kOK" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/bounty_board/directional/east,
+/turf/open/floor/iron,
+/area/security/brig)
 "kPn" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -23889,12 +24819,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"kQf" = (
-/obj/structure/moisture_trap,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard/aft)
 "kQw" = (
 /obj/machinery/light{
 	dir = 8
@@ -23940,6 +24864,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "kSV" = (
@@ -24008,6 +24933,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/courtroom)
 "kVz" = (
@@ -24026,7 +24955,7 @@
 "kVM" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "kWh" = (
 /obj/machinery/light{
@@ -24095,6 +25024,7 @@
 /obj/item/paper_bin{
 	pixel_y = 4
 	},
+/obj/item/storage/box/lights/mixed,
 /obj/item/paicard,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
@@ -24231,6 +25161,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/blue,
 /area/service/library)
 "lfS" = (
@@ -24309,13 +25240,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
-"lgW" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/iron/dark,
-/area/engineering/main)
 "lhF" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -24337,6 +25261,7 @@
 "lid" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small,
+/obj/structure/closet/crate,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "lie" = (
@@ -24345,6 +25270,17 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/security/detectives_office)
+"liH" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron,
+/area/security/brig)
 "liK" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -24429,10 +25365,19 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/qm)
+"lky" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engineering/main)
 "lkE" = (
 /obj/structure/closet/crate/bin,
+/obj/machinery/bounty_board/directional/north,
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/starboard)
 "lkI" = (
@@ -24471,6 +25416,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
+"llp" = (
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "lly" = (
 /obj/structure/chair{
 	dir = 4
@@ -24503,17 +25453,6 @@
 /obj/machinery/door/window/southleft,
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"lmt" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	name = "qm sorting disposal pipe";
-	sortType = 3
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "lmy" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay";
@@ -24573,7 +25512,7 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "lou" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24601,6 +25540,19 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/white,
 /area/science/research)
+"loM" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/engineering,
+/turf/open/floor/iron,
+/area/engineering/main)
 "loU" = (
 /turf/open/floor/iron/white,
 /area/medical/storage)
@@ -24644,6 +25596,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
+"lpI" = (
+/obj/structure/chair,
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit)
 "lqd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm{
@@ -24726,6 +25682,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "lsN" = (
@@ -24751,12 +25708,6 @@
 /obj/structure/sign/departments/science,
 /turf/closed/wall,
 /area/science/lab)
-"ltr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/science/research)
 "ltt" = (
 /obj/machinery/computer/security/qm{
 	dir = 4;
@@ -24785,10 +25736,8 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "lur" = (
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/iron,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/iron/dark,
 /area/engineering/main)
 "luN" = (
 /obj/structure/disposalpipe/segment,
@@ -24815,7 +25764,9 @@
 /turf/closed/wall,
 /area/maintenance/disposal)
 "lvC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "lvL" = (
@@ -24919,7 +25870,7 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "lyY" = (
-/obj/structure/closet/emcloset,
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "lzo" = (
@@ -24956,6 +25907,7 @@
 	pixel_x = -10;
 	pixel_y = -22
 	},
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/maintenance/disposal)
 "lAk" = (
@@ -24983,6 +25935,15 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
+"lAZ" = (
+/obj/structure/showcase/cyborg/old{
+	dir = 8;
+	pixel_x = 9;
+	pixel_y = 2
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "lBX" = (
 /obj/structure/window{
 	dir = 8
@@ -24991,6 +25952,7 @@
 /area/security/prison)
 "lCc" = (
 /obj/machinery/telecomms/receiver/preset_right,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "lCN" = (
@@ -25039,6 +26001,8 @@
 /area/maintenance/fore)
 "lEQ" = (
 /obj/machinery/vending/engivend,
+/obj/machinery/light/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/engineering/main)
 "lEY" = (
@@ -25101,13 +26065,16 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "lGE" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/photocopier,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"lGQ" = (
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/main)
 "lHK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
@@ -25134,12 +26101,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"lIv" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Showers"
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "lJm" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics";
 	req_access_txt = "24"
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lJu" = (
@@ -25155,6 +26130,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"lJQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/warehouse)
 "lJW" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom";
@@ -25316,6 +26298,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command)
+"lNp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/robotics/lab)
 "lNt" = (
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
@@ -25327,7 +26318,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_large,
+/turf/open/floor/iron/large,
 /area/engineering/main)
 "lND" = (
 /obj/structure/chair/office{
@@ -25407,6 +26398,11 @@
 	},
 /turf/open/floor/wood/large,
 /area/service/library)
+"lQj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "lQn" = (
 /obj/structure/closet/secure_closet/injection,
 /obj/effect/turf_decal/stripes/line{
@@ -25524,16 +26520,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/computer/atmos_control{
+	dir = 8;
+	sensors = list("n2_sensor" = "Nitrogen Tank", "o2_sensor" = "Oxygen Tank", "co2_sensor" = "Carbon Dioxide Tank", "tox_sensor" = "Plasma Tank", "n2o_sensor" = "Nitrous Oxide Tank", "air_sensor" = "Mixed Air Tank", "mix_sensor" = "Mix Tank", "mix2_sensor" = "Mix Tank #2", "distro-loop_meter" = "Distribution Loop", "atmos-waste_loop_meter" = "Atmos Waste Loop", "incinerator_sensor" = "Incinerator Chamber", "toxinslab_sensor" = "Toxins Mixing Chamber")
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "lSL" = (
 /obj/structure/table,
@@ -25652,6 +26643,14 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"lWE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron,
+/area/security/brig)
 "lWI" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -25701,13 +26700,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
-"lYV" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office";
-	req_one_access_txt = "1;4"
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "lYY" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -25765,10 +26757,26 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"mbr" = (
+/obj/machinery/duct,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "mbP" = (
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/lawoffice)
+"mbT" = (
+/obj/machinery/duct,
+/obj/machinery/duct,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port)
 "mbX" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -25786,11 +26794,8 @@
 /area/service/hydroponics)
 "mcr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/cardboard,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "mcB" = (
@@ -25802,6 +26807,32 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/engineering/main)
+"mcK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"mcO" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "mcT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/paramedic,
@@ -25879,6 +26910,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "mfn" = (
@@ -25886,7 +26918,7 @@
 /turf/open/floor/iron,
 /area/science/mixing)
 "mfx" = (
-/obj/structure/moisture_trap,
+/obj/effect/spawner/bundle/moisture_trap,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "mfD" = (
@@ -25934,6 +26966,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mgE" = (
@@ -25983,6 +27016,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mhS" = (
@@ -26217,6 +27252,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "mnA" = (
@@ -26259,17 +27295,18 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "moj" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /obj/structure/cable,
-/turf/open/floor/iron/smooth_half{
-	dir = 4
-	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/iron/smooth_large,
 /area/engineering/main)
 "mor" = (
 /obj/structure/disposalpipe/segment{
@@ -26313,10 +27350,9 @@
 /area/maintenance/starboard)
 "mpC" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/cardboard,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "mpE" = (
@@ -26360,6 +27396,7 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "mqn" = (
@@ -26443,10 +27480,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
-"mua" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/turf/open/floor/iron,
-/area/service/hydroponics)
 "muo" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -26637,6 +27670,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/courtroom)
 "mzT" = (
@@ -26708,16 +27745,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"mDp" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Library Maintenance";
-	req_access_txt = "12"
+"mDh" = (
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central)
+/turf/open/floor/iron/smooth_corner,
+/area/cargo/drone_boy)
 "mDy" = (
-/obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -26745,6 +27779,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/scatter/moisture,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -26837,6 +27872,17 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"mGm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/engineering/main)
 "mGs" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical{
@@ -26883,7 +27929,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Cold Loop to Gas"
+	name = "Cold Loop to Space"
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -26933,11 +27979,21 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"mJy" = (
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mJQ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -26969,6 +28025,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"mKx" = (
+/obj/effect/spawner/bundle/hobo_squat,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "mKA" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -27026,6 +28086,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/cargo/office)
 "mLZ" = (
@@ -27076,6 +28137,7 @@
 	dir = 4
 	},
 /obj/structure/cable/multilayer/connected,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "mOE" = (
@@ -27093,6 +28155,7 @@
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "mPj" = (
@@ -27115,6 +28178,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/science/research)
+"mPM" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/duct,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/carpet/black,
+/area/commons/dorms)
 "mPW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -27130,6 +28201,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/service/bar)
+"mQN" = (
+/obj/structure/sign/warning{
+	pixel_x = -32;
+	pixel_y = -32
+	},
+/turf/open/floor/iron/smooth,
+/area/cargo/drone_boy)
 "mRb" = (
 /obj/effect/spawner/structure/window,
 /obj/effect/turf_decal/tile/blue,
@@ -27189,6 +28267,14 @@
 /obj/structure/sign/poster/official/obey,
 /turf/closed/wall,
 /area/security/prison)
+"mSY" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "SupermatterExternal";
+	name = "radiation shutters"
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
 "mTd" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -27289,7 +28375,7 @@
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "mUl" = (
-/obj/structure/moisture_trap,
+/obj/effect/spawner/bundle/moisture_trap,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "mUs" = (
@@ -27308,6 +28394,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/white,
 /area/science/research)
 "mVn" = (
@@ -27357,6 +28444,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/bounty_board/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "mWf" = (
@@ -27524,7 +28612,14 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit)
 "naz" = (
-/obj/structure/moisture_trap,
+/obj/machinery/door/airlock/mining{
+	name = "Drone Bay";
+	req_access_txt = "31"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "naC" = (
@@ -27600,6 +28695,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
 "ncm" = (
@@ -27626,6 +28722,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "ndT" = (
@@ -27676,9 +28773,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "nfu" = (
@@ -27742,6 +28838,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "executionfireblast"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/education)
 "ngV" = (
@@ -27771,7 +28868,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "nhE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -27795,14 +28892,19 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/picture_frame/showroom/four{
+	pixel_y = -32
+	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "niq" = (
-/obj/structure/closet/crate/goldcrate,
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "niz" = (
 /obj/structure/closet/crate/bin,
+/obj/machinery/bounty_board/directional/north,
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
 "niD" = (
@@ -27857,6 +28959,10 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"nky" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter)
 "nkD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
@@ -27895,6 +29001,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"nnG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall,
+/area/maintenance/central)
 "nog" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -27978,10 +29089,18 @@
 /area/security/prison)
 "nqc" = (
 /obj/structure/table,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/scanning_module,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
+/obj/item/disk/tech_disk{
+	pixel_y = 6
+	},
+/obj/item/disk/tech_disk{
+	pixel_y = 6
+	},
+/obj/item/disk/tech_disk{
+	pixel_x = 6
+	},
+/obj/item/disk/tech_disk{
+	pixel_x = -6
+	},
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "nqh" = (
@@ -28089,6 +29208,8 @@
 /obj/structure/cable/multilayer/connected,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "nsU" = (
@@ -28120,12 +29241,15 @@
 /area/security/prison/safe)
 "ntJ" = (
 /obj/item/ectoplasm,
+/obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "ntV" = (
-/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/structure/rack,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/wrench,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "nuk" = (
@@ -28215,7 +29339,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/engineering/storage/tech)
 "nxk" = (
 /obj/machinery/light/small{
@@ -28245,15 +29369,11 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
-"nxW" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/machinery/light/small{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engineering/main)
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "nyU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
@@ -28321,6 +29441,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "nBH" = (
@@ -28362,15 +29483,25 @@
 	name = "black plastitanium floor"
 	},
 /area/service/bar)
+"nCj" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "nCk" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/landmark/start/security_officer,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/warden,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "nCm" = (
@@ -28414,9 +29545,6 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "nDv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -28453,12 +29581,30 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"nEn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/closet/crate/trashcart/filled,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"nEs" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/head/lobsterhat,
+/obj/item/clothing/head/rabbitears,
+/obj/item/clothing/head/xenos,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/item/crowbar,
+/obj/item/relic,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "nEJ" = (
 /obj/machinery/computer/bank_machine,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "nFu" = (
@@ -28555,11 +29701,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"nHp" = (
-/obj/structure/cable,
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "nHO" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue,
@@ -28574,7 +29715,7 @@
 "nIf" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/cable,
-/obj/effect/loot_site_spawner,
+/obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "nIk" = (
@@ -28674,7 +29815,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "nMR" = (
-/obj/structure/closet/crate/silvercrate,
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
 	dir = 1;
@@ -28724,7 +29864,6 @@
 /turf/open/floor/iron,
 /area/cargo/qm)
 "nOr" = (
-/obj/structure/closet/radiation,
 /obj/machinery/light,
 /obj/machinery/button/door{
 	id = "SupermatterExternal";
@@ -28732,7 +29871,13 @@
 	pixel_y = -24;
 	req_access_txt = "11"
 	},
-/turf/open/floor/iron,
+/obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/engineering/main)
 "nOv" = (
 /obj/structure/table/wood,
@@ -28748,6 +29893,13 @@
 	},
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"nOA" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/duct,
+/obj/structure/girder,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "nOK" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/electricshock{
@@ -28756,6 +29908,16 @@
 /obj/machinery/light,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"nPD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/security/brig)
 "nPX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -28763,6 +29925,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/white,
 /area/science/research)
 "nQc" = (
@@ -28851,6 +30014,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"nTh" = (
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/commons/dorms)
+"nTi" = (
+/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "nTr" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -29046,7 +30218,7 @@
 	pixel_x = -5;
 	pixel_y = 5
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "nXT" = (
 /obj/machinery/camera{
@@ -29095,17 +30267,14 @@
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
 "nYz" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/table,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow{
+	pixel_y = 4
+	},
+/obj/item/storage/belt/utility,
 /turf/open/floor/iron,
 /area/engineering/main)
 "nYX" = (
@@ -29129,7 +30298,7 @@
 "nZJ" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/engineering/break_room)
 "nZN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -29247,6 +30416,13 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"ocW" = (
+/obj/structure/table,
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/iron,
+/area/cargo/drone_boy)
 "odN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -29302,6 +30478,13 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"ofn" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/iron,
+/area/cargo/sorting)
 "ofq" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -29387,7 +30570,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/circuit/green,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/half,
 /area/science/robotics/mechbay)
 "oiD" = (
 /obj/effect/turf_decal/stripes/line{
@@ -29435,6 +30619,20 @@
 /obj/structure/flora/ausbushes/pointybush,
 /turf/open/floor/grass,
 /area/science/genetics)
+"okv" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"okJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/thermomachine/freezer/on{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "okP" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/structure/cable,
@@ -29472,6 +30670,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"oli" = (
+/obj/effect/spawner/lootdrop/gross_decal_spawner,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "olI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29589,6 +30792,7 @@
 /area/maintenance/disposal/incinerator)
 "onb" = (
 /obj/machinery/telecomms/processor/preset_three,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "onc" = (
@@ -29643,7 +30847,7 @@
 "oqd" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/item/gun/energy/e_gun/mini,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "oql" = (
 /obj/structure/disposaloutlet{
@@ -29659,6 +30863,8 @@
 /area/cargo/sorting)
 "oqm" = (
 /obj/structure/table,
+/obj/machinery/bounty_board/directional/east,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "oqE" = (
@@ -29728,7 +30934,7 @@
 	},
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/ai,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/engineering/storage/tech)
 "osN" = (
 /obj/effect/turf_decal/tile/red{
@@ -29748,6 +30954,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"otD" = (
+/turf/open/floor/iron/dark/smooth_edge,
+/area/command/heads_quarters/ce)
 "otG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29964,6 +31173,10 @@
 "ozT" = (
 /obj/structure/closet/secure_closet/courtroom,
 /obj/item/gavelhammer,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/security/courtroom)
 "ozY" = (
@@ -30029,6 +31242,7 @@
 /obj/machinery/ai_slipper{
 	uses = 10
 	},
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "oBl" = (
@@ -30036,6 +31250,7 @@
 	pixel_y = 8
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/duct,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
 "oBJ" = (
@@ -30084,6 +31299,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"oDu" = (
+/obj/machinery/atmospherics/components/unary/bluespace_sender,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "oDA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/tank_holder/oxygen,
@@ -30098,6 +31317,9 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
+"oDD" = (
+/turf/open/floor/iron/stairs,
+/area/cargo/drone_boy)
 "oDP" = (
 /obj/structure/chair{
 	dir = 4
@@ -30198,6 +31420,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "oGQ" = (
@@ -30343,6 +31566,13 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"oKh" = (
+/obj/machinery/camera{
+	c_tag = "Cargo Drone Bay"
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/cargo/drone_boy)
 "oKE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30515,7 +31745,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "oQj" = (
-/obj/structure/moisture_trap,
+/obj/effect/spawner/bundle/moisture_trap,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "oQl" = (
@@ -30530,6 +31760,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
+"oQL" = (
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "oQS" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -30555,6 +31791,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/machinery/light/warm/directional/west,
 /turf/open/floor/wood,
 /area/service/library)
 "oRn" = (
@@ -30641,21 +31878,23 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/black,
 /area/commons/dorms)
+"oTB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w,
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
+"oTN" = (
+/obj/machinery/requests_console{
+	department = "Atmospherics";
+	departmentType = 3;
+	name = "Atmos RC";
+	pixel_y = 30
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/engineering/atmos)
 "oTO" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
-"oUB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "oUE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -30773,6 +32012,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Cafeteria"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "oXS" = (
@@ -30784,13 +32024,16 @@
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "oXV" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/head/lobsterhat,
-/obj/item/clothing/head/rabbitears,
-/obj/item/clothing/head/xenos,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron,
+/area/cargo/drone_boy)
 "oYo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 1;
@@ -30817,6 +32060,14 @@
 /obj/machinery/vending/security,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"oZO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/tcommsat/server)
 "oZS" = (
 /obj/machinery/door/window/northright{
 	dir = 4;
@@ -30846,12 +32097,14 @@
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
 "paT" = (
-/obj/machinery/photocopier,
-/obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = -22
 	},
+/obj/machinery/bounty_board/directional/south{
+	pixel_x = 3
+	},
+/obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron,
 /area/cargo/office)
 "pbB" = (
@@ -30887,9 +32140,14 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"pcm" = (
+/obj/item/kirbyplants/random,
+/obj/item/radio/intercom/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "pcs" = (
-/obj/machinery/light/directional/north,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/light/warm/directional/east,
 /turf/open/floor/wood/tile,
 /area/service/library)
 "pcH" = (
@@ -30922,6 +32180,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/white,
 /area/science/research)
 "pdg" = (
@@ -30979,12 +32238,17 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "pfr" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/chair/office,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron/smooth,
 /area/engineering/main)
+"pfI" = (
+/obj/machinery/bounty_board/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "pgv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31076,6 +32340,15 @@
 "pjf" = (
 /turf/open/floor/iron,
 /area/cargo/office)
+"pjm" = (
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Dorm 2"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/commons/dorms)
 "pjr" = (
 /obj/structure/sign/departments/examroom,
 /turf/closed/wall,
@@ -31098,7 +32371,7 @@
 	pixel_x = -6
 	},
 /obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/science/robotics/lab)
 "pjE" = (
 /turf/open/floor/plating,
@@ -31138,11 +32411,10 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "plb" = (
-/obj/structure/table/wood,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "pls" = (
@@ -31152,6 +32424,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
+"plT" = (
+/obj/structure/cable,
+/obj/machinery/button/door{
+	id = "SupermatterExternal";
+	name = "Shutters Control";
+	pixel_x = -24;
+	req_access_txt = "11"
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
+/area/engineering/main)
 "plX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -31208,6 +32492,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/mob/living/simple_animal/hostile/lizard/wags_his_tail,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "pnf" = (
@@ -31397,7 +32682,7 @@
 /obj/item/radio/intercom{
 	pixel_x = 29
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/command/heads_quarters/ce)
 "ptT" = (
 /obj/machinery/door/firedoor,
@@ -31413,6 +32698,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/prison)
+"pub" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/aft)
 "pud" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -31487,6 +32778,17 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"pwe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "pwf" = (
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/ausbushes/brflowers,
@@ -31535,13 +32837,21 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_half,
 /area/security/office)
 "pxc" = (
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
+"pxw" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/fore)
 "pxC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -31575,6 +32885,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "pys" = (
@@ -31726,12 +33037,14 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "pEd" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"pEs" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/bounty_board/directional/west,
+/turf/open/floor/carpet,
+/area/hallway/secondary/entry)
 "pEY" = (
 /obj/structure/window{
 	dir = 1
@@ -31988,9 +33301,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "pNw" = (
-/obj/structure/closet/emcloset{
-	anchored = 1
-	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "pOa" = (
@@ -32072,7 +33383,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
-	name = "Loop to Freezers"
+	name = "Freezers to Loop"
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -32200,6 +33511,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/white,
 /area/science/research)
 "pVH" = (
@@ -32239,7 +33551,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/command/heads_quarters/ce)
 "pWI" = (
 /obj/effect/turf_decal/stripes/line{
@@ -32295,6 +33609,13 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
+"pZA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "pZQ" = (
 /obj/structure/chair{
 	dir = 1
@@ -32361,11 +33682,6 @@
 /obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qaS" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable,
-/turf/open/floor/wood,
-/area/service/library)
 "qbr" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -32393,13 +33709,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
-"qbX" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/turf/open/floor/iron/smooth,
-/area/engineering/main)
 "qcp" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 1
@@ -32411,6 +33720,14 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
+"qcr" = (
+/obj/structure/chair/sofa/corner{
+	dir = 8;
+	name = "plush sofa"
+	},
+/obj/machinery/bounty_board/directional/east,
+/turf/open/floor/wood,
+/area/service/bar)
 "qcW" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -32459,13 +33776,18 @@
 	pixel_x = -1;
 	pixel_y = -1
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/machinery/camera{
 	c_tag = "Cargo Delivery Office";
 	dir = 4
+	},
+/obj/item/hand_labeler{
+	pixel_y = 8
+	},
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	name = "Cargo Bay RC";
+	pixel_x = -30
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
@@ -32554,6 +33876,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/structure/filingcabinet/employment,
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
 "qgD" = (
@@ -32626,7 +33949,7 @@
 /turf/open/floor/iron,
 /area/science/server)
 "qiz" = (
-/obj/structure/moisture_trap,
+/obj/effect/spawner/bundle/moisture_trap,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "qiA" = (
@@ -32704,6 +34027,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "qlt" = (
@@ -32773,11 +34097,26 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel,
 /area/maintenance/solars/starboard/aft)
+"qnh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/edge{
+	dir = 1
+	},
+/area/engineering/main)
 "qnj" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"qnK" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/iron/dark/textured_large,
+/area/engineering/main)
 "qnO" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white,
@@ -32845,6 +34184,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "qpp" = (
@@ -32856,14 +34198,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "qpN" = (
-/obj/structure/table,
-/obj/item/wrench,
-/obj/item/stack/cable_coil{
-	amount = 5
-	},
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet,
 /turf/open/floor/iron,
 /area/engineering/main)
 "qqd" = (
@@ -32874,8 +34212,15 @@
 /area/science/mixing)
 "qqh" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"qqi" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/chair/office,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/drone_boy)
 "qqk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32891,6 +34236,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "qqE" = (
@@ -33012,11 +34364,19 @@
 /area/engineering/gravity_generator)
 "qtD" = (
 /obj/machinery/nuclearbomb/selfdestruct,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/iron/dark/textured_large,
 /area/ai_monitored/command/nuke_storage)
 "qtO" = (
 /turf/closed/wall,
 /area/maintenance/starboard)
+"qtY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "quj" = (
 /obj/effect/spawner/structure/window/reinforced/indestructable,
 /turf/open/floor/plating/airless,
@@ -33044,7 +34404,7 @@
 	name = "Robotics Operating Computer"
 	},
 /obj/machinery/light/small,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/science/robotics/lab)
 "qwe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -33119,8 +34479,17 @@
 "qyc" = (
 /obj/structure/closet,
 /obj/item/book/random,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"qyn" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1;
+	name = "engineering sorting disposal pipe";
+	sortType = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "qyp" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /obj/structure/cable,
@@ -33128,6 +34497,12 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port)
+"qzf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/scatter/grime,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "qzX" = (
 /turf/open/floor/carpet/black,
 /area/security/prison)
@@ -33167,19 +34542,10 @@
 	name = "Robotics Conveyor Belt";
 	pixel_x = 8
 	},
-/turf/open/floor/iron,
-/area/science/robotics/lab)
-"qBk" = (
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/engineering/main)
+/area/science/robotics/lab)
 "qBL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33198,10 +34564,25 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron,
 /area/service/library)
+"qBY" = (
+/obj/structure/closet/crate/trashcart/filled,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "qCa" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"qCo" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/bounty_board/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
+"qCE" = (
+/obj/structure/grille/broken,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qCG" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -33338,7 +34719,7 @@
 "qHu" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/circuit,
 /area/engineering/engine_smes)
 "qHw" = (
 /obj/structure/table,
@@ -33460,6 +34841,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "qMx" = (
@@ -33534,8 +34917,8 @@
 "qPY" = (
 /obj/machinery/photocopier,
 /obj/item/radio/intercom{
-	pixel_x = 29;
-	pixel_y = 4
+	pixel_x = 33;
+	pixel_y = -1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
@@ -33564,6 +34947,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "qQg" = (
@@ -33616,6 +35000,11 @@
 /obj/effect/landmark/start/chemist,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
+"qRv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/violet,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/engineering/main)
 "qRG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -33634,6 +35023,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "qSY" = (
@@ -33663,6 +35053,10 @@
 /obj/structure/closet/secure_closet/atmospherics,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"qUi" = (
+/obj/effect/landmark/start/cargo_technician,
+/turf/open/floor/iron,
+/area/cargo/office)
 "qUs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -33676,6 +35070,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "qVf" = (
@@ -33694,7 +35089,7 @@
 /area/science/xenobiology)
 "qVF" = (
 /obj/machinery/mecha_part_fabricator,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/science/robotics/lab)
 "qWa" = (
 /obj/effect/landmark/start/bartender,
@@ -33723,7 +35118,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "qXs" = (
 /obj/effect/turf_decal/delivery,
@@ -33751,8 +35146,6 @@
 /area/medical/virology)
 "qYx" = (
 /obj/effect/landmark/start/quartermaster,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "qYz" = (
@@ -33815,7 +35208,7 @@
 	dir = 4
 	},
 /obj/structure/closet/radiation,
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured_half,
 /area/engineering/gravity_generator)
 "qZN" = (
 /obj/effect/landmark/event_spawn,
@@ -33884,7 +35277,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/science/robotics/lab)
 "raM" = (
 /obj/structure/disposalpipe/segment,
@@ -33934,6 +35327,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/main)
 "rbK" = (
@@ -34080,7 +35475,7 @@
 "rfR" = (
 /obj/effect/decal/cleanable/generic,
 /turf/closed/wall,
-/area/maintenance/port/aft)
+/area/cargo/drone_boy)
 "rfU" = (
 /obj/machinery/door/window/eastright{
 	name = "Bridge Delivery";
@@ -34162,10 +35557,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_x = -29
+/obj/machinery/computer/secure_data{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/reagent_dispensers/peppertank/directional/west,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
 /area/security/office)
 "riG" = (
 /obj/machinery/door/airlock/maintenance{
@@ -34174,6 +35572,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"rja" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/iron,
+/area/cargo/warehouse)
+"rjl" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/light/warm/directional/east,
+/turf/open/floor/wood/large,
+/area/service/library)
 "rjm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34198,6 +35607,14 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
+"rjz" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/bounty_board/directional/south,
+/turf/open/floor/iron,
+/area/security/brig)
 "rke" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -34222,13 +35639,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/security/prison)
-"rkY" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/iron/dark,
-/area/security/office)
 "rla" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -34326,7 +35736,7 @@
 /obj/structure/closet/emcloset{
 	anchored = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured_corner,
 /area/engineering/gravity_generator)
 "roz" = (
 /obj/structure/cable,
@@ -34450,6 +35860,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate,
+/obj/item/crowbar,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "rrr" = (
@@ -34569,8 +35982,13 @@
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/starboard)
+"rvE" = (
+/obj/structure/closet/crate/solarpanel_small,
+/turf/open/floor/plating,
+/area/engineering/main)
 "rvF" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "rwb" = (
@@ -34611,12 +36029,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"rwH" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "rwS" = (
 /obj/effect/decal/cleanable/glitter,
 /obj/item/grenade/chem_grenade/colorful,
@@ -34624,10 +36036,6 @@
 /area/maintenance/central)
 "rxf" = (
 /mob/living/simple_animal/pet/dog/corgi/ian,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/royalblue,
@@ -34661,6 +36069,12 @@
 	},
 /turf/open/floor/grass,
 /area/medical/medbay/central)
+"ryF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "ryV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -34685,6 +36099,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
+"rAk" = (
+/obj/effect/spawner/bundle/hobo_squat,
+/obj/item/poster/random_contraband,
+/obj/item/poster/random_contraband,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "rAm" = (
 /obj/machinery/requests_console{
 	department = "Chapel";
@@ -34782,9 +36202,10 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rEw" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/machinery/modular_computer/console/preset/cargochat/service{
 	dir = 8
 	},
 /turf/open/floor/plastic,
@@ -34837,6 +36258,21 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
+"rFH" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Library Maintenance";
+	req_access_txt = "12"
+	},
+/obj/structure/cable,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/service/library)
+"rGh" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/wood,
+/area/service/library)
 "rGu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -34861,6 +36297,14 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
+"rGM" = (
+/obj/structure/tank_dispenser{
+	pixel_x = -1
+	},
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
+/area/engineering/break_room)
 "rHf" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -34975,14 +36419,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"rKX" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/engineering/engine_smes)
 "rKZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -35004,6 +36440,8 @@
 "rLv" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/closet,
+/obj/effect/spawner/lootdrop/gambling,
+/obj/item/relic,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "rLL" = (
@@ -35028,7 +36466,10 @@
 /obj/machinery/power/smes/engineering{
 	charge = 5e+006
 	},
-/turf/open/floor/iron,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/textured_corner{
+	dir = 8
+	},
 /area/engineering/gravity_generator)
 "rME" = (
 /obj/effect/turf_decal/stripes/line{
@@ -35036,13 +36477,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/nanite)
-"rMJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+"rML" = (
+/obj/structure/cable,
+/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/storage)
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "rNp" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/door/window/eastleft{
@@ -35116,6 +36557,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/brig)
+"rPL" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood,
+/area/commons/dorms)
 "rPO" = (
 /turf/closed/wall,
 /area/service/chapel/office)
@@ -35151,6 +36597,11 @@
 "rSF" = (
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
+"rSO" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/iron/dark/textured,
+/area/engineering/break_room)
 "rSS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35205,6 +36656,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"rTQ" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/obj/effect/landmark/start/security_officer,
+/turf/open/floor/iron/dark,
+/area/security/office)
 "rTW" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
@@ -35252,8 +36713,13 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
+"rUC" = (
+/obj/machinery/bounty_board/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "rUF" = (
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
 "rUN" = (
@@ -35284,6 +36750,7 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rWe" = (
@@ -35344,15 +36811,16 @@
 /turf/open/floor/iron,
 /area/service/library)
 "rXA" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/effect/landmark/start/hangover,
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
 /area/commons/dorms)
+"rXF" = (
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "rYf" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister,
@@ -35394,7 +36862,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/science/robotics/lab)
 "rYy" = (
 /obj/structure/extinguisher_cabinet{
@@ -35409,6 +36877,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rYJ" = (
@@ -35436,7 +36905,9 @@
 /area/engineering/main)
 "rZw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/science/robotics/lab)
 "rZx" = (
 /obj/machinery/conveyor{
@@ -35463,7 +36934,7 @@
 	id = "Robotics Belt B";
 	name = "Robotics Conveyor"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/science/robotics/lab)
 "rZW" = (
 /turf/open/floor/iron/showroomfloor,
@@ -35545,6 +37016,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
+"sdk" = (
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/vault,
+/area/ai_monitored/command/nuke_storage)
 "sdI" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35578,13 +37053,13 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "sdT" = (
-/obj/structure/rack,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron,
 /area/engineering/main)
 "sdY" = (
@@ -35637,6 +37112,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"sfu" = (
+/obj/machinery/bounty_board/directional/south,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "sfv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -35741,9 +37220,10 @@
 	},
 /area/maintenance/aft)
 "siB" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
+/obj/machinery/vending/tool,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/engineering/break_room)
 "sjm" = (
 /obj/structure/window/plasma/reinforced,
@@ -35863,6 +37343,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"smM" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/courtroom)
+"snc" = (
+/obj/machinery/light,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/iron/edge,
+/area/engineering/main)
 "snf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35971,6 +37464,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/engine,
 /area/engineering/main)
 "sps" = (
@@ -35992,6 +37486,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "spB" = (
@@ -36116,10 +37611,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"suf" = (
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "sup" = (
 /obj/docking_port/stationary/random{
 	id = "pod_2_lavaland";
@@ -36127,6 +37618,12 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"suB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/hallway/secondary/exit)
 "suU" = (
 /obj/structure/frame/machine,
 /turf/open/floor/wood{
@@ -36235,6 +37732,9 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "sye" = (
+/obj/structure/sign/poster/official/love_ian{
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "syg" = (
@@ -36263,6 +37763,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
+"szL" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/lightreplacer{
+	pixel_y = 7
+	},
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "szW" = (
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
@@ -36286,8 +37796,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sAF" = (
@@ -36303,7 +37811,7 @@
 	name = "Chief Engineer RC";
 	pixel_y = 30
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "sBb" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -36336,6 +37844,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
 "sBH" = (
@@ -36474,6 +37983,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"sGc" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance";
+	req_access_txt = "31"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "sGv" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -36506,6 +38024,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
+"sHC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "sHE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36522,6 +38046,12 @@
 	},
 /turf/closed/indestructible/riveted,
 /area/science/test_area)
+"sHT" = (
+/obj/machinery/exodrone_launcher,
+/obj/item/exodrone,
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/iron/smooth,
+/area/cargo/drone_boy)
 "sHU" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -36571,11 +38101,11 @@
 	},
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/circuit,
 /area/engineering/engine_smes)
 "sIR" = (
 /obj/machinery/gateway/centerstation,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/command/gateway)
 "sIS" = (
 /obj/machinery/light,
@@ -36626,10 +38156,31 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
+"sJF" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
 "sJJ" = (
 /obj/structure/guillotine,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"sJQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron,
+/area/security/brig)
 "sJR" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_y = -30
@@ -36646,6 +38197,7 @@
 "sKc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "sKk" = (
@@ -36679,6 +38231,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron,
 /area/cargo/office)
 "sKX" = (
@@ -36688,6 +38241,7 @@
 /area/maintenance/central/secondary)
 "sLa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "sLD" = (
@@ -36706,6 +38260,10 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/science/test_area)
+"sLV" = (
+/obj/machinery/bounty_board/directional/east,
+/turf/open/floor/iron,
+/area/commons/fitness)
 "sMi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36723,9 +38281,6 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "sMB" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 1
 	},
@@ -36830,7 +38385,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -36889,6 +38443,10 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"sRL" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "sRX" = (
 /obj/structure/chair/comfy/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36972,11 +38530,10 @@
 /turf/open/floor/iron,
 /area/maintenance/central)
 "sTz" = (
-/obj/machinery/computer/atmos_control{
-	dir = 1;
-	sensors = list("n2_sensor" = "Nitrogen Tank", "o2_sensor" = "Oxygen Tank", "co2_sensor" = "Carbon Dioxide Tank", "tox_sensor" = "Plasma Tank", "n2o_sensor" = "Nitrous Oxide Tank", "air_sensor" = "Mixed Air Tank", "mix_sensor" = "Mix Tank", "mix2_sensor" = "Mix Tank #2", "distro-loop_meter" = "Distribution Loop", "atmos-waste_loop_meter" = "Atmos Waste Loop", "incinerator_sensor" = "Incinerator Chamber", "toxinslab_sensor" = "Toxins Mixing Chamber")
+/obj/machinery/computer/station_alert{
+	dir = 1
 	},
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "sTN" = (
 /obj/effect/turf_decal/tile/green{
@@ -36994,15 +38551,7 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
-"sTO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/bundle/hobo_squat,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "sTU" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -37017,6 +38566,12 @@
 	pixel_y = -22
 	},
 /obj/machinery/power/apc/auto_name/south,
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bottle/multiver,
+/obj/item/reagent_containers/glass/bottle/epinephrine{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/syringe,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "sTW" = (
@@ -37041,6 +38596,7 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
+/obj/item/kirbyplants,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "sUF" = (
@@ -37248,6 +38804,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
 "tbE" = (
@@ -37274,6 +38831,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"tca" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "tcf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -37305,6 +38869,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/bounty_board/directional/east,
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "tdm" = (
@@ -37405,6 +38971,7 @@
 "tga" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
+/obj/effect/spawner/lootdrop/minor/twentyfive_percent_cyborg_mask,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "tgf" = (
@@ -37477,7 +39044,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "tia" = (
 /obj/effect/turf_decal/bot,
@@ -37512,12 +39079,39 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"tiW" = (
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/iron/ten,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/scanning_module,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/box/corners{
+	dir = 4
+	},
+/obj/item/crowbar,
+/turf/open/floor/iron/edge,
+/area/cargo/drone_boy)
 "tjb" = (
 /obj/structure/janitorialcart,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"tjs" = (
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/science/robotics/lab)
 "tjx" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -37533,11 +39127,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"tjP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/engineering/atmos)
+"tjQ" = (
+/obj/structure/closet/wardrobe/pjs,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "tjX" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Security";
@@ -37661,7 +39254,7 @@
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/circuit,
 /area/engineering/engine_smes)
 "tmj" = (
 /turf/closed/wall/r_wall,
@@ -37685,6 +39278,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"tng" = (
+/obj/effect/loot_site_spawner,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "tni" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -37738,6 +39336,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
 /turf/open/floor/engine,
 /area/engineering/main)
+"tpF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/white,
+/area/medical/exam_room)
 "tpK" = (
 /obj/machinery/camera{
 	c_tag = "Bridge Hallway West";
@@ -37752,7 +39360,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "tqg" = (
-/obj/structure/cable,
+/obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron,
 /area/cargo/office)
 "tqr" = (
@@ -37784,6 +39392,10 @@
 /area/commons/vacant_room/office)
 "tqP" = (
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "tqR" = (
@@ -37820,7 +39432,6 @@
 "trn" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "trx" = (
@@ -37883,6 +39494,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"tsl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/turf/open/floor/iron,
+/area/command)
 "tsz" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -37915,7 +39533,9 @@
 	pixel_x = -8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/science/robotics/lab)
 "tsI" = (
 /obj/structure/cable,
@@ -38009,13 +39629,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
-"two" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/effect/spawner/scatter/moisture,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "twD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -38030,6 +39643,20 @@
 	name = "black plastitanium floor"
 	},
 /area/service/bar)
+"twY" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/exoscanner{
+	pixel_y = -3
+	},
+/obj/item/circuitboard/machine/exoscanner,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/item/circuitboard/machine/exoscanner{
+	pixel_y = 3
+	},
+/turf/open/floor/iron,
+/area/cargo/drone_boy)
 "txA" = (
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -38123,6 +39750,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"tyW" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/security/office)
 "tzk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/scrubber/huge,
@@ -38330,6 +39965,14 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/maintenance/solars/port/fore)
+"tFF" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Fitness"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
 "tFK" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -38380,6 +40023,12 @@
 "tGp" = (
 /turf/closed/wall,
 /area/commons/toilet)
+"tGx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "tGN" = (
 /turf/closed/wall,
 /area/science/mixing)
@@ -38408,6 +40057,7 @@
 "tHM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "tIA" = (
@@ -38420,6 +40070,11 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"tJa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/engineering/break_room)
 "tJm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38476,6 +40131,20 @@
 /obj/item/book/random,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tKp" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"tKA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green,
+/turf/closed/wall/r_wall,
+/area/engineering/supermatter)
 "tKZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -38550,10 +40219,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"tNg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "tNn" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "tNp" = (
@@ -38587,6 +40269,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "tPt" = (
@@ -38666,6 +40354,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
+"tRi" = (
+/obj/structure/sign/picture_frame/showroom/one{
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/royalblue,
+/area/command/heads_quarters/hop)
 "tRl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38757,8 +40451,15 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
+"tSk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/cargo/drone_boy)
 "tSy" = (
 /obj/effect/loot_site_spawner,
+/obj/effect/spawner/bundle/costume/plaguedoctor,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -38777,13 +40478,25 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"tTs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/north,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/iron/smooth,
+/area/engineering/main)
 "tTH" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
+"tUc" = (
+/obj/machinery/light/warm/directional/west,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "tUn" = (
 /obj/effect/landmark/blobstart,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "tUB" = (
@@ -38814,15 +40527,11 @@
 /turf/open/space/basic,
 /area/space)
 "tVQ" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "Cargo Belt";
-	name = "Cargo Belt 2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/status_display/supply{
-	pixel_y = 30
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/open/floor/iron,
 /area/cargo/storage)
 "tVR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -38849,16 +40558,6 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/white,
 /area/medical/storage)
-"tWk" = (
-/obj/structure/table,
-/obj/structure/cable,
-/obj/machinery/recharger{
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/iron/smooth,
-/area/engineering/main)
 "tWG" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -38892,6 +40591,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"tYB" = (
+/obj/machinery/skill_station,
+/turf/open/floor/wood,
+/area/service/library)
 "tYO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38942,6 +40645,11 @@
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/plating,
 /area/command)
+"tZT" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/donkpockets,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "tZZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -38972,6 +40680,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "uby" = (
@@ -38994,6 +40703,7 @@
 /area/engineering/atmos)
 "ubH" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "ubS" = (
@@ -39021,6 +40731,7 @@
 "ucy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -39032,6 +40743,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/starboard)
+"ucZ" = (
+/obj/machinery/computer/exoscanner_control{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/iron/edge,
+/area/cargo/drone_boy)
 "udk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -39074,6 +40794,11 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/radio/intercom/directional/west,
+/obj/item/wirecutters,
+/obj/item/wrench,
+/obj/item/crowbar,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "udM" = (
@@ -39265,6 +40990,7 @@
 	name = "Garden"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "ujo" = (
@@ -39275,8 +41001,20 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"ujp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/cargo/drone_boy)
 "ujF" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -39310,7 +41048,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/science/robotics/lab)
 "ukF" = (
 /obj/machinery/door/poddoor/preopen{
@@ -39329,7 +41067,14 @@
 "ukV" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/turf/open/floor/iron/smooth,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Equipment Room";
+	req_access_txt = "11"
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
 /area/engineering/main)
 "uln" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -39360,6 +41105,7 @@
 /area/hallway/secondary/exit)
 "umd" = (
 /obj/structure/cable,
+/obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -39409,7 +41155,9 @@
 "unh" = (
 /obj/effect/landmark/start/roboticist,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/science/robotics/lab)
 "unF" = (
 /turf/open/floor/carpet/royalblue,
@@ -39466,6 +41214,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/smooth_large,
 /area/engineering/engine_smes)
 "unW" = (
@@ -39502,7 +41251,7 @@
 /area/engineering/gravity_generator)
 "uou" = (
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/science/robotics/lab)
 "uow" = (
 /obj/effect/turf_decal/stripes/line{
@@ -39560,6 +41309,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"uqo" = (
+/obj/machinery/light/small/broken/directional/west,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "uqI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -39711,6 +41464,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
+"uvI" = (
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "uvM" = (
 /turf/closed/wall,
 /area/science/mixing/chamber)
@@ -39758,6 +41517,7 @@
 /area/command/teleporter)
 "uxg" = (
 /obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers,
 /turf/open/space,
 /area/maintenance/disposal/incinerator)
 "uxr" = (
@@ -39772,7 +41532,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "Gas to Cold Loop"
+	name = "Space to Cold Loop"
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
@@ -39796,10 +41556,10 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/wood/parquet,
 /area/service/library)
 "uyn" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -39812,6 +41572,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command)
+"uyT" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/turf/open/floor/iron/half,
+/area/service/hydroponics)
 "uze" = (
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark,
@@ -39836,7 +41600,8 @@
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "uzz" = (
-/obj/machinery/suit_storage_unit/security,
+/obj/structure/tank_dispenser/oxygen,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "uAk" = (
@@ -39867,6 +41632,7 @@
 "uAA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "uAM" = (
@@ -39944,14 +41710,16 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit)
 "uCf" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Freezers";
 	dir = 4;
 	network = list("ss13","engine")
 	},
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	amount = 5
+	},
+/obj/item/wrench,
 /turf/open/floor/iron,
 /area/engineering/main)
 "uCt" = (
@@ -40011,8 +41779,23 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/commons/fitness)
+/obj/machinery/computer/cryopod{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/cold/directional/south,
+/obj/machinery/camera{
+	c_tag = "Dormitory Cryogenics";
+	dir = 1
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
 "uDr" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -40048,6 +41831,11 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"uEa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "uFa" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/structure/cable,
@@ -40226,6 +42014,13 @@
 "uJY" = (
 /turf/open/floor/plating,
 /area/science/mixing)
+"uKk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "uKo" = (
 /obj/machinery/door/poddoor{
 	id = "toxinsdriver";
@@ -40285,7 +42080,7 @@
 "uMa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "uMd" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -40351,7 +42146,9 @@
 /area/science/test_area)
 "uOh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_half{
+	dir = 1
+	},
 /area/security/office)
 "uOm" = (
 /obj/structure/chair/office{
@@ -40383,6 +42180,18 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"uOz" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
 "uOK" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -40500,6 +42309,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
+"uSU" = (
+/obj/effect/spawner/bundle/moisture_trap,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "uSV" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/costume,
@@ -40571,6 +42384,7 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/engineering/main)
 "uUA" = (
@@ -40635,13 +42449,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"uVH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth_half{
-	dir = 1
+"uVM" = (
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4;
+	pipe_color = "#0000FF"
 	},
-/area/engineering/main)
+/turf/closed/wall/r_wall,
+/area/science/mixing/chamber)
 "uVQ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -40654,9 +42468,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/obj/structure/closet/emcloset{
-	anchored = 1
-	},
+/obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "uWf" = (
@@ -40666,6 +42478,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
+"uWx" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "uWy" = (
 /obj/machinery/biogenerator{
 	pixel_x = 2
@@ -40689,15 +42505,28 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"uWJ" = (
+/obj/structure/table/wood/bar,
+/obj/effect/spawner/lootdrop/maint_drugs,
+/obj/effect/spawner/lootdrop/maint_drugs,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "uWM" = (
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"uWN" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/light/cold/directional/south,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "uXv" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
 /area/engineering/main)
 "uXR" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -40737,7 +42566,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "uYy" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -40756,6 +42585,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"uYE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "uYU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
@@ -40841,6 +42676,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "vbG" = (
@@ -40878,6 +42716,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vdm" = (
@@ -40960,6 +42799,11 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
+"vhr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/bundle/hobo_squat,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "vht" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 1;
@@ -40979,6 +42823,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
+"vhQ" = (
+/obj/effect/landmark/start/mime,
+/obj/structure/mirror/directional/west,
+/turf/open/floor/iron/cafeteria,
+/area/service/theater)
 "vii" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -40994,6 +42843,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"vis" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
+/area/commons/toilet)
 "vit" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -41245,8 +43099,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "vpr" = (
@@ -41317,6 +43169,9 @@
 "vqN" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
+"vqR" = (
+/turf/closed/wall,
+/area/cargo/drone_boy)
 "vrd" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/window{
@@ -41378,6 +43233,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"vsl" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vsp" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -41464,7 +43332,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "vtY" = (
 /obj/machinery/button/door{
@@ -41505,6 +43374,8 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
+/obj/machinery/holopad/secure,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "vuN" = (
@@ -41628,6 +43499,10 @@
 	},
 /turf/open/floor/plating,
 /area/command/heads_quarters/hop)
+"vxy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w,
+/turf/open/floor/circuit/telecomms,
+/area/science/xenobiology)
 "vxV" = (
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/iron,
@@ -41711,10 +43586,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "vyG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
@@ -41726,14 +43597,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/vending/clothing,
+/obj/machinery/light/warm/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"vzc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/commons/fitness)
 "vzz" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -41745,6 +43612,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "vzP" = (
@@ -41786,6 +43654,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"vAu" = (
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "vAz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -41845,6 +43717,8 @@
 "vCn" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/effect/turf_decal/bot_white/right,
+/obj/structure/closet/crate/goldcrate,
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "vCr" = (
@@ -41965,16 +43839,14 @@
 /area/command/heads_quarters/rd)
 "vFl" = (
 /obj/structure/rack,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/iron/dark,
 /area/engineering/main)
 "vFu" = (
 /obj/structure/lattice,
@@ -42109,11 +43981,19 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
+/obj/structure/table,
+/obj/item/multitool{
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/obj/item/radio/off{
+	pixel_x = -4
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "vII" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "vJe" = (
 /obj/effect/turf_decal/tile/blue{
@@ -42220,6 +44100,10 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"vLQ" = (
+/obj/structure/closet/crate/trashcart/filled,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "vLY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -42313,6 +44197,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
+"vOL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/engineering/main)
 "vOM" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/blue{
@@ -42325,12 +44214,33 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"vPH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/item/paicard{
+	pixel_x = 4
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/open/floor/iron,
+/area/commons/dorms)
 "vPK" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"vPN" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/security/courtroom)
 "vPR" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -42478,6 +44388,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/security/brig)
 "vUW" = (
@@ -42510,6 +44421,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"vVZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engineering/main)
 "vWc" = (
 /obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom{
@@ -42594,6 +44509,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"vYc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/engineering/main)
 "vYs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -42636,10 +44558,10 @@
 "vYY" = (
 /obj/structure/table,
 /obj/machinery/recharger{
-	pixel_x = -8
+	pixel_x = -6
 	},
 /obj/machinery/recharger{
-	pixel_x = 8
+	pixel_x = 6
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -42648,6 +44570,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "vZg" = (
@@ -42710,6 +44633,12 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wbu" = (
@@ -42736,6 +44665,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -42814,6 +44744,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/security/office)
 "wfN" = (
@@ -42822,6 +44755,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wfT" = (
@@ -42889,6 +44823,7 @@
 "whX" = (
 /obj/structure/table/wood/poker,
 /obj/item/clothing/glasses/blindfold,
+/obj/effect/spawner/lootdrop/maint_drugs,
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
 	},
@@ -42941,6 +44876,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"wjt" = (
+/obj/structure/fireaxecabinet/directional/south,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/engineering/atmos)
 "wjE" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
@@ -43296,15 +45238,12 @@
 /obj/machinery/igniter/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"wsN" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/cargo/warehouse)
 "wsY" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
 	req_access_txt = "10"
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "wth" = (
@@ -43334,14 +45273,15 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "wwz" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/iron/smooth,
+/obj/machinery/computer/atmos_alert{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
 /area/engineering/main)
 "wwK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -43465,6 +45405,7 @@
 	},
 /obj/item/paper_bin,
 /obj/item/folder/red,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "wAv" = (
@@ -43561,6 +45502,7 @@
 "wCI" = (
 /obj/structure/table,
 /obj/item/bodybag,
+/obj/effect/spawner/lootdrop/gambling,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wCT" = (
@@ -43607,6 +45549,8 @@
 /area/science/mixing)
 "wDK" = (
 /obj/machinery/light,
+/obj/machinery/firealarm/directional/south,
+/obj/structure/table,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "wEF" = (
@@ -43631,6 +45575,8 @@
 "wFs" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
+/obj/effect/spawner/lootdrop/donkpockets,
+/obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "wFw" = (
@@ -43652,6 +45598,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"wGn" = (
+/obj/structure/reagent_dispensers/plumbed,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port)
 "wGq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -43708,6 +45660,7 @@
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "wHS" = (
@@ -43743,6 +45696,20 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/science/mixing)
+"wJB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/drone_boy)
 "wKb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -43759,7 +45726,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "wKf" = (
-/obj/effect/landmark/start/station_engineer,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "wKh" = (
@@ -43782,7 +45749,7 @@
 	pixel_y = 32
 	},
 /obj/item/book/manual/wiki/robotics_cyborgs,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "wKy" = (
 /obj/structure/chair{
@@ -43855,6 +45822,10 @@
 	initial_gas_mix = "TEMP=2.7"
 	},
 /area/science/test_area)
+"wLS" = (
+/obj/effect/spawner/bundle/hobo_squat,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "wMh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -43945,6 +45916,15 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
+"wNM" = (
+/obj/structure/displaycase/trophy{
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/service/library)
 "wNU" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/chair/stool,
@@ -43983,6 +45963,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/official/build{
+	pixel_y = 32
+	},
 /turf/open/floor/iron,
 /area/engineering/main)
 "wPB" = (
@@ -44142,6 +46125,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/rack,
+/obj/item/clothing/head/welding,
+/obj/item/multitool,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wTL" = (
@@ -44183,6 +46169,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "wUU" = (
@@ -44199,6 +46188,12 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"wVf" = (
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/port/aft)
 "wVk" = (
 /obj/machinery/shieldgen,
 /turf/open/floor/plating,
@@ -44386,6 +46381,7 @@
 	name = "Garden"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "xbi" = (
@@ -44407,6 +46403,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"xbr" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/engineering/main)
 "xbu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /obj/structure/cable,
@@ -44423,6 +46424,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"xbB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/start/cargo_technician,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "xbN" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "SupermatterExternal";
@@ -44717,6 +46728,13 @@
 "xke" = (
 /turf/closed/wall/r_wall,
 /area/security/brig)
+"xkh" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/cargo/storage)
 "xky" = (
 /obj/machinery/computer/security/hos{
 	dir = 4
@@ -44758,9 +46776,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
 /obj/structure/closet/crate{
 	name = "DIY Canister Kit"
 	},
@@ -44768,6 +46783,8 @@
 	amount = 25
 	},
 /obj/item/stack/sheet/iron/fifty,
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos)
 "xlD" = (
@@ -44857,18 +46874,23 @@
 	desc = "It doesn't measure anything! Nobody knows why it's here.";
 	name = "Nothing Meter"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured_large,
 /area/engineering/atmos)
 "xoM" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "xoP" = (
-/obj/structure/sign/poster/official/love_ian{
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/sign/picture_frame/showroom/three{
+	pixel_x = -11;
+	pixel_y = -32
+	},
+/obj/structure/sign/picture_frame/showroom/two{
+	pixel_x = 11;
+	pixel_y = -32
 	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
@@ -45026,6 +47048,8 @@
 /area/hallway/primary/central)
 "xsr" = (
 /obj/structure/cable,
+/obj/structure/filingcabinet/medical,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "xst" = (
@@ -45088,20 +47112,21 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xtn" = (
-/obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 28
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xto" = (
@@ -45133,11 +47158,11 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "xtu" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
 /obj/item/radio/intercom{
 	pixel_y = -30
 	},
 /obj/structure/cable,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/engineering/main)
 "xtK" = (
@@ -45475,6 +47500,9 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "xCS" = (
@@ -45559,11 +47587,15 @@
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/main)
 "xEl" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
+	},
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing)
@@ -45593,6 +47625,12 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"xEU" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/closet/crate/trashcart/filled,
+/obj/item/relic,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xEZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/chair{
@@ -45623,7 +47661,8 @@
 /area/commons/dorms)
 "xFg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/moisture_trap,
+/obj/effect/spawner/bundle/moisture_trap,
+/obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "xFq" = (
@@ -45689,6 +47728,8 @@
 "xHz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/bounty_board/directional/north,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "xIg" = (
@@ -45737,13 +47778,8 @@
 /area/science/xenobiology)
 "xKV" = (
 /obj/machinery/light,
-/obj/machinery/button/door{
-	id = "SupermatterExternal";
-	name = "Shutters Control";
-	pixel_y = -24;
-	req_access_txt = "11"
-	},
 /obj/structure/cable,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/plating,
 /area/engineering/main)
 "xKY" = (
@@ -45758,8 +47794,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad/secure,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"xLg" = (
+/obj/machinery/exodrone_launcher,
+/obj/item/exodrone,
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/iron/smooth,
+/area/cargo/drone_boy)
 "xLw" = (
 /obj/structure/table,
 /obj/machinery/camera{
@@ -45767,15 +47810,12 @@
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/item/stack/sheet/iron/fifty,
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/clothing/glasses/welding,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "xLM" = (
@@ -45863,7 +47903,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
 /area/engineering/main)
 "xOW" = (
 /obj/machinery/light/small{
@@ -45969,6 +48011,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness)
 "xSz" = (
@@ -45994,6 +48037,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"xUe" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/computer/cargo/request{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "xUl" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -46015,15 +48068,15 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "xUo" = (
-/obj/structure/filingcabinet/employment,
-/obj/structure/cable,
+/obj/effect/turf_decal/bot_white/right,
+/obj/structure/closet/crate/silvercrate,
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "xUG" = (
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/circuit,
 /area/engineering/engine_smes)
 "xUQ" = (
 /obj/structure/cable,
@@ -46054,6 +48107,7 @@
 	freq = 1400;
 	location = "QM #1"
 	},
+/obj/machinery/bounty_board/directional/south,
 /turf/open/floor/plating,
 /area/cargo/storage)
 "xWk" = (
@@ -46084,8 +48138,10 @@
 /turf/open/floor/iron/freezer,
 /area/maintenance/starboard/aft)
 "xWC" = (
-/obj/machinery/vending/tool,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "xWP" = (
 /turf/open/floor/iron/edge,
@@ -46101,6 +48157,7 @@
 /area/engineering/atmos)
 "xXj" = (
 /obj/structure/filingcabinet/security,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "xXl" = (
@@ -46119,11 +48176,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/engineering/main)
-"xXu" = (
-/obj/effect/loot_site_spawner,
-/obj/effect/spawner/lootdrop/maint_drugs,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "xXv" = (
 /obj/structure/festivus{
 	name = "Dancer Pole"
@@ -46147,6 +48199,7 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/donkpockets,
 /obj/machinery/light,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "xYa" = (
@@ -46196,6 +48249,7 @@
 	req_one_access_txt = "10;24"
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
 "yal" = (
@@ -46283,7 +48337,7 @@
 	pixel_y = -3
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "ybc" = (
 /obj/machinery/rnd/bepis,
@@ -46474,7 +48528,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/command/gateway)
 "yeZ" = (
 /obj/effect/turf_decal/tile/red{
@@ -46648,6 +48704,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "yjw" = (
@@ -46673,6 +48730,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
+"yjE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/structure/reagent_dispensers/plumbed,
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "yjI" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -59003,7 +61065,7 @@ aUN
 aUN
 aUN
 sJl
-gfQ
+fsz
 fsz
 gfQ
 gfQ
@@ -59754,9 +61816,9 @@ xGp
 fQu
 uCf
 qpN
+lGQ
 aVw
-aVw
-xGp
+xbr
 gfQ
 gfQ
 gfQ
@@ -59765,23 +61827,23 @@ gfQ
 vYN
 fsz
 sSV
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-gfQ
-fsz
-gfQ
-gfQ
-fsz
-fsz
-fsz
-gfQ
+bnA
+bnA
+bnA
+bnA
+bnA
+bnA
+bnA
+bnA
+bnA
+bnA
+bnA
+bnA
+bnA
+clp
+clp
+clp
+bnA
 gfQ
 fsz
 fsz
@@ -60009,11 +62071,11 @@ xGp
 xGp
 xGp
 muR
+qRv
 muR
-iwq
-muR
-muR
-xGp
+lGQ
+aVw
+xbr
 xGp
 xGp
 xGp
@@ -60023,21 +62085,21 @@ vYN
 fsz
 vYN
 bnA
-bnA
-bnA
-bnA
-bnA
-bnA
-bnA
-bnA
-bnA
-bnA
-bnA
-bnA
-bnA
-bnA
-bnA
-bnA
+sCk
+fPo
+fPo
+fPo
+fPo
+fPo
+fPo
+fPo
+fPo
+fPo
+fPo
+fPo
+fPo
+fPo
+jne
 bnA
 fsz
 fsz
@@ -60218,7 +62280,7 @@ gQk
 bzC
 cgJ
 opY
-opY
+xCg
 ihX
 lEY
 bQF
@@ -60269,10 +62331,10 @@ pQn
 vgb
 dKv
 vgb
-jEP
 vgb
-vgb
-vgb
+imH
+imH
+imH
 dyX
 xGp
 xGp
@@ -60280,7 +62342,7 @@ oyy
 aYD
 blf
 bnA
-fsz
+cES
 vSM
 vSM
 vSM
@@ -60524,7 +62586,7 @@ wmb
 wmb
 jTX
 wmb
-jhE
+wmb
 wmb
 jTX
 wmb
@@ -60537,7 +62599,7 @@ sfv
 aUA
 blf
 bnA
-fsz
+cES
 vSM
 qFh
 gSP
@@ -60787,14 +62849,14 @@ oCG
 oCG
 plX
 vWi
-vVk
+vOL
 jvd
 xGp
 xds
 aUA
 blf
 bnA
-fsz
+cES
 vSM
 qFh
 qFh
@@ -60986,7 +63048,7 @@ lYY
 woq
 nqF
 yjp
-bfv
+dii
 dAl
 ehE
 ksz
@@ -61051,7 +63113,7 @@ xds
 aUA
 blf
 bnA
-fsz
+cES
 vSM
 ixC
 hJH
@@ -61301,14 +63363,14 @@ rmU
 uya
 uya
 czP
-vVk
+vOL
 sbX
 xGp
 uYU
 sJl
 blf
 bnA
-fsz
+cES
 vSM
 cyz
 iJd
@@ -61565,7 +63627,7 @@ aUN
 dDZ
 kIC
 bnA
-lpf
+mVJ
 lpf
 juJ
 lpf
@@ -61815,14 +63877,14 @@ hLk
 fIJ
 bFQ
 czP
-vVk
+vOL
 sbX
 wVb
 rKZ
 rKZ
 rKZ
 bnA
-xzY
+oDu
 xzY
 irn
 jMy
@@ -62072,7 +64134,7 @@ hLk
 vKu
 bnq
 xjD
-vVk
+vOL
 lqd
 wVb
 jNy
@@ -62329,7 +64391,7 @@ hLk
 fIJ
 bFQ
 xjD
-vVk
+vOL
 twD
 mcB
 lFi
@@ -62578,18 +64640,18 @@ aYz
 aWk
 oCg
 rmU
-rmU
+tKA
 rmU
 nRT
 rmU
-rmU
+nky
 rmU
 oCg
 uVe
-vVk
+vOL
 sbX
 xGp
-qiF
+iNY
 xzY
 xzY
 xzY
@@ -62794,7 +64856,7 @@ bku
 aPn
 qWD
 aXs
-uzz
+kdl
 xrN
 bCa
 bfT
@@ -62830,7 +64892,7 @@ iSD
 hjW
 rnY
 xGp
-czP
+hWw
 jHw
 sFk
 ejW
@@ -62843,10 +64905,10 @@ tBF
 csU
 wrn
 qjZ
-vVk
-sbX
+fqT
+lky
 xGp
-qiF
+vsl
 xzY
 xzY
 xzY
@@ -63050,8 +65112,8 @@ xIr
 xIr
 xIr
 xIr
-lYV
-xIr
+rhI
+bJz
 xrN
 rHI
 rHI
@@ -63088,9 +65150,9 @@ ife
 qZG
 wVb
 fLo
-nbU
+bij
 gxV
-cKN
+sOW
 svO
 azS
 hKj
@@ -63103,13 +65165,13 @@ uCU
 nbU
 abB
 wVb
-gfa
 aYb
-oUB
-aYs
+aYb
+qiF
+qiF
 aYs
 iSm
-aYs
+qiF
 xzY
 irn
 xzY
@@ -63307,12 +65369,12 @@ rhI
 aQi
 gpV
 riy
+tyW
 aXs
-rkY
 aZD
 uux
 cXi
-tRl
+aWC
 uXR
 uwe
 bSK
@@ -63341,7 +65403,7 @@ bgb
 aTv
 gKI
 jLl
-jLl
+dYb
 dbX
 wVb
 wVb
@@ -63361,7 +65423,7 @@ xGp
 wVb
 wVb
 bnA
-aYg
+hbZ
 aYg
 aYg
 bnA
@@ -63558,13 +65620,13 @@ xke
 xke
 xke
 xke
-oHf
+foU
 rtK
 kiu
 aXs
 aXs
 aXs
-aXs
+bdz
 aXs
 bcN
 uXR
@@ -63614,11 +65676,11 @@ xkT
 jXT
 gtO
 tPk
-gft
+sth
 sdT
 wVb
 gXi
-doY
+fLG
 dyS
 doY
 xlt
@@ -63818,7 +65880,7 @@ eDb
 azD
 fDa
 rhI
-tia
+rYZ
 cuY
 jVL
 wfm
@@ -63875,12 +65937,12 @@ gft
 btN
 wVb
 rjq
-aYe
-tUn
-tjP
 aVW
+tUn
+aoh
+aoh
 aXA
-aYs
+qiF
 xzY
 xzY
 xzY
@@ -64079,11 +66141,11 @@ tia
 uXR
 yaY
 nXR
-cXi
+rTQ
 hym
 mWM
 nvx
-tRl
+aWC
 kyC
 nTC
 oSx
@@ -64107,32 +66169,32 @@ csI
 aEk
 bbf
 lca
-lca
+dmq
 bgY
 lca
 edI
 tBa
-grI
+vSN
 vSN
 wjH
 pPS
 qcW
 biL
-xpv
+kqh
 jXT
 pKk
 xkT
 tEu
 xkT
 pKk
-jXT
+mSY
 koO
-biL
+kwm
 sth
 gxY
 wVb
 jtt
-aoh
+bWb
 keN
 eJJ
 aKR
@@ -64336,14 +66398,14 @@ tia
 uXR
 vII
 uMa
-cXi
+rTQ
 aZG
 bbj
 uOh
 gVE
-ahL
+gOm
 eEi
-vVe
+ger
 xIr
 dKC
 mnE
@@ -64382,16 +66444,16 @@ hov
 pKk
 pKk
 pKk
-xbN
-ibM
-biL
+mSY
+koO
+kwm
 sth
 fNB
 wVb
-bnA
-aYg
+oTN
+bWb
 iUe
-aYg
+wjt
 bnA
 bnA
 sAA
@@ -64593,11 +66655,11 @@ jCe
 uXR
 kVM
 uMa
-cXi
+rTQ
 aZG
 bcs
 jbL
-tRl
+hwI
 rBp
 cqA
 vVe
@@ -64642,16 +66704,16 @@ xKV
 wVb
 izR
 biL
-qBk
+biL
 biL
 qPA
-aYs
-hDu
+bWb
+aVW
 lSx
 hDu
-hDu
+bnA
 xtn
-aYs
+xzY
 xzY
 xzY
 xzY
@@ -64846,7 +66908,7 @@ xke
 azJ
 fDa
 rhI
-tia
+rYZ
 mZg
 egL
 mnZ
@@ -64875,15 +66937,15 @@ fsz
 aEk
 rqE
 wVb
-ayb
+rvE
 dfb
 jsN
-nxW
-xRI
+ojU
+gaE
 iPv
 oqd
 thQ
-uHL
+otD
 uwP
 vtY
 wNk
@@ -64898,16 +66960,16 @@ xbN
 qiT
 wVb
 cgq
-ajO
+uOp
 nYz
 fye
 wVb
 ghJ
-suf
+aYg
 vtD
-xzY
-xzY
-xzY
+aYg
+bnA
+tKp
 xzY
 xzY
 xzY
@@ -65103,7 +67165,7 @@ xke
 azM
 fDa
 rhI
-tia
+oZu
 aXs
 aXs
 aXs
@@ -65133,7 +67195,7 @@ aEk
 rqj
 wVb
 ayb
-ayb
+xkT
 tVS
 xkT
 xRI
@@ -65148,22 +67210,22 @@ jky
 uOp
 xWP
 uXv
-qbX
 fkV
-jms
+fkV
+plT
 ydM
-tWk
+ydM
 ukV
-tPk
+qnh
 uOp
-gft
+eaG
 lEQ
 wVb
 eYM
 wbb
 edM
-rwo
-rwo
+mcK
+mJy
 qqC
 oXq
 bFZ
@@ -65362,15 +67424,15 @@ tZP
 rhI
 gyC
 aXs
-oZu
-aXs
+tia
+tia
 sfI
-rYZ
-bbq
+tia
+dWa
 bcN
 tRl
 bbq
-rYZ
+bkS
 tjH
 rhI
 thO
@@ -65402,18 +67464,18 @@ hAJ
 tuo
 dsA
 biM
-uOp
+fsX
 xWP
 xOU
-fkV
-fkV
-haH
-fkV
-fkV
+aac
+sHC
+jms
+aNq
+lQj
 iIJ
-biL
-biL
-qBk
+bwg
+uOp
+uOp
 biD
 wVb
 wTA
@@ -65658,16 +67720,16 @@ fHp
 duY
 uHL
 wNk
-jky
+loM
 uOp
-xWP
-xGp
-fkV
+snc
+vVZ
+tTs
 fkV
 moj
 fkV
-fkV
-iIJ
+jrE
+wVb
 wth
 fjO
 fjO
@@ -65919,11 +67981,11 @@ kgG
 biL
 lZH
 ksc
-uVH
-uVH
+lQj
+lQj
 fPF
-uVH
-uVH
+lQj
+lQj
 chl
 fjO
 nwX
@@ -66137,7 +68199,7 @@ bez
 bez
 bez
 bez
-bez
+dug
 tPP
 sHE
 bez
@@ -66176,8 +68238,8 @@ vvx
 uOp
 xWP
 jvy
-seZ
-seZ
+aTA
+szL
 ooH
 seZ
 pfr
@@ -66387,9 +68449,9 @@ xke
 xke
 lgV
 imN
+kOK
+liH
 blG
-blG
-gLx
 blG
 mFB
 aYR
@@ -66425,13 +68487,13 @@ xSQ
 pRI
 xAj
 waV
-tZa
-wFw
+wGn
+rXF
 tRS
 xXr
 hMw
 uOp
-hfJ
+xpv
 sOf
 hSL
 hSL
@@ -66662,7 +68724,7 @@ jdC
 jdC
 bdX
 iMd
-iMd
+lWE
 iMd
 klF
 enS
@@ -66682,8 +68744,8 @@ xUm
 waV
 waV
 waV
-oCT
-rsu
+wGn
+iJh
 wVb
 cpP
 cQt
@@ -66928,9 +68990,9 @@ xke
 nmm
 xke
 xke
+sRp
 aEZ
 wFw
-sRp
 tQd
 rIm
 rIm
@@ -66940,15 +69002,15 @@ oCT
 wFw
 wFw
 wFw
-oCT
-wFw
+mbT
+rXF
 wsY
 jyK
 iFa
 cUt
 sOf
 sIJ
-rKX
+bWC
 mHQ
 fWV
 kNc
@@ -67202,12 +69264,12 @@ xbx
 wVb
 wPl
 iFa
-cUt
+qnK
 sOf
 xUG
 bWC
 wKf
-eLP
+dWv
 lLQ
 wth
 uOT
@@ -67219,7 +69281,7 @@ wth
 wqJ
 vJI
 bnA
-fsz
+cES
 vSM
 pBg
 fPj
@@ -67419,7 +69481,7 @@ igv
 aRc
 ciu
 vQo
-mqQ
+sJQ
 sHE
 oJO
 mkQ
@@ -67457,9 +69519,9 @@ gfQ
 gfQ
 gfQ
 wVb
-jyK
-ajO
-lgW
+fdw
+vYc
+qnK
 hnd
 tlX
 qpo
@@ -67476,7 +69538,7 @@ wth
 rqg
 tRP
 bnA
-fsz
+cES
 vSM
 cJC
 sGv
@@ -67676,7 +69738,7 @@ xvP
 xvP
 xvP
 xvP
-mqQ
+fgB
 sHE
 kcR
 bVO
@@ -67715,7 +69777,7 @@ xBz
 gfQ
 wVb
 fuO
-aGA
+mGm
 aGA
 sOf
 sOf
@@ -67733,7 +69795,7 @@ wth
 rqg
 tRP
 bnA
-fsz
+cES
 vSM
 cJC
 nxk
@@ -67937,18 +69999,18 @@ mqQ
 sHE
 aZK
 bVO
-mKc
+fjg
 qik
 bRx
 cwE
 axU
-dpX
+axU
 dPc
 eoI
 vJh
 fSK
 gDZ
-pWJ
+fve
 xun
 jIE
 kQw
@@ -67965,7 +70027,7 @@ gfQ
 xBz
 xUo
 baC
-gJv
+baC
 rek
 jaR
 xBz
@@ -67975,7 +70037,7 @@ rbk
 wVb
 wVb
 nhw
-siB
+rGM
 bhS
 bhU
 bhZ
@@ -67990,7 +70052,7 @@ wth
 dxC
 tRP
 bnA
-fsz
+cES
 vSM
 vSM
 vSM
@@ -68192,7 +70254,7 @@ fri
 gqW
 vEB
 hBf
-kcR
+rjz
 jdC
 iJf
 vYY
@@ -68204,8 +70266,8 @@ dPh
 erw
 vJh
 pWJ
-pWJ
-pWJ
+evz
+fve
 xun
 nWs
 nWs
@@ -68247,21 +70309,21 @@ bMW
 eYL
 tRP
 bnA
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-fsz
-joR
+nCj
+lpf
+lpf
+lpf
+lpf
+lpf
+lpf
+lpf
+lpf
+lpf
+lpf
+lpf
+lpf
+lpf
+cGr
 rKZ
 iJy
 igd
@@ -68451,10 +70513,10 @@ mqQ
 sHE
 kcR
 jdC
-gbh
-gbh
+bVO
+bVO
 jdC
-cyQ
+lVS
 vYu
 vYu
 dPh
@@ -68462,7 +70524,7 @@ etf
 vJh
 pWJ
 gGt
-pWJ
+fve
 xun
 jKu
 jKu
@@ -68489,13 +70551,13 @@ kFm
 uOp
 rZu
 mDY
-aaT
-wGg
+rSO
+rSO
 aGP
 wGg
 xWC
-mDY
-vYu
+tJa
+fXr
 mFo
 bRN
 qsa
@@ -68507,16 +70569,16 @@ bnA
 bnA
 bnA
 bnA
+rKZ
 bnA
 bnA
 bnA
+rKZ
 bnA
 bnA
-bnA
-bnA
-bnA
-bnA
-bnA
+rKZ
+rKZ
+rKZ
 bnA
 bnA
 bnA
@@ -68752,7 +70814,7 @@ jnT
 wGg
 sTz
 mDY
-vYu
+alH
 mFo
 iNF
 xqz
@@ -68992,7 +71054,7 @@ aEk
 gfQ
 xBz
 xXj
-baC
+sdk
 akX
 baC
 kHK
@@ -69019,7 +71081,7 @@ kSV
 ewM
 bnA
 bnA
-mmM
+nEn
 tuj
 eSr
 vZs
@@ -69031,7 +71093,7 @@ tuj
 tYO
 mDy
 vZs
-lib
+dAn
 aHw
 aHw
 aHw
@@ -69218,7 +71280,7 @@ kIP
 aSR
 kIP
 xke
-mqQ
+nPD
 bbI
 nqn
 pGp
@@ -69233,7 +71295,7 @@ rEE
 vJh
 pWJ
 gOB
-pWJ
+smM
 xun
 jKu
 jKu
@@ -69288,7 +71350,7 @@ sxe
 rYJ
 uzs
 tuj
-tuj
+qCE
 aHw
 gfQ
 gfQ
@@ -69482,15 +71544,15 @@ xke
 vHv
 vHv
 xke
-cyQ
+lVS
 vYu
 uqd
 tIA
 mmn
 vJh
 pWJ
-pWJ
-pWJ
+evz
+smM
 xun
 jNu
 jNu
@@ -69515,7 +71577,7 @@ gfQ
 wpw
 cXn
 vYu
-vYu
+cBK
 nhw
 mDY
 mDY
@@ -69545,7 +71607,7 @@ aHw
 aHw
 xjx
 aof
-tuj
+nEs
 aHw
 gfQ
 gfQ
@@ -69723,7 +71785,7 @@ xUQ
 ehq
 xUQ
 avg
-nrT
+tng
 qiz
 uJa
 bxZ
@@ -69742,17 +71804,17 @@ eCf
 hWW
 vYu
 ggx
-tIA
+pwe
 iVw
 ePA
 cmN
 gPo
-pWJ
+smM
 xun
 jND
 kVx
 mzu
-vJh
+vPN
 ozT
 sov
 jNV
@@ -69780,7 +71842,7 @@ pJH
 pJH
 pJH
 bim
-pJH
+ipf
 biz
 mCN
 ckw
@@ -69802,7 +71864,7 @@ gfQ
 aHw
 qsA
 tuj
-jpD
+pub
 aHw
 gfQ
 gfQ
@@ -70037,7 +72099,7 @@ ujF
 ujF
 ujF
 ujF
-ujF
+iId
 fxU
 mne
 vZs
@@ -70265,7 +72327,7 @@ vTq
 pLL
 pLL
 kWh
-pLL
+goW
 nrZ
 oAn
 pJK
@@ -70294,7 +72356,7 @@ qjs
 pLL
 pLL
 pLL
-pLL
+qyn
 bgK
 hlG
 aTu
@@ -70500,7 +72562,7 @@ sVb
 lSd
 bhF
 uJa
-uJa
+vLQ
 foq
 xke
 vUV
@@ -70510,10 +72572,10 @@ ecm
 bkL
 xMu
 eCf
-cBP
+aRT
 vYu
 drd
-lAk
+iDa
 kEt
 orB
 orB
@@ -71015,7 +73077,7 @@ bhD
 biF
 adN
 uJa
-uJa
+oxh
 lSd
 xke
 jna
@@ -71049,7 +73111,7 @@ xok
 flO
 xXl
 eLb
-xXl
+iOT
 bbX
 bbY
 vbq
@@ -71088,7 +73150,7 @@ aHw
 xjx
 fRs
 vZs
-uPm
+jQG
 vHe
 vsQ
 qlC
@@ -71281,7 +73343,7 @@ ecm
 bkL
 xMu
 eCf
-cBP
+aRT
 vYu
 aaH
 dSR
@@ -71300,7 +73362,7 @@ xRK
 xRK
 wXl
 fhP
-vqo
+ryF
 xGY
 vBY
 vBY
@@ -71327,7 +73389,7 @@ wAv
 vYu
 vZs
 tuj
-tuj
+lib
 neN
 gfQ
 gfQ
@@ -71541,7 +73603,7 @@ eCf
 cBP
 vYu
 aby
-vYu
+hze
 wXl
 ePQ
 aQv
@@ -71599,11 +73661,11 @@ gfQ
 gfQ
 gfQ
 aHw
-tuj
+fdD
 tuj
 uVD
 xjx
-mmM
+qtY
 vsQ
 vsQ
 vsQ
@@ -71856,9 +73918,9 @@ gfQ
 gfQ
 gfQ
 aHw
+lzG
 tuj
-tuj
-tuj
+rhF
 cmm
 jfV
 gVT
@@ -72071,7 +74133,7 @@ rXk
 nIT
 wXl
 xGY
-vqo
+ryF
 eki
 vBY
 xaC
@@ -72098,10 +74160,10 @@ oMD
 bqm
 vZs
 tuj
-tuj
+uSU
 uuC
-aHw
-aHw
+aHy
+aHy
 aHy
 aHB
 aoj
@@ -72115,13 +74177,13 @@ bYN
 bYN
 vQC
 dAn
-tuj
+jls
 cvJ
-rwH
-aof
-rhF
-tuj
-vZs
+vqR
+vqR
+vqR
+vqR
+vsQ
 vsQ
 vsQ
 vsQ
@@ -72355,10 +74417,10 @@ hEB
 cfI
 vZs
 tuj
-tuj
-naz
-xXu
-jkP
+vQC
+vZs
+gpP
+gpP
 gpP
 csh
 buH
@@ -72372,15 +74434,15 @@ khC
 bYN
 bYN
 bYN
-aof
+wVf
 cDT
-vZs
-vZs
-vQC
-tuj
-aHw
-gfQ
-gfQ
+vqR
+twY
+bmH
+tiW
+mDh
+mQN
+jQl
 gfQ
 fsz
 gfQ
@@ -72574,7 +74636,7 @@ fSS
 rkx
 aQv
 aQv
-aQv
+fWK
 vaF
 aQv
 lgb
@@ -72585,7 +74647,7 @@ kDl
 qBX
 wXl
 xtO
-vqo
+ryF
 xtO
 vBY
 awV
@@ -72612,32 +74674,32 @@ hEB
 cfI
 vZs
 tuj
-tuj
-hYd
 xkU
-sTO
-gpP
-csh
+sGc
+xkh
+xkh
+xkh
+xkh
 hXX
-rMJ
+nft
 mhN
 nft
 dRd
-bYN
+fch
 qMi
 eCe
 voR
 mcr
-evw
-lmt
-jfV
-lzG
-vZs
+bYN
+tuj
+gKd
+vqR
+oKh
 oXV
-aof
-aHw
-gfQ
-gfQ
+jzs
+jtG
+sHT
+jQl
 gfQ
 fsz
 gfQ
@@ -72868,33 +74930,33 @@ cfI
 hEB
 cfI
 vZs
-tuj
-tuj
-tuj
+mKx
+jkP
+vZs
 hYd
-ids
-gpP
+xbB
+tGx
 tVQ
 gIl
 lgw
 qYx
 aVq
-krh
+svp
 jAB
 dME
 wTe
 ash
 mpC
-bYN
-iuu
-tuj
+bgU
+grL
+tNg
 naz
-vZs
-vZs
-tuj
-aHw
-gfQ
-gfQ
+tSk
+ujp
+oDD
+ffH
+bHS
+jQl
 gfQ
 fsz
 gfQ
@@ -73091,7 +75153,7 @@ fOx
 fOx
 fOx
 wix
-fbo
+aQv
 uCK
 aED
 wXl
@@ -73128,11 +75190,11 @@ aHm
 aHm
 aHm
 aHm
-aHm
+cAK
 aco
 act
-acx
-acB
+svp
+svp
 krh
 svp
 ocJ
@@ -73140,18 +75202,18 @@ gxF
 bYN
 fPp
 spy
-gVQ
+lJQ
 gnJ
 bYN
 iuu
 jls
-aof
-dAn
-tuj
-tuj
-aHw
-gfQ
-gfQ
+vqR
+ocW
+wJB
+ucZ
+jtG
+xLg
+jQl
 gfQ
 fsz
 gfQ
@@ -73348,7 +75410,7 @@ tnP
 awZ
 tnP
 poo
-qaS
+aQv
 hHv
 biS
 wXl
@@ -73391,7 +75453,7 @@ aHm
 acy
 acC
 cWY
-acD
+jbC
 acD
 iXW
 bYN
@@ -73402,13 +75464,13 @@ lid
 bYN
 vwh
 rYD
-tuj
-aof
-tuj
+vqR
+dvj
+qqi
 fUj
-aHw
-gfQ
-gfQ
+fhd
+jav
+jQl
 gfQ
 fsz
 gfQ
@@ -73604,10 +75666,10 @@ pcs
 iNn
 iNn
 iNn
-cQM
-wXl
-mDp
-wXl
+poo
+aQv
+uCK
+wNM
 wXl
 aEY
 xQv
@@ -73641,13 +75703,13 @@ exH
 smo
 mOJ
 aHo
-mOJ
+ofn
 vSt
 nfi
 aHm
 kLm
-ctT
-ejv
+cYg
+qzf
 ctT
 acD
 xVA
@@ -73655,7 +75717,7 @@ bYN
 kuM
 rny
 gVQ
-wsN
+rCl
 bYN
 iuu
 tuj
@@ -73861,11 +75923,11 @@ wXl
 wXl
 wXl
 wXl
-wXl
-wXl
-uMp
+aQv
+tYB
+rjl
 alh
-xtO
+wXl
 xtO
 xtO
 xtO
@@ -73875,7 +75937,7 @@ vqo
 wWn
 xcn
 acf
-sxg
+vhQ
 wNC
 wWn
 eSn
@@ -73912,7 +75974,7 @@ bYN
 reB
 reM
 xOz
-rCl
+rja
 bYN
 iuu
 tuj
@@ -74117,16 +76179,16 @@ xtO
 fVP
 baK
 uAA
-aXZ
-xtO
-jRu
-uMp
-uMp
-baK
-sgN
-uMp
-uMp
-uMp
+wXl
+rGh
+wXl
+wXl
+wXl
+wXl
+kHB
+aGw
+eeS
+xGY
 uMp
 vqo
 wWn
@@ -74373,14 +76435,14 @@ gla
 xtO
 fVV
 sgN
-uAA
-xtO
-xtO
-nHp
-two
+nnG
+wXl
+rFH
+wXl
 xGY
 xGY
 xsR
+xGY
 pVM
 pVM
 xGY
@@ -74427,7 +76489,7 @@ syK
 ltt
 ldr
 sCZ
-jkP
+tuj
 iuu
 vZs
 hnF
@@ -74635,7 +76697,7 @@ uMp
 uMp
 uMp
 lvC
-eki
+xGY
 tdq
 tdq
 tdq
@@ -74876,7 +76938,7 @@ sVb
 uJa
 uJa
 xyp
-lSd
+hyd
 uJa
 hqh
 xyp
@@ -74941,7 +77003,7 @@ nOq
 tCU
 nKt
 sCZ
-vGt
+fuI
 ids
 vZs
 qaL
@@ -75109,7 +77171,7 @@ gfQ
 gfQ
 wYX
 flU
-fxb
+pcm
 xyp
 xyp
 xyp
@@ -75177,11 +77239,11 @@ qks
 qks
 hCx
 qks
-cfI
+uWx
 rLe
 pfj
 rxU
-pjf
+eEl
 acJ
 mKV
 jtX
@@ -75199,7 +77261,7 @@ ldr
 jnC
 sCZ
 vGt
-ids
+kyY
 vZs
 vZs
 fBs
@@ -75376,7 +77438,7 @@ uJa
 uJa
 xUQ
 uJa
-uJa
+aca
 agh
 xyp
 xyp
@@ -75449,7 +77511,7 @@ acE
 pjf
 pjf
 hsV
-pjf
+qUi
 pLz
 pgv
 urf
@@ -75457,7 +77519,7 @@ fbI
 sCZ
 vGt
 xRS
-vGt
+dVD
 nIf
 fBs
 rwm
@@ -75623,7 +77685,7 @@ gfQ
 wYX
 aeq
 ygg
-ygg
+sfu
 xyp
 xhd
 xhd
@@ -75891,7 +77953,7 @@ xhd
 xUQ
 uJa
 rIH
-uJa
+qBY
 fRK
 xyp
 uJa
@@ -75969,7 +78031,7 @@ acF
 acF
 acF
 acF
-rhF
+xEU
 fkL
 vZs
 tvB
@@ -76226,7 +78288,7 @@ xWk
 apC
 kFX
 rEK
-tuj
+iTS
 ids
 bUm
 vGt
@@ -76460,7 +78522,7 @@ gvi
 wWt
 mQA
 mQA
-aRG
+jHO
 yfY
 acc
 rLe
@@ -77218,7 +79280,7 @@ ePJ
 jdd
 vyu
 hoy
-bhm
+vCD
 yfY
 aYL
 twI
@@ -77438,7 +79500,7 @@ ayr
 tVH
 aAD
 aGo
-brq
+bKq
 ajP
 brq
 brI
@@ -77733,7 +79795,7 @@ yay
 oVO
 dMq
 pox
-vCD
+uyT
 yfY
 yfY
 aQU
@@ -77946,7 +80008,7 @@ arN
 arN
 atK
 adM
-ady
+pEs
 adF
 adM
 tVH
@@ -78246,8 +80308,8 @@ rSF
 bhd
 bor
 vyu
-mua
-mua
+bhm
+uyT
 yfY
 drj
 gvi
@@ -78513,12 +80575,12 @@ eId
 xMg
 fcD
 aRB
-aiA
+qcr
 fcr
 jAb
 aiA
 yfY
-cfI
+uWx
 rLe
 exH
 dIv
@@ -79513,7 +81575,7 @@ eBc
 anz
 bkg
 bkh
-bkh
+mcO
 iXz
 aQS
 bko
@@ -79570,7 +81632,7 @@ gPP
 cfI
 cfI
 edc
-bqm
+qCo
 mku
 ulu
 vPZ
@@ -80007,7 +82069,7 @@ ady
 xNm
 hzP
 aAK
-maz
+rPL
 xNm
 btv
 brB
@@ -80270,7 +82332,7 @@ aUd
 aVj
 aeN
 xNm
-aZT
+pZA
 cBO
 tGp
 tGp
@@ -80520,23 +82582,23 @@ avH
 bqZ
 xNm
 xNm
-aAN
 xNm
+pjm
 xNm
 xNm
 bsv
 xNm
 xNm
 bsy
-ivy
+hJJ
 tGp
 bjm
 bKk
-dVA
+uWN
 tGp
 jkp
 bjU
-ybn
+rUC
 ozS
 bjS
 gcu
@@ -80777,13 +82839,13 @@ xNm
 xNm
 xNm
 xNm
+tjQ
 aGy
-bcV
-ivy
+tUc
 ivy
 bsK
 vHo
-ivy
+tUc
 aZT
 bdJ
 tGp
@@ -80867,8 +82929,8 @@ vKo
 ulu
 ulu
 vHl
-fjt
-fjt
+suB
+lpI
 eko
 gfQ
 gfQ
@@ -81034,7 +83096,7 @@ xNm
 bre
 maz
 xNm
-qxD
+vPH
 aGy
 aGy
 agn
@@ -81124,8 +83186,8 @@ xFq
 ulu
 ulu
 vHl
-fjt
-fjt
+suB
+lpI
 eko
 gfQ
 gfQ
@@ -81550,13 +83612,13 @@ ayA
 xNm
 aAY
 ivy
-aVQ
+asd
 aUg
 aVz
 aWR
 aYI
 aZh
-aZT
+uKk
 bdK
 bqU
 bKm
@@ -81812,8 +83874,8 @@ aUh
 aVC
 aKu
 aYI
-ivy
 aTD
+nTh
 tGp
 aWe
 bKO
@@ -81859,7 +83921,7 @@ skV
 xcl
 xMh
 pnn
-cfI
+vAu
 rLe
 uio
 aoc
@@ -82063,18 +84125,18 @@ awv
 irO
 xNm
 aBa
-ivy
+nTh
 aLK
-oTu
+mPM
 oBl
+fHL
 aVQ
-aVQ
-rmK
-aZV
+feW
+nTh
 tGp
 tGp
 tGp
-teK
+lIv
 tGp
 dfX
 dyz
@@ -82082,17 +84144,17 @@ bdO
 eBg
 fid
 beu
-beN
+xUe
 beN
 jad
 jXG
 wSE
 mPg
-wSE
+jzd
 wfN
 wSE
 wSE
-wSE
+jzd
 tcM
 ujo
 wSE
@@ -82305,7 +84367,7 @@ wby
 nrY
 uUb
 oCD
-ygg
+sfu
 uwV
 ybK
 ybK
@@ -82314,24 +84376,24 @@ ybK
 ybK
 ybK
 hyg
-hIq
+vhx
 xNm
 kHI
 ayD
 azd
 aGy
-ivy
-rmK
+iIG
+auV
 auV
 aVG
 azZ
-aYJ
+aZV
 rmK
 aZX
 tGp
 brA
 bLd
-dVA
+vis
 tGp
 ybn
 bjU
@@ -82399,7 +84461,7 @@ eab
 geY
 tJB
 vmQ
-vmQ
+dTx
 xDX
 edi
 yam
@@ -82571,19 +84633,19 @@ yiQ
 yiQ
 yiQ
 aaj
-hIq
+vhx
 xNm
 vjO
 xFe
 xNm
 aBn
-aLc
-brU
-xNm
+nTh
+cQK
+cQK
 aMn
-xNm
-xNm
-ivy
+jSi
+tjQ
+cil
 bZD
 tGp
 btD
@@ -82835,10 +84897,10 @@ xNm
 xNm
 aBo
 rXA
-ljc
-xNm
+sJF
+kGC
 uDc
-uJv
+jSi
 xNm
 xNm
 xNm
@@ -83085,17 +85147,17 @@ gfQ
 gfQ
 gfQ
 ybK
-hIq
-yiQ
-yiQ
-gAn
+vhx
+adS
+oQL
 xNm
-aBx
-aLc
 ljc
-xNm
+aLc
+fWB
+gUA
+uOz
 aMp
-sKc
+tFF
 aMQ
 aZi
 sKc
@@ -83342,17 +85404,17 @@ gfQ
 gfQ
 fsz
 ybK
-hIq
-yiQ
-sRB
-yiQ
+vhx
+nOA
+oQL
 xNm
-xNm
+ljc
+aLc
 aLi
-xNm
-xNm
+hUx
+hUx
 aMq
-vzc
+jSi
 uJv
 aZk
 ePY
@@ -83408,7 +85470,7 @@ uln
 unF
 unF
 wXz
-unF
+tRi
 tTH
 aSG
 agw
@@ -83600,16 +85662,16 @@ gfQ
 gfQ
 ybK
 auH
-yiQ
-yiQ
-yiQ
-azg
-sQO
-yiQ
+adS
+rAk
+xNm
+xNm
+xNm
+mbr
 vaN
-yaE
-yaE
-yaE
+vaN
+vaN
+vaN
 aMS
 yaE
 yaE
@@ -83857,12 +85919,12 @@ gfQ
 gfQ
 ybK
 auJ
-hIq
-hIq
-hIq
-kbg
-yiQ
-yiQ
+okv
+okv
+rML
+pxw
+uvI
+uvI
 vaN
 xrI
 xrI
@@ -84134,7 +86196,7 @@ xrI
 eRs
 ybn
 bjU
-ybn
+sRL
 vqN
 cTt
 fEc
@@ -84373,7 +86435,7 @@ ybK
 iaf
 gxo
 ybK
-hIq
+hEh
 wrE
 yiQ
 aLr
@@ -84401,10 +86463,10 @@ fnK
 kjZ
 qnO
 mRb
-nBH
-iie
-sXv
-nFu
+tpF
+aCU
+aDS
+bWe
 ydF
 imf
 tQc
@@ -84630,7 +86692,7 @@ ybK
 aLB
 dGI
 ybK
-hIq
+hEh
 wrE
 kbg
 aLr
@@ -84661,7 +86723,7 @@ aPR
 nCm
 cnf
 iie
-nFu
+bWe
 ydF
 tlL
 tQc
@@ -84887,7 +86949,7 @@ ybK
 ybK
 ybK
 ybK
-hIq
+uYE
 kbg
 wrE
 aLs
@@ -85173,8 +87235,8 @@ knV
 tRt
 rmB
 nCs
-wVB
-evf
+yjE
+awt
 qUD
 rWP
 tqR
@@ -85985,7 +88047,7 @@ qAe
 cND
 cND
 cND
-qAe
+tsl
 cND
 hND
 wir
@@ -86426,11 +88488,11 @@ gfQ
 gfQ
 gfQ
 lEE
-wEK
-gAn
+nTi
+hGk
 sRB
 ayE
-aLF
+fVR
 aBz
 vhx
 vaN
@@ -86698,7 +88760,7 @@ aNa
 ahP
 aZZ
 jtc
-uJv
+sLV
 vzM
 uJv
 cQP
@@ -86713,7 +88775,7 @@ bgD
 jmn
 phb
 xIp
-uWM
+pfI
 nDC
 uWM
 pUX
@@ -87980,13 +90042,13 @@ aUs
 yiQ
 vro
 aYK
-aZl
+tZT
 aZl
 aNp
 aYK
 ecf
 nzD
-yiQ
+aBF
 xAk
 iwn
 eaJ
@@ -88033,7 +90095,7 @@ jig
 dCK
 tmj
 tLd
-tvz
+yal
 xsd
 xsd
 xsd
@@ -88291,12 +90353,12 @@ pCh
 tmj
 tLd
 yal
-dKw
+bdd
 pRZ
 itI
 wse
-gGu
-gGu
+llp
+sUT
 xsd
 gfQ
 gfQ
@@ -88507,7 +90569,7 @@ pjZ
 rpj
 oec
 aPm
-oec
+cnA
 dao
 juY
 kwD
@@ -88774,7 +90836,7 @@ pup
 hwL
 hwL
 lok
-koC
+tjs
 qBf
 kxW
 cQC
@@ -88805,7 +90867,7 @@ dCK
 tmj
 eiO
 yal
-yal
+tvz
 hvE
 yal
 yal
@@ -89025,7 +91087,7 @@ hnG
 nqc
 juY
 kxR
-ltr
+mUs
 mUy
 nOj
 mUy
@@ -89064,10 +91126,10 @@ tLd
 lnf
 yal
 wse
-yal
+wLS
 mFL
 mFL
-kQf
+dKw
 xsd
 gfQ
 gfQ
@@ -89282,7 +91344,7 @@ wUU
 wUU
 jvA
 ezk
-wRL
+bUl
 fUf
 nIB
 ygi
@@ -89291,7 +91353,7 @@ dOK
 dOK
 dOK
 dOK
-ioj
+lNp
 wpn
 ure
 pgy
@@ -89352,7 +91414,7 @@ gfQ
 idc
 fxj
 ngH
-uWf
+jXO
 tbB
 whm
 idc
@@ -89610,7 +91672,7 @@ idc
 mlW
 mnV
 uWf
-mnV
+fWJ
 utH
 idc
 gfQ
@@ -90031,7 +92093,7 @@ gfQ
 gfQ
 gfQ
 ybK
-wEK
+oli
 biX
 blr
 bjA
@@ -90605,7 +92667,7 @@ tmj
 ydD
 wse
 xsd
-gMq
+djN
 pbB
 qTO
 kga
@@ -90625,7 +92687,7 @@ gfQ
 xBZ
 dZb
 nsS
-wda
+fxT
 kqd
 wda
 rwq
@@ -91409,7 +93471,7 @@ khn
 kTy
 cAJ
 vGB
-cAJ
+lAZ
 kTy
 kTy
 kTy
@@ -91895,7 +93957,7 @@ iLZ
 qTO
 iTL
 xsd
-lQu
+caA
 ahf
 wNU
 whX
@@ -92136,7 +94198,7 @@ jig
 jig
 nSz
 kPK
-gID
+wjQ
 kmZ
 uDR
 uDR
@@ -92163,7 +94225,7 @@ fsz
 gfQ
 xBZ
 mwm
-iiy
+jMZ
 hTx
 thn
 wpL
@@ -92393,7 +94455,7 @@ cKi
 hou
 mqn
 cQR
-gID
+wjQ
 jsA
 lwL
 hsb
@@ -92433,7 +94495,7 @@ gfQ
 iQl
 iQl
 dCk
-uZb
+bpE
 cmf
 qMT
 iDZ
@@ -92604,7 +94666,7 @@ gfQ
 fsz
 xxF
 xII
-xII
+aSh
 xxF
 aZs
 xII
@@ -92650,10 +94712,10 @@ jig
 jig
 nSz
 kPK
-gID
+wjQ
 qTV
 uDR
-lHP
+vxy
 lHP
 tmj
 fXz
@@ -92677,7 +94739,7 @@ gfQ
 gfQ
 xBZ
 gQY
-iiy
+jMZ
 rST
 oiJ
 iLO
@@ -92907,10 +94969,10 @@ jig
 jig
 nSz
 kxZ
-gID
+wjQ
 vTl
 uDR
-lHP
+vxy
 oYo
 tmj
 xsd
@@ -92934,7 +94996,7 @@ gfQ
 gfQ
 xBZ
 rCW
-iiy
+jMZ
 biV
 oiJ
 pWw
@@ -93145,7 +95207,7 @@ qkf
 kGJ
 uAk
 tvm
-uyn
+uVM
 lMh
 wyS
 vvR
@@ -93159,7 +95221,7 @@ cTD
 pyP
 vBA
 tmj
-tmj
+oTB
 tmj
 tmj
 tmj
@@ -93167,7 +95229,7 @@ wXt
 dUW
 vTl
 uDR
-uDR
+uEa
 tmj
 tmj
 yal
@@ -93191,7 +95253,7 @@ gfQ
 gfQ
 iOP
 iOP
-umy
+oZO
 umy
 umy
 jTv
@@ -93388,7 +95450,7 @@ gfQ
 mVn
 xII
 cNO
-fzM
+cNO
 fzM
 fzM
 cNO
@@ -93421,10 +95483,10 @@ njM
 hKA
 mGj
 nlX
+tca
 nlX
 nlX
-nlX
-nlX
+okJ
 tmj
 apm
 yal
@@ -93644,7 +95706,7 @@ gfQ
 gfQ
 mVn
 xII
-cNO
+eAI
 cNO
 cNO
 cNO
@@ -94210,7 +96272,7 @@ cwY
 rVk
 qTO
 fzu
-yal
+uqo
 yal
 gGu
 fLa
@@ -94448,7 +96510,7 @@ bmr
 iIf
 qtO
 sEt
-vnF
+sEt
 sEt
 tAs
 qtO
@@ -94466,8 +96528,8 @@ xqY
 gbw
 xsd
 akO
-yal
-yal
+uWJ
+gMq
 gMq
 fLa
 fLa
@@ -94950,18 +97012,18 @@ pyP
 pyP
 pyP
 tGN
-tGN
-tGN
-tGN
-tGN
+qqE
+qqE
+qqE
+qqE
 nWX
 pyP
 vXD
 ieR
 qtO
 sUF
-xGm
-vnF
+etH
+fGy
 xGm
 vnF
 vnF
@@ -95221,7 +97283,7 @@ xGm
 xGm
 vnF
 xGm
-vnF
+xfF
 vjx
 gfQ
 gfQ
@@ -95696,7 +97758,7 @@ xII
 xII
 xII
 ciT
-uyr
+vhr
 xxF
 aWT
 xxF
@@ -95732,7 +97794,7 @@ qtO
 cYp
 vnF
 bSR
-xGm
+eBi
 qtO
 qtO
 fsz

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -435,6 +435,11 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"adm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "adn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white/side{
@@ -968,7 +973,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/camera/motion{
-	c_tag = "AI Upload";
+	c_tag = "Command - AI Upload";
 	dir = 8;
 	network = list("aiupload")
 	},
@@ -2179,6 +2184,10 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Cargo - Mining Shuttle Dock";
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "apG" = (
@@ -3168,6 +3177,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"axF" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_half,
+/area/cargo/miningdock)
 "axO" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3198,7 +3213,7 @@
 "axZ" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/machinery/camera{
-	c_tag = "Virology Break Room";
+	c_tag = "Medbay - Virology Break Room";
 	network = list("ss13","medbay")
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -4854,7 +4869,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/camera{
-	c_tag = "Bridge";
+	c_tag = "Command - Aft Bridge";
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/south,
@@ -5878,7 +5893,7 @@
 "aWf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter North";
+	c_tag = "Engineering - Supermatter - Fore";
 	dir = 1;
 	network = list("ss13","engine")
 	},
@@ -7266,7 +7281,7 @@
 "bgq" = (
 /obj/machinery/field/generator,
 /obj/machinery/camera{
-	c_tag = "Secure Storage";
+	c_tag = "Engineering - Secure Storage";
 	dir = 1;
 	network = list("ss13","engine")
 	},
@@ -7316,7 +7331,7 @@
 /area/maintenance/port/aft)
 "bgV" = (
 /obj/machinery/camera{
-	c_tag = "Gravity Generator Room";
+	c_tag = "Gravity Generator";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7360,7 +7375,7 @@
 /area/hallway/primary/central)
 "bhj" = (
 /obj/machinery/camera{
-	c_tag = "Virology Main";
+	c_tag = "Medbay - Virology Airlock";
 	dir = 4;
 	network = list("ss13","medbay")
 	},
@@ -7477,6 +7492,11 @@
 /obj/item/radio/intercom{
 	pixel_x = -29
 	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Lobby";
+	dir = 4;
+	network = list("ss13","engine")
+	},
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
 	},
@@ -7487,11 +7507,6 @@
 /area/service/bar)
 "bhZ" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/machinery/camera{
-	c_tag = "Engineering Lobby";
-	dir = 4;
-	network = list("ss13","engine")
-	},
 /obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron/dark/smooth_half{
 	dir = 1
@@ -8132,7 +8147,7 @@
 "boj" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
-	c_tag = "Gravity Generator Room";
+	c_tag = "Gravity Generator Exterior";
 	dir = 8
 	},
 /turf/open/space/basic,
@@ -8398,9 +8413,9 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "bsI" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/shaft_miner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
 /area/cargo/miningdock)
 "bsK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8596,7 +8611,7 @@
 "bwh" = (
 /obj/structure/cable,
 /obj/machinery/camera{
-	c_tag = "Brig Prison Hallway North West";
+	c_tag = "Security - Brigmed";
 	network = list("ss13","prison")
 	},
 /obj/effect/turf_decal/tile/red{
@@ -8641,6 +8656,10 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"bxJ" = (
+/obj/structure/table,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "bxK" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -8730,6 +8749,10 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera{
+	c_tag = "Command - Fore Bridge";
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/command/bridge)
 "bAg" = (
@@ -10100,6 +10123,10 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Aft Starboard Corner";
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "cwr" = (
@@ -10771,7 +10798,7 @@
 "cTt" = (
 /obj/structure/chair/sofa/corner,
 /obj/machinery/camera{
-	c_tag = "Medbay Breakroom"
+	c_tag = "Medbay - Breakroom"
 	},
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
@@ -11071,7 +11098,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Gravity Generator Room";
+	c_tag = "Gravity Generator Foyer";
 	dir = 10
 	},
 /turf/open/floor/iron/textured_half,
@@ -11875,7 +11902,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Atmos Entry";
+	c_tag = "Atmospherics - Entrance";
 	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -12453,7 +12480,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
+	c_tag = "Engineering - Supermatter Chamber";
 	dir = 4;
 	network = list("ss13","engine")
 	},
@@ -13058,6 +13085,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "dZv" = (
@@ -13068,9 +13096,6 @@
 	},
 /turf/open/floor/grass,
 /area/hallway/primary/central)
-"dZA" = (
-/turf/closed/wall/r_wall,
-/area/command)
 "dZB" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine{
@@ -13142,7 +13167,7 @@
 /area/science/lab)
 "eaK" = (
 /obj/machinery/camera{
-	c_tag = "Medbay Chemistry";
+	c_tag = "Medbay - Chemistry";
 	dir = 1;
 	network = list("ss13","medbay")
 	},
@@ -13466,7 +13491,7 @@
 	pixel_x = -31
 	},
 /obj/machinery/camera{
-	c_tag = "Captains Office";
+	c_tag = "Command - Captain's Office";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13954,7 +13979,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter South";
+	c_tag = "Engineering - Supermatter - Aft";
 	network = list("ss13","engine")
 	},
 /turf/open/floor/engine,
@@ -14507,12 +14532,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "eRN" = (
-/obj/structure/transit_tube/station/reverse{
-	dir = 1
-	},
-/obj/structure/transit_tube_pod{
-	dir = 4
-	},
+/obj/structure/transit_tube/station/dispenser/flipped,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
 "eSn" = (
@@ -14991,7 +15011,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Pharmacy"
+	c_tag = "Medbay - Pharmacy"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -15352,6 +15372,11 @@
 /area/hallway/primary/port)
 "flQ" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer/on,
+/obj/machinery/camera{
+	c_tag = "Telecommunications Chamber";
+	dir = 8;
+	network = list("ss13","engine")
+	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "flS" = (
@@ -15448,7 +15473,7 @@
 /area/maintenance/port/fore)
 "foE" = (
 /obj/machinery/camera{
-	c_tag = "Atmos Central";
+	c_tag = "Atmospherics - Central";
 	network = list("ss13","engine");
 	view_range = 10
 	},
@@ -15830,6 +15855,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/bot,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "fxU" = (
@@ -15933,6 +15959,7 @@
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "fAC" = (
@@ -16497,7 +16524,7 @@
 /area/cargo/drone_boy)
 "fUR" = (
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Fore Starboard";
+	c_tag = "MiniSat - Exterior - Fore Starboard";
 	dir = 4;
 	network = list("minisat")
 	},
@@ -16512,6 +16539,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "fVr" = (
@@ -17602,7 +17630,7 @@
 /area/engineering/main)
 "gxY" = (
 /obj/machinery/camera{
-	c_tag = "Engineering South";
+	c_tag = "Engineering - Equipment Room";
 	dir = 1;
 	network = list("ss13","engine")
 	},
@@ -18600,8 +18628,8 @@
 /area/ai_monitored/turret_protected/ai)
 "hbq" = (
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Fore Port";
-	dir = 8;
+	c_tag = "MiniSat- Exterior - Fore Port";
+	dir = 9;
 	network = list("minisat")
 	},
 /turf/open/space/basic,
@@ -19239,6 +19267,10 @@
 "htU" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Aux Chamber";
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
@@ -20160,6 +20192,10 @@
 	pixel_y = 30
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/camera{
+	c_tag = "Cargo - Mech Pad";
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "hYH" = (
@@ -20431,6 +20467,14 @@
 /obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"igr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/cargo/miningdock)
 "igv" = (
 /obj/machinery/camera{
 	c_tag = "Security - Interrogation";
@@ -20676,7 +20720,7 @@
 "ipn" = (
 /obj/structure/bookcase/random/reference,
 /obj/machinery/camera{
-	c_tag = "Medbay Psychologist's Office";
+	c_tag = "Medbay - Psychologist's Office";
 	dir = 8;
 	network = list("ss13","medbay")
 	},
@@ -20686,7 +20730,7 @@
 "ipo" = (
 /obj/structure/cable,
 /obj/machinery/camera{
-	c_tag = "Medbay South Hallway";
+	c_tag = "Medbay - Aft Hallway";
 	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21484,6 +21528,13 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
+"iPX" = (
+/obj/structure/cable/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/tcommsat/computer)
 "iQl" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/aisat/exterior)
@@ -21764,7 +21815,7 @@
 	},
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /obj/machinery/camera{
-	c_tag = "Cargo Bay";
+	c_tag = "Cargo - Bay";
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -22350,6 +22401,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"jrt" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Port";
+	dir = 4;
+	network = list("ss13","engine");
+	view_range = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jrE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22365,7 +22432,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/camera{
-	c_tag = "Bridge Entry East";
+	c_tag = "Command - Port Bridge Entrance";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22530,7 +22597,7 @@
 "jvy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/camera{
-	c_tag = "Engineering North";
+	c_tag = "Engineering - Central";
 	dir = 8;
 	network = list("ss13","engine")
 	},
@@ -23820,7 +23887,7 @@
 	pixel_y = 25
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay North Hallway";
+	c_tag = "Medbay - Fore Hallway";
 	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24048,6 +24115,7 @@
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "kqh" = (
@@ -24225,7 +24293,7 @@
 "kuM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
-	c_tag = "Cargo Warehouse"
+	c_tag = "Cargo - Warehouse"
 	},
 /turf/open/floor/iron,
 /area/cargo/warehouse)
@@ -24860,9 +24928,9 @@
 /area/tcommsat/server)
 "kKX" = (
 /obj/machinery/camera{
-	c_tag = "Turbine Room";
+	c_tag = "Atmospherics - Turbine Room";
 	dir = 4;
-	network = list("ss13","engine")
+	network = list("ss13","engine","turbine")
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -24966,7 +25034,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "kNc" = (
 /obj/machinery/camera{
-	c_tag = "SMES Storage";
+	c_tag = "Engineering - SMES Storage";
 	dir = 1;
 	network = list("ss13","engine")
 	},
@@ -25129,7 +25197,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
 /area/cargo/miningdock)
 "kTy" = (
 /turf/closed/wall/r_wall,
@@ -25347,7 +25417,7 @@
 /area/service/library)
 "ldl" = (
 /obj/machinery/camera{
-	c_tag = "Captains Quarters"
+	c_tag = "Command - Captain's Quarters"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -26004,7 +26074,7 @@
 	network = list("mine","auxbase","vault","qm")
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo Quartermaster's Office";
+	c_tag = "Command - Quartermaster's Office";
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -26071,7 +26141,7 @@
 /area/maintenance/disposal/incinerator)
 "lvR" = (
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Aft Starboard";
+	c_tag = "MiniSat - Exterior - Aft Starboard";
 	dir = 4;
 	network = list("minisat")
 	},
@@ -26275,8 +26345,8 @@
 /area/maintenance/central/secondary)
 "lDV" = (
 /obj/machinery/camera{
-	c_tag = "AI Satellite - Fore";
-	dir = 1;
+	c_tag = "MiniSat - Exterior - Fore";
+	dir = 10;
 	name = "ai camera";
 	network = list("minisat");
 	start_active = 1
@@ -26579,7 +26649,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo Office";
+	c_tag = "Cargo - Office";
 	dir = 4
 	},
 /obj/structure/cable,
@@ -26593,7 +26663,7 @@
 	name = "bridge blast door"
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge Entry West";
+	c_tag = "Command - Starboard Bridge Entrance";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/end{
@@ -26778,7 +26848,7 @@
 /area/maintenance/central/secondary)
 "lRx" = (
 /obj/machinery/camera{
-	c_tag = "Mining Dock East";
+	c_tag = "Cargo - Mining Office Processing";
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/east,
@@ -27167,11 +27237,6 @@
 /obj/effect/landmark/start/paramedic,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
-"mcU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/cargo/miningdock)
 "mdd" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -27304,6 +27369,11 @@
 	},
 /obj/structure/reagent_dispensers/fueltank/large,
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Fore";
+	network = list("ss13","engine");
+	view_range = 10
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mgE" = (
@@ -27939,6 +28009,13 @@
 	name = "black plastitanium floor"
 	},
 /area/maintenance/central)
+"mwG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/cargo/miningdock)
 "mwH" = (
 /obj/structure/window,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -28325,6 +28402,7 @@
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "mJy" = (
@@ -28422,6 +28500,7 @@
 /area/security/execution/transfer)
 "mLA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "mLC" = (
@@ -28493,7 +28572,6 @@
 	dir = 4
 	},
 /obj/structure/cable/multilayer/connected,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "mOE" = (
@@ -29150,7 +29228,7 @@
 /area/service/library)
 "nfy" = (
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Aft Port";
+	c_tag = "MiniSat - Exterior - Aft Port";
 	dir = 8;
 	network = list("minisat")
 	},
@@ -29302,6 +29380,9 @@
 /area/science/xenobiology)
 "njN" = (
 /obj/machinery/computer/cargo/request,
+/obj/machinery/camera{
+	c_tag = "Cargo - Lobby"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "njR" = (
@@ -29426,13 +29507,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"npm" = (
-/obj/machinery/camera{
-	c_tag = "Bridge";
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblue,
-/area/command/bridge)
 "npv" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -29584,8 +29658,6 @@
 /obj/structure/cable/multilayer/connected,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer1,
-/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "nsU" = (
@@ -30666,7 +30738,7 @@
 /area/security/office)
 "nXT" = (
 /obj/machinery/camera{
-	c_tag = "Mining Dock West";
+	c_tag = "Cargo - Mining Office";
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -30999,7 +31071,7 @@
 /area/science/xenobiology)
 "ogN" = (
 /obj/machinery/camera/motion{
-	c_tag = "MiniSat Maintenance";
+	c_tag = "MiniSat - Maintenance";
 	dir = 1;
 	network = list("minisat")
 	},
@@ -31121,6 +31193,10 @@
 /obj/machinery/recharger{
 	pixel_x = -4;
 	pixel_y = 3
+	},
+/obj/machinery/camera{
+	c_tag = "Command - Port Bridge";
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/command/bridge)
@@ -31269,7 +31345,7 @@
 "ooP" = (
 /obj/machinery/light,
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior Access West";
+	c_tag = "Command - Transit Tubes";
 	dir = 1;
 	network = list("minisat")
 	},
@@ -31297,6 +31373,13 @@
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
+"ope" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/shaft_miner,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "opY" = (
 /turf/open/floor/iron,
 /area/security/execution/transfer)
@@ -31756,10 +31839,11 @@
 	},
 /area/maintenance/port)
 "oCY" = (
-/obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
 /area/cargo/miningdock)
 "oDu" = (
 /obj/machinery/atmospherics/components/unary/bluespace_sender,
@@ -32009,7 +32093,7 @@
 /area/security/brig)
 "oKh" = (
 /obj/machinery/camera{
-	c_tag = "Cargo Drone Bay"
+	c_tag = "Cargo - Drone Bay"
 	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
@@ -32432,6 +32516,10 @@
 "oXl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera{
+	c_tag = "Command - Secure Tech Storage";
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "oXq" = (
@@ -32508,7 +32596,7 @@
 	req_access_txt = null
 	},
 /obj/machinery/camera{
-	c_tag = "Library";
+	c_tag = "Service - Library";
 	dir = 1
 	},
 /obj/structure/sign/poster/official/random{
@@ -33655,10 +33743,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"pJM" = (
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron/showroomfloor,
-/area/ai_monitored/turret_protected/aisat/foyer)
 "pJW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
@@ -33689,6 +33773,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/engineering/main)
+"pKp" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Aft";
+	dir = 1;
+	network = list("ss13","engine");
+	view_range = 10
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "pKs" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -34094,7 +34191,6 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "qab" = (
-/obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -34140,6 +34236,12 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/brown,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Starboard";
+	dir = 8;
+	network = list("ss13","engine");
+	view_range = 10
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -34233,7 +34335,7 @@
 	pixel_y = -1
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo Delivery Office";
+	c_tag = "Cargo - Delivery Office";
 	dir = 4
 	},
 /obj/item/hand_labeler{
@@ -34659,7 +34761,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Freezers";
+	c_tag = "Engineering - Supermatter - Port";
 	dir = 4;
 	network = list("ss13","engine")
 	},
@@ -35023,6 +35125,10 @@
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = -22
+	},
+/obj/machinery/camera{
+	c_tag = "Service - Library Backroom";
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/service/library)
@@ -35699,15 +35805,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
-"rac" = (
-/obj/machinery/camera{
-	c_tag = "Telecommunications Chamber";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark/telecomms,
-/area/tcommsat/server)
 "rae" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -36071,7 +36168,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/camera{
-	c_tag = "Atmos Storage";
+	c_tag = "Atmospherics - Control Room";
 	network = list("ss13","engine");
 	view_range = 10
 	},
@@ -36476,6 +36573,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "rwr" = (
@@ -37281,7 +37379,7 @@
 /area/science/mixing)
 "rYg" = (
 /obj/machinery/camera{
-	c_tag = "Emitter Room";
+	c_tag = "Engineering - Emitter Room";
 	network = list("ss13","engine")
 	},
 /obj/machinery/light{
@@ -37849,7 +37947,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/camera{
-	c_tag = "Virology Main 2";
+	c_tag = "Medbay - Virology";
 	dir = 1;
 	network = list("ss13","medbay")
 	},
@@ -38267,7 +38365,7 @@
 "sAF" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/camera{
-	c_tag = "CE's Room";
+	c_tag = "Command - Chief Engineer's Office";
 	network = list("ss13","engine")
 	},
 /obj/machinery/requests_console{
@@ -39099,7 +39197,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera{
-	c_tag = "Medbay Lobby";
+	c_tag = "Medbay - Lobby";
 	dir = 1;
 	network = list("ss13","medbay")
 	},
@@ -39498,7 +39596,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/cargo/miningdock)
 "tgo" = (
 /obj/machinery/airalarm{
@@ -39510,7 +39608,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Treatment Center";
+	c_tag = "Medbay - Treatment Center";
 	dir = 1;
 	network = list("ss13","medbay")
 	},
@@ -39526,7 +39624,7 @@
 "thn" = (
 /obj/structure/cable,
 /obj/machinery/camera{
-	c_tag = "Bridge Entry East";
+	c_tag = "Telecommunications Control Room";
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/west,
@@ -39734,6 +39832,10 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Port Hallway - Atmospherics";
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "tll" = (
@@ -39862,7 +39964,7 @@
 /area/medical/exam_room)
 "tpK" = (
 /obj/machinery/camera{
-	c_tag = "Bridge Hallway West";
+	c_tag = "Command - Starboard Bridge Hallway";
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -39900,7 +40002,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_half,
 /area/cargo/miningdock)
 "tqO" = (
 /obj/machinery/airalarm{
@@ -39983,7 +40088,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera{
-	c_tag = "Medbay Cryogenics";
+	c_tag = "Medbay - Cryogenics";
 	dir = 1;
 	network = list("ss13","medbay")
 	},
@@ -40064,6 +40169,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"tth" = (
+/obj/effect/landmark/start/shaft_miner,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "ttH" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/iron/cafeteria,
@@ -40109,12 +40218,6 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
 	name = "Pure Inlet Pump"
-	},
-/obj/machinery/camera{
-	c_tag = "Atmos West";
-	dir = 4;
-	network = list("ss13","engine");
-	view_range = 10
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -41114,7 +41217,7 @@
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera{
-	c_tag = "Medbay Storage"
+	c_tag = "Medbay - Storage"
 	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
@@ -42167,7 +42270,7 @@
 /obj/structure/tank_dispenser/oxygen,
 /obj/structure/cable,
 /obj/machinery/camera{
-	c_tag = "Security - EVA Storage & Brigmed";
+	c_tag = "Security - EVA Storage";
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
@@ -42807,10 +42910,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"uOL" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Aft Port Corner";
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uOT" = (
 /obj/machinery/vending/assist,
 /obj/machinery/camera{
-	c_tag = "Tech Storage"
+	c_tag = "Engineering - Tech Storage"
 	},
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark,
@@ -43773,11 +43883,10 @@
 /area/maintenance/central)
 "vqs" = (
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior Access - East";
+	c_tag = "MiniSat - Foyer";
 	dir = 1;
 	network = list("minisat")
 	},
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "vqK" = (
@@ -44602,7 +44711,7 @@
 /area/security/prison)
 "vIg" = (
 /obj/machinery/camera/motion{
-	c_tag = "MiniSat Foyer";
+	c_tag = "MiniSat - Teleporter";
 	dir = 4;
 	network = list("minisat")
 	},
@@ -44846,6 +44955,12 @@
 "vPD" = (
 /obj/machinery/light,
 /obj/machinery/portable_atmospherics/canister,
+/obj/machinery/camera{
+	c_tag = "Atmospherics - Supermatter Entrance";
+	dir = 4;
+	network = list("ss13","engine");
+	view_range = 10
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vPH" = (
@@ -45335,6 +45450,7 @@
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "wdx" = (
@@ -45655,11 +45771,11 @@
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
 "wmO" = (
-/obj/structure/transit_tube/station/reverse/flipped,
+/obj/structure/transit_tube/station/dispenser/flipped,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "wnD" = (
-/obj/machinery/newscaster/directional/south,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "wnE" = (
@@ -47260,7 +47376,7 @@
 /area/service/theater)
 "xed" = (
 /obj/machinery/camera{
-	c_tag = "Bridge Hallway East";
+	c_tag = "Command - Port Bridge Hallway";
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
@@ -47311,7 +47427,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Engineering North Hall";
+	c_tag = "Engineering - Fore Hall";
 	dir = 8;
 	network = list("ss13","engine")
 	},
@@ -47550,7 +47666,8 @@
 "xmS" = (
 /obj/structure/lattice,
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Aft";
+	c_tag = "MiniSat - Exterior - Aft";
+	dir = 6;
 	network = list("minisat")
 	},
 /turf/open/space/basic,
@@ -47587,7 +47704,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay Morgue";
+	c_tag = "Medbay - Morgue";
 	dir = 8;
 	network = list("ss13","medbay")
 	},
@@ -47607,6 +47724,7 @@
 /area/engineering/atmos)
 "xoM" = (
 /obj/structure/closet/firecloset,
+/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "xoP" = (
@@ -49194,7 +49312,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera{
-	c_tag = "Medbay Surgery";
+	c_tag = "Medbay - Surgery";
 	dir = 1;
 	network = list("ss13","medbay")
 	},
@@ -49333,16 +49451,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"yfA" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "Atmos South";
-	dir = 1;
-	network = list("ss13","engine");
-	view_range = 10
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "yfW" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -49581,7 +49689,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Medbay CMO Office";
+	c_tag = "Command - Chief Medical Officer's Office";
 	dir = 1;
 	network = list("ss13","medbay")
 	},
@@ -64407,7 +64515,7 @@ cwS
 lpf
 juJ
 lpf
-cwS
+jrt
 qgD
 sJu
 lpf
@@ -64415,7 +64523,7 @@ oeh
 lpf
 nsx
 xzY
-xzY
+uOL
 bnA
 bnA
 bnA
@@ -66985,7 +67093,7 @@ xzY
 tTR
 kcx
 wOk
-yfA
+rCg
 cES
 fsz
 fsz
@@ -67243,7 +67351,7 @@ sXJ
 waO
 wOk
 xzY
-cES
+pKp
 vSM
 vSM
 vSM
@@ -79565,7 +79673,7 @@ sKV
 cxs
 pSt
 aqg
-pSt
+ope
 hql
 rEK
 rEK
@@ -79822,7 +79930,7 @@ fjZ
 acF
 kSo
 vjA
-pSt
+bxJ
 pSt
 rEK
 gfQ
@@ -80078,7 +80186,7 @@ vfG
 jdB
 acF
 bsI
-vjA
+mwG
 agJ
 pSt
 rEK
@@ -80334,9 +80442,9 @@ sIc
 fyC
 eEE
 rEK
-pSt
+axF
 oCY
-pSt
+tth
 lpp
 acF
 gfQ
@@ -80592,8 +80700,8 @@ fyC
 oTO
 rEK
 tqB
-mcU
-pSt
+oCY
+tth
 hMX
 acF
 gfQ
@@ -80849,7 +80957,7 @@ ceQ
 oQJ
 snF
 tgf
-mcU
+oCY
 mLA
 hMX
 acF
@@ -81106,7 +81214,7 @@ sIc
 moX
 rEK
 kTp
-hql
+igr
 qab
 qXs
 acF
@@ -89082,7 +89190,7 @@ ezH
 erg
 tJq
 dIV
-npm
+jaa
 dfA
 hfO
 qKs
@@ -89330,7 +89438,7 @@ bvf
 bvf
 bvf
 bvf
-dZA
+bvf
 bvf
 orD
 hDh
@@ -92428,7 +92536,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-eqS
+khn
 wkn
 jZO
 poS
@@ -92689,7 +92797,7 @@ khn
 fWC
 jZO
 rpp
-eqS
+khn
 khn
 khn
 gfQ
@@ -93199,14 +93307,14 @@ gfQ
 gfQ
 xAV
 gfQ
-khn
-pJM
+adm
+iiy
 fJZ
 wmO
 iiy
 vqs
 eqS
-khn
+adm
 khn
 jgU
 lrE
@@ -93456,7 +93564,7 @@ fsz
 gfQ
 gfQ
 gfQ
-khn
+adm
 dZb
 nsS
 fxT
@@ -93713,14 +93821,14 @@ gfQ
 gfQ
 gfQ
 gfQ
-khn
+adm
 gYL
 mJl
 iiy
 fwg
 wnD
 eqS
-khn
+adm
 khn
 eJj
 nhU
@@ -94228,9 +94336,9 @@ gfQ
 gfQ
 gfQ
 gfQ
-xBZ
-hLU
-xBZ
+oiJ
+iPX
+oiJ
 gfQ
 gfQ
 gfQ
@@ -94484,10 +94592,10 @@ gfQ
 gfQ
 gfQ
 gfQ
-fsz
-xBZ
+mfS
+oiJ
 hLU
-xBZ
+oiJ
 gfQ
 gfQ
 gfQ
@@ -96284,7 +96392,7 @@ iOP
 nff
 blp
 kKP
-rac
+aRr
 mRm
 aRr
 fnJ

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -1515,6 +1515,8 @@
 /area/hallway/secondary/entry)
 "ald" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ale" = (
@@ -4222,6 +4224,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "aIr" = (
@@ -5412,6 +5416,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "aRT" = (
@@ -7160,6 +7166,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "beO" = (
@@ -9667,7 +9676,9 @@
 "cch" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plastic,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/hallway/secondary/service)
 "ccl" = (
 /obj/structure/window{
@@ -9715,6 +9726,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/command/bridge)
 "cdD" = (
@@ -12015,7 +12027,9 @@
 /area/tcommsat/server)
 "dxa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/security/warden)
 "dxo" = (
 /obj/effect/turf_decal/stripes/line,
@@ -12160,6 +12174,8 @@
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "dAl" = (
@@ -13303,6 +13319,10 @@
 /obj/machinery/modular_computer/console/preset/cargochat/engineering{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "eai" = (
@@ -13332,10 +13352,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
-"eaG" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/large,
-/area/engineering/main)
 "eaJ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/purple{
@@ -14210,6 +14226,10 @@
 /obj/machinery/computer/cargo/request{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron/dark,
 /area/engineering/break_room)
 "eBT" = (
@@ -14392,7 +14412,9 @@
 "eJQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/large,
 /area/engineering/atmos/upper)
 "eJV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16020,7 +16042,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "fxU" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -16112,6 +16135,11 @@
 "fzM" = (
 /turf/open/floor/engine,
 /area/science/explab)
+"fAc" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
+/turf/open/floor/iron/sepia,
+/area/service/chapel/main)
 "fAy" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -17037,7 +17065,9 @@
 "gcu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/medical/pharmacy)
 "gcC" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -18872,6 +18902,8 @@
 /area/security/brig)
 "hev" = (
 /obj/effect/landmark/start/psychologist,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "hfb" = (
@@ -19068,7 +19100,9 @@
 /area/engineering/gravity_generator)
 "hkq" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron/white,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/medical/storage)
 "hkM" = (
 /obj/machinery/airalarm{
@@ -19122,6 +19156,11 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"hlW" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/security/execution/transfer)
 "hmb" = (
 /obj/structure/chair{
 	dir = 1
@@ -19197,9 +19236,9 @@
 	},
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "hou" = (
@@ -19863,6 +19902,19 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"hJo" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/cable,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/cargo/office)
 "hJH" = (
 /obj/machinery/air_sensor/atmos/mix_tank{
 	id_tag = "mix2_sensor"
@@ -22113,6 +22165,8 @@
 "jbR" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "jcc" = (
@@ -22452,7 +22506,9 @@
 /area/cargo/qm)
 "jnT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/engineering/break_room)
 "joz" = (
 /obj/machinery/status_display/evac/directional/north,
@@ -22969,6 +23025,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"jBL" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/carpet/cyan,
+/area/hallway/primary/port)
 "jBN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/start/hangover,
@@ -23651,6 +23713,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
 "jXT" = (
@@ -23665,6 +23728,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/wood,
 /area/service/library)
 "jYl" = (
@@ -24868,6 +24933,13 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"kGx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/cargo/miningdock)
 "kGC" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -26676,6 +26748,8 @@
 	pixel_x = -6;
 	pixel_y = -24
 	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "lLh" = (
@@ -30030,7 +30104,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad/secure,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/tcommsat/computer)
 "nBH" = (
 /obj/effect/turf_decal/tile/blue{
@@ -30771,6 +30846,7 @@
 "nWg" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "nWs" = (
@@ -31498,7 +31574,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/cafeteria,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/service/kitchen)
 "opY" = (
 /turf/open/floor/iron,
@@ -31909,6 +31987,7 @@
 	uses = 10
 	},
 /obj/machinery/holopad/secure,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "oBl" = (
@@ -32977,6 +33056,13 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron,
 /area/science/storage)
+"piQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/carpet/red,
+/area/service/chapel/main)
 "piW" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -33125,7 +33211,7 @@
 "pmn" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/command/heads_quarters/rd)
 "pmw" = (
 /obj/structure/table/wood/bar,
@@ -33967,6 +34053,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"pMx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/security/prison)
 "pME" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -34941,6 +35035,14 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
+"qqt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qqC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
 	dir = 8
@@ -35177,8 +35279,9 @@
 /area/maintenance/central)
 "qxD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "qxO" = (
@@ -35946,6 +36049,8 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "qZR" = (
@@ -39569,6 +39674,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
+"sYy" = (
+/obj/structure/chair,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/security/courtroom)
 "sYz" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/red,
@@ -40306,6 +40417,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/command/bridge)
 "tsz" = (
@@ -41293,6 +41405,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
 "tSy" = (
@@ -41655,7 +41769,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/service/hydroponics)
 "udV" = (
 /obj/structure/table/glass,
@@ -42333,6 +42447,8 @@
 "uwb" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "uwe" = (
@@ -44298,7 +44414,8 @@
 	},
 /obj/machinery/holopad/secure,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
 /area/tcommsat/computer)
 "vuN" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -45240,6 +45357,7 @@
 /obj/machinery/holopad/secure,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "vSt" = (
@@ -45629,7 +45747,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/command/heads_quarters/cmo)
 "wda" = (
 /obj/structure/cable/layer3,
@@ -46051,7 +46169,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron,
 /area/science/robotics/lab)
 "wqn" = (
 /obj/machinery/computer/security/telescreen/vault{
@@ -46356,6 +46474,11 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
+"wzT" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/carpet/royalblue,
+/area/command/corporate_showroom)
 "wzZ" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/orange,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -46484,6 +46607,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "wDc" = (
@@ -46604,6 +46729,7 @@
 	pixel_x = 24;
 	pixel_y = -22
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "wHG" = (
@@ -46694,7 +46820,9 @@
 /area/science/research)
 "wKf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
+/turf/open/floor/iron,
 /area/engineering/engine_smes)
 "wKh" = (
 /obj/machinery/door/airlock/external{
@@ -47833,6 +47961,7 @@
 	pixel_x = 24;
 	pixel_y = 22
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "xmL" = (
@@ -48818,6 +48947,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "xLg" = (
@@ -48947,6 +49077,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/security/brig)
 "xQm" = (
@@ -63328,7 +63460,7 @@ ftA
 gQk
 bzC
 cgJ
-opY
+hlW
 fIE
 ihX
 lEY
@@ -67176,7 +67308,7 @@ spv
 osZ
 wBx
 osZ
-osZ
+pMx
 osZ
 osZ
 hKJ
@@ -67272,7 +67404,7 @@ fsz
 joR
 bnA
 itf
-cZH
+qqt
 gIp
 xzY
 nDS
@@ -68267,7 +68399,7 @@ ydM
 ukV
 qnh
 uOp
-eaG
+fsX
 lEQ
 wVb
 eYM
@@ -72342,7 +72474,7 @@ wzD
 tIA
 rEE
 vJh
-pWJ
+sYy
 gOB
 smM
 xun
@@ -74117,7 +74249,7 @@ xUQ
 uxJ
 vUW
 ksI
-wyf
+fAc
 aCs
 axs
 npx
@@ -74431,7 +74563,7 @@ xok
 grH
 xSz
 xSz
-beC
+jBL
 oiT
 vYu
 wAv
@@ -75153,7 +75285,7 @@ aWu
 mIL
 aWu
 nRK
-nRK
+piQ
 nRK
 aWt
 sVb
@@ -79065,7 +79197,7 @@ clA
 rxU
 aKw
 pjf
-ihq
+hJo
 bBW
 paT
 acF
@@ -79585,7 +79717,7 @@ mKV
 vul
 dqX
 dqX
-lnE
+kGx
 lnE
 rpZ
 xwj
@@ -86261,7 +86393,7 @@ uio
 fdc
 etA
 ppj
-nck
+wzT
 xoP
 tTH
 aSF

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -3609,10 +3609,12 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/status_display/evac/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/cold/directional/north,
+/obj/structure/sink/kitchen{
+	pixel_y = 22
+	},
 /turf/open/floor/iron/cafeteria,
 /area/commons/dorms)
 "aBp" = (
@@ -13060,7 +13062,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "dZv" = (
 /obj/structure/flora/junglebush/b,
 /obj/item/toy/plush/snakeplushie,
@@ -13380,6 +13382,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green,
 /turf/open/floor/engine,
 /area/engineering/main)
+"ejX" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/cafeteria,
+/area/commons/dorms)
 "ekh" = (
 /obj/machinery/light{
 	dir = 4
@@ -13535,7 +13547,7 @@
 "eqS" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "eqU" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
@@ -15665,7 +15677,7 @@
 "fwg" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "fwj" = (
 /obj/machinery/camera{
 	c_tag = "Experimentor Lab";
@@ -15775,7 +15787,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "fxU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -16100,7 +16112,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "fKe" = (
 /obj/effect/landmark/start/scientist,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -16426,7 +16438,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "fVr" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -16507,7 +16519,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "fWF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -16715,7 +16727,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "gaE" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
@@ -18360,7 +18372,7 @@
 "gYL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "gZh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
@@ -20296,7 +20308,7 @@
 /area/medical/exam_room)
 "iiy" = (
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "ijy" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -23330,7 +23342,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "kal" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23875,7 +23887,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "kqh" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark,
@@ -28034,6 +28046,12 @@
 /obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"mJl" = (
+/obj/structure/cable/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "mJy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -28252,7 +28270,7 @@
 "mQu" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "mQA" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -29282,7 +29300,7 @@
 /obj/structure/cable/layer1,
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "nsU" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -32681,7 +32699,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/space/basic,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "ppj" = (
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/carpet/royalblue,
@@ -35886,7 +35904,7 @@
 /obj/structure/transit_tube/horizontal,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "rpt" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/lab)
@@ -43311,7 +43329,7 @@
 	network = list("minisat")
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "vqK" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -44842,7 +44860,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "wdx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
@@ -45080,7 +45098,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "wkU" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -45156,7 +45174,7 @@
 "wmO" = (
 /obj/structure/transit_tube/station/reverse/flipped,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "wnE" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
@@ -47053,7 +47071,7 @@
 "xoM" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "xoP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -47187,7 +47205,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "xsd" = (
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
@@ -48395,7 +48413,7 @@
 "xZa" = (
 /obj/structure/transit_tube/horizontal,
 /turf/open/floor/iron/showroomfloor,
-/area/tcommsat/computer)
+/area/ai_monitored/turret_protected/aisat/foyer)
 "xZv" = (
 /obj/machinery/power/solar{
 	id = "foreportsolar";
@@ -85576,7 +85594,7 @@ nOA
 oQL
 xNm
 ljc
-aLc
+ejX
 aLi
 hUx
 hUx
@@ -92080,13 +92098,13 @@ gfQ
 gfQ
 gfQ
 gfQ
-xBZ
+khn
 fWC
 jZO
 rpp
 eqS
-xBZ
-xBZ
+khn
+khn
 gfQ
 khn
 khn
@@ -92337,13 +92355,13 @@ gfQ
 gfQ
 gfQ
 gfQ
-xBZ
+khn
 gay
 jZO
 xZa
 mQu
 xoM
-xBZ
+khn
 gfQ
 khn
 cbo
@@ -92594,7 +92612,7 @@ gfQ
 gfQ
 xAV
 gfQ
-xBZ
+khn
 iiy
 fJZ
 wmO
@@ -92851,7 +92869,7 @@ fsz
 gfQ
 gfQ
 gfQ
-xBZ
+khn
 dZb
 nsS
 fxT
@@ -93108,9 +93126,9 @@ gfQ
 gfQ
 gfQ
 gfQ
-xBZ
+khn
 gYL
-hLU
+mJl
 iiy
 fwg
 iiy
@@ -93365,13 +93383,13 @@ fsz
 gfQ
 gfQ
 gfQ
-xBZ
+khn
 eqS
 fUT
 eqS
-xBZ
-xBZ
-xBZ
+khn
+khn
+khn
 gfQ
 khn
 vlR

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -43,6 +43,14 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
+"aau" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
+/area/hallway/secondary/entry)
 "aaw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/airless,
@@ -301,6 +309,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/theater)
 "acf" = (
@@ -725,6 +734,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "aeJ" = (
@@ -1068,6 +1078,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "agS" = (
@@ -1122,11 +1133,13 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "ahz" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "ahC" = (
@@ -1134,6 +1147,7 @@
 	name = "Kitchen"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "ahD" = (
@@ -1275,6 +1289,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "ajp" = (
@@ -1289,6 +1304,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "aju" = (
@@ -1587,6 +1603,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "alH" = (
@@ -1620,6 +1637,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "alO" = (
@@ -1834,6 +1852,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/brig)
 "amP" = (
@@ -2230,6 +2249,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "apC" = (
@@ -2275,6 +2295,7 @@
 /obj/effect/landmark/start/prisoner,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "aqg" = (
@@ -2348,6 +2369,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "arv" = (
@@ -3518,6 +3540,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "aAs" = (
@@ -3525,6 +3548,7 @@
 	name = "Chapel Office";
 	req_access_txt = "22"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "aAD" = (
@@ -4650,12 +4674,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
-"aMS" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "aMX" = (
@@ -6114,6 +6132,7 @@
 	req_access_txt = "24"
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/upper)
 "aXG" = (
@@ -6559,6 +6578,7 @@
 "bai" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /obj/machinery/light/cold/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/plastic,
 /area/hallway/secondary/service)
 "bak" = (
@@ -6725,6 +6745,7 @@
 	name = "Interrogation";
 	req_access_txt = "63"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "bbX" = (
@@ -6886,6 +6907,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Fitness"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "bdp" = (
@@ -6945,6 +6967,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "bdM" = (
@@ -7005,6 +7028,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom Vending"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "bel" = (
@@ -7071,6 +7095,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "bez" = (
@@ -7158,6 +7183,7 @@
 	req_access_txt = "35"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "bfe" = (
@@ -7383,6 +7409,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/main)
 "bhd" = (
@@ -8404,6 +8431,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel Viewing Room"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "bsf" = (
@@ -8579,6 +8607,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "buJ" = (
@@ -9148,6 +9177,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "bNd" = (
@@ -9337,6 +9367,7 @@
 	req_one_access_txt = "22;25;26;28;35;37;38;46"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
 "bVm" = (
@@ -10318,6 +10349,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "cAB" = (
@@ -10555,6 +10587,11 @@
 "cJC" = (
 /turf/open/floor/engine/o2,
 /area/engineering/atmos)
+"cJQ" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "cKi" = (
 /obj/effect/spawner/lootdrop/two_percent_xeno_egg_spawner,
 /turf/open/floor/engine,
@@ -10718,6 +10755,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "cQC" = (
@@ -11114,6 +11152,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "dbq" = (
@@ -11702,6 +11741,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
 "dsI" = (
@@ -12438,6 +12478,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "dJf" = (
@@ -13584,6 +13625,7 @@
 /obj/machinery/computer/cargo{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
 "epn" = (
@@ -13639,6 +13681,7 @@
 /obj/structure/table/wood/poker,
 /obj/item/clothing/glasses/monocle,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
 "erb" = (
@@ -13846,6 +13889,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "evz" = (
@@ -14007,6 +14051,7 @@
 /area/hallway/primary/starboard)
 "eAq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "eAy" = (
@@ -14463,7 +14508,7 @@
 	dir = 8;
 	name = "service camera"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/cafeteria,
 /area/service/theater)
 "eOU" = (
 /obj/effect/decal/remains/human,
@@ -14512,6 +14557,7 @@
 /area/service/hydroponics)
 "ePQ" = (
 /obj/structure/bookcase/random/fiction,
+/obj/machinery/bounty_board/directional/north,
 /turf/open/floor/wood,
 /area/service/library)
 "ePY" = (
@@ -14877,6 +14923,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "fco" = (
@@ -15439,6 +15486,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "fmE" = (
@@ -16168,6 +16216,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"fIE" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/security/execution/transfer)
 "fIJ" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/engine,
@@ -16319,6 +16372,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "fPj" = (
@@ -16401,6 +16455,15 @@
 /obj/machinery/shower,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
+"fRi" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/engineering/main)
 "fRl" = (
 /turf/open/floor/plating,
 /area/security/brig)
@@ -16757,6 +16820,7 @@
 	pixel_x = -24
 	},
 /obj/structure/table/wood,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "fZN" = (
@@ -16799,6 +16863,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "gay" = (
@@ -18121,6 +18186,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "gPP" = (
@@ -18305,6 +18371,7 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "gTE" = (
@@ -18703,6 +18770,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/wood,
 /area/service/bar)
 "hfr" = (
@@ -18818,6 +18886,7 @@
 /area/hallway/primary/aft)
 "hip" = (
 /obj/machinery/photocopier,
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "hiv" = (
@@ -18960,6 +19029,7 @@
 /area/hallway/secondary/entry)
 "hmt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "hmI" = (
@@ -19120,6 +19190,14 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
+"hre" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/security/brig)
 "hrw" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/structure/cable,
@@ -19246,6 +19324,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hvT" = (
@@ -19889,6 +19968,23 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"hQO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer4,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hQP" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -20946,6 +21042,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "iyn" = (
@@ -21350,6 +21447,7 @@
 /area/engineering/atmos)
 "iOh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/security/prison)
 "iOj" = (
@@ -21378,6 +21476,13 @@
 /obj/machinery/bounty_board/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"iPb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "iPn" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -21390,6 +21495,7 @@
 	req_access_txt = "42"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "iPv" = (
@@ -21950,6 +22056,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/medical/psychology)
 "jes" = (
@@ -21957,6 +22064,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"jev" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "jey" = (
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
@@ -22039,6 +22153,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
 "jjd" = (
@@ -22651,6 +22766,7 @@
 	name = "warehouse shutters"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "jAG" = (
@@ -23566,6 +23682,7 @@
 	pixel_y = 24
 	},
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "kei" = (
@@ -23811,6 +23928,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "kkt" = (
@@ -23923,6 +24041,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "kmZ" = (
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "knB" = (
@@ -24671,6 +24790,14 @@
 	name = "black plastitanium floor"
 	},
 /area/service/bar)
+"kIe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
+/area/hallway/secondary/entry)
 "kIs" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/reagent_dispensers/watertank,
@@ -26367,6 +26494,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "lKL" = (
@@ -26522,6 +26650,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/large,
 /area/engineering/main)
+"lNw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/security/prison)
 "lND" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -26954,6 +27088,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/wood,
 /area/service/lawoffice)
 "maz" = (
@@ -27007,8 +27142,8 @@
 	name = "Atmospherics-Engine";
 	req_access_txt = "24"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/engineering/main)
 "mcK" = (
@@ -27324,6 +27459,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"mjG" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/engineering/main)
 "mjT" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -27420,6 +27564,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "mne" = (
@@ -27518,6 +27663,12 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron/smooth_large,
 /area/engineering/main)
+"mok" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/freezer,
+/area/security/prison)
 "mor" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27779,6 +27930,7 @@
 	req_access_txt = "25"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
@@ -27810,6 +27962,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/service/library)
 "mxm" = (
@@ -28164,6 +28317,7 @@
 	name = "Chapel Viewing Room"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "mJh" = (
@@ -28955,6 +29109,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "ndT" = (
@@ -29224,6 +29379,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/brig)
 "nnc" = (
@@ -29460,10 +29616,10 @@
 	name = "Supermatter Engine Room";
 	req_access_txt = "10"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/engine,
 /area/engineering/main)
 "nti" = (
@@ -29516,6 +29672,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "nuO" = (
@@ -29561,6 +29718,7 @@
 /area/security/office)
 "nwA" = (
 /obj/machinery/smartfridge,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "nwW" = (
@@ -29602,6 +29760,7 @@
 	req_access_txt = "28"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "nxS" = (
@@ -29985,6 +30144,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/transit_tube)
+"nIo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "nIx" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -30163,6 +30330,7 @@
 	id = "aux_base_shutters";
 	name = "Auxillary Base Shutters"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "nOA" = (
@@ -30444,6 +30612,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/science/mixing)
 "nXh" = (
@@ -30740,6 +30909,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"oew" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "oeI" = (
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -32213,6 +32389,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "oVR" = (
@@ -32720,6 +32897,7 @@
 	pixel_x = -24;
 	req_access_txt = "11"
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -33389,6 +33567,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/brig)
 "pGN" = (
@@ -35145,6 +35324,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "qLt" = (
@@ -35240,6 +35420,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "qPY" = (
@@ -35727,6 +35908,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/science/genetics)
 "rei" = (
@@ -35770,6 +35952,7 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "reV" = (
@@ -36323,6 +36506,7 @@
 	name = "Auxillary Base Shutters"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "rwm" = (
@@ -36801,6 +36985,7 @@
 	charge = 5e+006
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/textured_corner{
 	dir = 8
 	},
@@ -36937,14 +37122,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/iron/dark/textured,
 /area/engineering/break_room)
-"rSS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/prison)
 "rST" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
@@ -36956,6 +37133,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
@@ -36989,6 +37167,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "rTQ" = (
@@ -37070,6 +37249,7 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "rVk" = (
@@ -37295,8 +37475,14 @@
 /area/hallway/secondary/exit/departure_lounge)
 "sbi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
+"sbk" = (
+/obj/structure/cable,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "sbx" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -37323,6 +37509,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "sbJ" = (
@@ -37403,6 +37590,7 @@
 	dir = 4;
 	name = "Chamber Inject"
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/engine,
 /area/engineering/main)
 "sdZ" = (
@@ -37478,6 +37666,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/research)
 "sgI" = (
@@ -37548,6 +37737,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "sis" = (
@@ -37561,10 +37751,6 @@
 	dir = 1
 	},
 /area/engineering/break_room)
-"sjO" = (
-/obj/machinery/light/built,
-/turf/open/floor/wood,
-/area/maintenance/starboard/aft)
 "sjT" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -37700,6 +37886,7 @@
 	req_access_txt = "46"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/maintenance/central)
 "snF" = (
@@ -37813,6 +38000,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
+"spv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Prison Air Supply";
+	piping_layer = 4
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "spy" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/event_spawn,
@@ -37850,6 +38047,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "srf" = (
@@ -37872,6 +38070,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "srJ" = (
@@ -37977,6 +38176,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/science/mixing)
 "svp" = (
@@ -38233,6 +38433,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"sCL" = (
+/obj/machinery/door/airlock/external{
+	name = "Supply Dock Airlock";
+	req_access_txt = "31"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/cargo/storage)
 "sCR" = (
 /mob/living/simple_animal/bot/floorbot,
 /obj/effect/turf_decal/tile/blue{
@@ -38310,6 +38518,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sFk" = (
@@ -38435,6 +38644,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/security/prison)
 "sIx" = (
@@ -38732,6 +38942,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
+"sOO" = (
+/obj/machinery/light/built,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/maintenance/starboard/aft)
 "sOT" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -39310,6 +39526,7 @@
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "teX" = (
@@ -39507,6 +39724,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/hos)
 "tke" = (
@@ -40099,6 +40317,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/science/research)
 "tyS" = (
@@ -40242,6 +40461,7 @@
 	dir = 8;
 	name = "Chamber Extract"
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/engine,
 /area/engineering/main)
 "tBG" = (
@@ -40253,6 +40473,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tCK" = (
@@ -40356,6 +40577,7 @@
 	name = "Fitness"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/freezer,
 /area/commons/cryopods)
 "tFK" = (
@@ -40818,6 +41040,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/solars/starboard/aft)
+"tSe" = (
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/security/prison)
 "tSh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -40976,6 +41202,7 @@
 /area/maintenance/aft)
 "tYB" = (
 /obj/machinery/skill_station,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/service/library)
 "tYO" = (
@@ -41012,6 +41239,7 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/engineering/break_room)
 "tZG" = (
@@ -41155,6 +41383,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "uds" = (
@@ -41226,9 +41455,9 @@
 	name = "Supermatter Engine Room";
 	req_access_txt = "10"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/engine,
 /area/engineering/main)
 "ueQ" = (
@@ -41363,6 +41592,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"uiJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "uiK" = (
 /obj/structure/window{
 	dir = 4
@@ -41729,6 +41963,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "ure" = (
@@ -42249,6 +42484,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "uFm" = (
@@ -42437,6 +42673,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/science/research)
 "uLe" = (
@@ -42637,6 +42874,7 @@
 	req_access_txt = "24"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/maintenance/port/aft)
 "uPm" = (
@@ -43395,6 +43633,7 @@
 	name = "Auxillary Base Construction";
 	req_one_access_txt = "32;47;48"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "vmk" = (
@@ -43699,6 +43938,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vsH" = (
@@ -43792,6 +44032,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "vuD" = (
@@ -44510,6 +44751,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "vKQ" = (
@@ -44590,6 +44832,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/security/prison)
 "vNW" = (
@@ -45136,6 +45379,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "wdH" = (
@@ -45163,6 +45407,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
+"weJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "weO" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -45321,6 +45571,7 @@
 /area/engineering/atmos/upper)
 "wjE" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/bounty_board/directional/west,
 /turf/open/floor/wood,
 /area/service/bar)
 "wjH" = (
@@ -46805,6 +47056,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
+"wZE" = (
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/iron,
+/area/security/prison)
 "wZK" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -47134,6 +47389,15 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
+"xih" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Supplementary Air Supply";
+	piping_layer = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron,
+/area/security/prison)
 "xiq" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -47863,6 +48127,8 @@
 "xyS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/security/prison)
 "xyV" = (
@@ -48130,6 +48396,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/bounty_board/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "xFu" = (
@@ -48173,6 +48440,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/main)
 "xGY" = (
@@ -49011,6 +49279,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"yfo" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "yfs" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
@@ -60157,7 +60431,7 @@ oRu
 bRe
 ygB
 anC
-xyS
+weJ
 apU
 asI
 pMF
@@ -60671,7 +60945,7 @@ jbw
 amk
 ygB
 anT
-osZ
+jev
 xlD
 xlD
 vBc
@@ -61186,7 +61460,7 @@ osZ
 amy
 osZ
 dbl
-osZ
+jev
 dnN
 ygB
 nJA
@@ -61443,7 +61717,7 @@ apc
 xlD
 xlD
 arz
-osZ
+jev
 xlD
 xLR
 rmy
@@ -61700,7 +61974,7 @@ xaQ
 srQ
 srQ
 mSU
-osZ
+jev
 xlD
 ygB
 rmy
@@ -61957,7 +62231,7 @@ amm
 amz
 iDu
 ygB
-osZ
+jev
 xlD
 ygB
 nJA
@@ -62214,7 +62488,7 @@ euO
 tll
 anU
 ygB
-osZ
+jev
 asN
 ygB
 ygB
@@ -62746,7 +63020,7 @@ gQk
 bzC
 cgJ
 opY
-xCg
+fIE
 ihX
 lEY
 bQF
@@ -62985,7 +63259,7 @@ dOY
 tll
 nei
 ygB
-pua
+nIo
 jbw
 imL
 avd
@@ -63242,7 +63516,7 @@ uiV
 srQ
 srQ
 mSU
-osZ
+jev
 xlD
 ygB
 avf
@@ -63491,15 +63765,15 @@ xlD
 mRJ
 ahv
 aeI
-osZ
+jev
 ndS
-osZ
-osZ
-pua
-osZ
-osZ
-osZ
-osZ
+jev
+jev
+nIo
+jev
+jev
+jev
+jev
 xlD
 ygB
 ygB
@@ -63756,7 +64030,7 @@ amM
 xlD
 xlD
 nrR
-osZ
+jev
 xlD
 ewP
 rmy
@@ -63820,13 +64094,13 @@ czP
 xEh
 sIj
 oQV
-oQV
+mjG
 rmU
 thj
 thj
 thj
 rmU
-uya
+fRi
 uya
 czP
 vOL
@@ -64013,7 +64287,7 @@ qDw
 qDw
 qDw
 qDw
-osZ
+jev
 xlD
 ygB
 rmy
@@ -64031,7 +64305,7 @@ nqF
 nXh
 bez
 asr
-fDa
+hre
 hFs
 aOk
 hao
@@ -64270,7 +64544,7 @@ qDw
 mNi
 kNf
 qDw
-osZ
+jev
 xlD
 ygB
 mgQ
@@ -64628,7 +64902,7 @@ dlD
 iuZ
 iuZ
 iuZ
-cZH
+uiJ
 iQn
 cZH
 gTe
@@ -64784,7 +65058,7 @@ qDw
 tba
 qDw
 qDw
-osZ
+jev
 xlD
 xlD
 xlD
@@ -65041,9 +65315,9 @@ jbw
 amL
 jbw
 adY
-osZ
+jev
 jbw
-rSS
+jbw
 jbw
 jbw
 jbw
@@ -65298,7 +65572,7 @@ xlD
 amM
 xlD
 xlD
-uDr
+cJQ
 xlD
 jbw
 xlD
@@ -65555,7 +65829,7 @@ qDw
 qDw
 qDw
 qDw
-uDr
+cJQ
 thl
 jbw
 xlD
@@ -65803,7 +66077,7 @@ fsz
 gfQ
 uRW
 fQN
-aje
+mok
 rkL
 ygB
 vrs
@@ -65815,7 +66089,7 @@ qDw
 kdY
 xlD
 jbw
-xlD
+tSe
 yin
 uea
 sWN
@@ -66069,7 +66343,7 @@ qDw
 gbL
 wVI
 qDw
-uDr
+cJQ
 xlD
 jbw
 asZ
@@ -66326,16 +66600,16 @@ qDw
 qDw
 mDZ
 qDw
-uDr
+cJQ
 xlD
 jbw
 xlD
-yhG
+lNw
 asl
 ldL
 xlD
-yhG
-xlD
+lNw
+wZE
 xlD
 hPS
 xlD
@@ -66578,18 +66852,18 @@ ajt
 vNQ
 alN
 alG
-osZ
-osZ
-osZ
-osZ
-osZ
-osZ
-osZ
+jev
+jev
+jev
+jev
+jev
+jev
+jev
 dbl
 xyS
 sIv
-osZ
-osZ
+jev
+spv
 osZ
 wBx
 osZ
@@ -66844,11 +67118,11 @@ arz
 xlD
 xlD
 xlD
-yhG
-xlD
-ute
-xlD
-yhG
+lNw
+xih
+cJQ
+iPb
+lNw
 xlD
 ute
 xlD
@@ -67102,7 +67376,7 @@ auR
 auR
 aUK
 yin
-xlD
+yfo
 iOp
 lMI
 yin
@@ -69231,7 +69505,7 @@ xQD
 xJL
 wth
 hvG
-uYy
+hQO
 wdH
 wUN
 hGI
@@ -74632,9 +74906,9 @@ aHy
 aHy
 aHy
 aHB
-aoj
+sCL
 aHy
-aoj
+sCL
 ePH
 aHy
 bYN
@@ -79946,7 +80220,7 @@ arN
 arN
 vcx
 vcx
-vcx
+kIe
 arN
 arN
 arN
@@ -83544,7 +83818,7 @@ arN
 arN
 aeh
 aeh
-aeh
+aau
 arN
 arN
 arN
@@ -86138,10 +86412,10 @@ etj
 etj
 etj
 etj
-aMS
+aNm
 yaE
 yaE
-aMS
+aNm
 yaE
 yaE
 yaE
@@ -86927,7 +87201,7 @@ fnK
 fnK
 fnK
 kjZ
-qnO
+sbk
 mRb
 tpF
 aCU
@@ -91339,7 +91613,7 @@ yal
 yal
 hvE
 yal
-xsd
+fLa
 gfQ
 gfQ
 gfQ
@@ -92881,9 +93155,9 @@ qTO
 oxx
 hvE
 xsd
-fLa
-fLa
 xsd
+fLa
+fLa
 xsd
 xsd
 gfQ
@@ -93399,7 +93673,7 @@ ahf
 ahf
 xWX
 fFL
-uRk
+sOO
 xsd
 fsz
 gfQ
@@ -93656,8 +93930,8 @@ hDe
 pmw
 gBx
 sPs
-sjO
-xsd
+ahf
+fLa
 gfQ
 gfQ
 fsz
@@ -93914,7 +94188,7 @@ ygc
 xAn
 ygc
 ixL
-xsd
+fLa
 fsz
 fsz
 fsz
@@ -94664,7 +94938,7 @@ jig
 jig
 nSz
 kPK
-wjQ
+oew
 kmZ
 uDR
 uDR

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -304,7 +304,7 @@
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured,
 /area/cargo/storage)
 "acp" = (
 /obj/structure/disposalpipe/segment{
@@ -10183,7 +10183,7 @@
 "csh" = (
 /obj/machinery/conveyor{
 	dir = 10;
-	id = "cargodelivery2";
+	id = "cargodelivery";
 	name = "Cargo Belt"
 	},
 /turf/open/floor/iron/dark,
@@ -10482,7 +10482,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/textured,
 /area/cargo/storage)
 "cAP" = (
 /obj/machinery/door/airlock/maintenance{
@@ -13080,15 +13080,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
-"dRd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "cargodelivery2"
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "dRA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/service,
@@ -18414,10 +18405,6 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "gIl" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "Cargo Belt";
-	name = "CargoLoading"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -27911,7 +27898,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron,
+/turf/open/floor/engine,
 /area/engineering/main)
 "mcK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
@@ -28154,6 +28141,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/conveyor_switch/oneway{
+	id = "cargodelivery2"
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "mhS" = (
@@ -29807,7 +29797,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/maintenance/port/aft)
 "naC" = (
 /obj/machinery/light/small{
@@ -30227,6 +30217,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/conveyor_switch/oneway{
+	id = "cargodelivery"
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "noH" = (
@@ -32303,6 +32296,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"otR" = (
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/cargo/storage)
 "oub" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -48476,7 +48474,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/engineering/storage/tech)
 "wXl" = (
 /turf/closed/wall,
@@ -77032,7 +77030,7 @@ noi
 nft
 mhN
 nft
-dRd
+tGx
 fch
 eCe
 eCe
@@ -79084,7 +79082,7 @@ mzq
 oql
 aHm
 ybc
-acD
+otR
 vFy
 acD
 acD

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -152,6 +152,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/item/radio/intercom/directional/east,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/engine,
 /area/engineering/main)
 "abD" = (
@@ -160,6 +162,7 @@
 /area/medical/exam_room)
 "abK" = (
 /obj/structure/chair,
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "abL" = (
@@ -555,6 +558,7 @@
 /area/maintenance/fore)
 "adS" = (
 /obj/machinery/duct,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "adU" = (
@@ -583,6 +587,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "aec" = (
@@ -1053,11 +1058,13 @@
 	c_tag = "Fore Hallway - Chapel";
 	dir = 1
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ahk" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/grimy,
 /area/security/prison/workout)
 "ahs" = (
@@ -1067,6 +1074,13 @@
 	dir = 8;
 	name = "Perma Camera";
 	network = list("ss13","prison")
+	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_x = 32;
+	pixel_y = 0;
+	prison_radio = 1
 	},
 /turf/open/floor/carpet/black,
 /area/security/prison/workout)
@@ -1083,6 +1097,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/security/prison/mess)
 "ahC" = (
@@ -1100,6 +1115,13 @@
 	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_x = 32;
+	pixel_y = 0;
+	prison_radio = 1
 	},
 /turf/open/floor/iron/cafeteria,
 /area/security/prison/mess)
@@ -1251,6 +1273,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_x = 32;
+	pixel_y = 0;
+	prison_radio = 1
+	},
 /turf/open/floor/iron/freezer,
 /area/security/prison/shower)
 "aju" = (
@@ -1337,6 +1366,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"ake" = (
+/obj/structure/grille,
+/obj/structure/girder,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/fore)
 "akf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1734,6 +1770,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_x = -32;
+	pixel_y = 0;
+	prison_radio = 1
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "amz" = (
@@ -1931,6 +1974,7 @@
 	name = "Chapel Maintenance";
 	req_access_txt = "12"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "anN" = (
@@ -1975,6 +2019,9 @@
 "anU" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/poppy,
+/obj/structure/sign/poster/contraband/ambrosia_vulgaris{
+	pixel_y = -32
+	},
 /turf/open/floor/grass,
 /area/security/prison/garden)
 "anV" = (
@@ -1985,6 +2032,12 @@
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
+	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_y = -30;
+	prison_radio = 1
 	},
 /turf/open/floor/grass,
 /area/security/prison/garden)
@@ -2305,6 +2358,7 @@
 /obj/machinery/biogenerator{
 	pixel_x = 2
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "arq" = (
@@ -2535,6 +2589,12 @@
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_y = -31;
+	prison_radio = 1
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "asL" = (
@@ -2557,11 +2617,14 @@
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "asT" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "asU" = (
@@ -2593,6 +2656,12 @@
 /area/maintenance/central/secondary)
 "asZ" = (
 /obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "Permabrig - Cellblock Yard";
+	dir = 10;
+	name = "Perma Camera";
+	network = list("ss13","prison")
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "ata" = (
@@ -2622,6 +2691,7 @@
 "atn" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/landmark/start/chaplain,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/red,
 /area/service/chapel/main)
 "ato" = (
@@ -2842,6 +2912,12 @@
 "avf" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "avg" = (
@@ -3043,6 +3119,12 @@
 /area/commons/dorms)
 "awE" = (
 /obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "awJ" = (
@@ -3427,7 +3509,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "azM" = (
@@ -3562,6 +3643,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/vending/autodrobe/all_access,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
 "aAZ" = (
@@ -3742,6 +3824,7 @@
 /area/hallway/primary/fore)
 "aDB" = (
 /obj/machinery/light,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aDD" = (
@@ -4118,9 +4201,6 @@
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
 "aHC" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -4501,6 +4581,7 @@
 "aLn" = (
 /obj/machinery/bookbinder,
 /obj/machinery/light/warm/directional/south,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/wood/large,
 /area/service/library)
 "aLr" = (
@@ -4879,6 +4960,13 @@
 	},
 /turf/open/floor/iron,
 /area/science/robotics/mechbay)
+"aOL" = (
+/obj/structure/weightmachine/stacklifter,
+/obj/structure/sign/poster/contraband/communist_state{
+	pixel_y = 31
+	},
+/turf/open/floor/carpet/black,
+/area/security/prison/workout)
 "aOP" = (
 /obj/machinery/computer/security/mining{
 	dir = 1
@@ -4907,6 +4995,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "aOX" = (
@@ -6057,6 +6146,9 @@
 	pixel_x = 25;
 	req_access_txt = "10"
 	},
+/obj/structure/extinguisher_cabinet/directional/east{
+	pixel_x = 37
+	},
 /turf/open/floor/engine,
 /area/engineering/main)
 "aXe" = (
@@ -6638,6 +6730,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "bbj" = (
@@ -6701,6 +6794,7 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "bbR" = (
@@ -6720,6 +6814,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bbY" = (
@@ -7246,6 +7341,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron,
 /area/service/theater)
 "bgb" = (
@@ -7697,6 +7793,7 @@
 	pixel_y = -4
 	},
 /obj/structure/cable,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "bjx" = (
@@ -8265,7 +8362,7 @@
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
-	department = "Warden";
+	department = "Warden's Desk";
 	departmentType = 5;
 	name = "Warden's RC";
 	pixel_x = 32
@@ -8319,6 +8416,7 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "brA" = (
@@ -8450,6 +8548,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/fore)
+"bti" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - N2";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine/o2,
+/area/engineering/atmos)
 "btl" = (
 /obj/structure/window{
 	dir = 1
@@ -8527,6 +8633,13 @@
 "buj" = (
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_x = -32;
+	pixel_y = 0;
+	prison_radio = 1
 	},
 /turf/open/floor/iron,
 /area/security/prison/mess)
@@ -8775,6 +8888,7 @@
 	c_tag = "Command - Fore Bridge";
 	dir = 6
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron,
 /area/command/bridge)
 "bAg" = (
@@ -9253,7 +9367,7 @@
 /area/ai_monitored/turret_protected/ai)
 "bTw" = (
 /obj/machinery/camera{
-	c_tag = "Security -  Entrance";
+	c_tag = "Security - Entrance";
 	network = list("ss13","prison")
 	},
 /obj/effect/turf_decal/tile/red{
@@ -9560,6 +9674,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
 "ccl" = (
@@ -9591,6 +9706,10 @@
 	},
 /turf/open/floor/iron,
 /area/service/chapel/main)
+"cdf" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "cdq" = (
 /obj/item/radio/intercom{
 	pixel_x = -29
@@ -9677,6 +9796,7 @@
 /area/commons/toilet)
 "cff" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "cfz" = (
@@ -9847,6 +9967,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"cjd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/checker,
+/area/security/prison)
 "cjv" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -9899,6 +10024,11 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"ckL" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "cln" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = -30
@@ -9973,6 +10103,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cne" = (
@@ -9994,6 +10125,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/lab)
+"cnB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_x = 32;
+	pixel_y = 0;
+	prison_radio = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "cof" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -10229,6 +10373,7 @@
 /obj/machinery/light/built{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
 "cyp" = (
@@ -10267,6 +10412,13 @@
 /obj/structure/chair/office,
 /turf/open/floor/iron,
 /area/command/bridge)
+"czJ" = (
+/obj/structure/grille,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "czP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10580,6 +10732,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"cLa" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "cLV" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
@@ -10862,6 +11018,23 @@
 "cTD" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
+"cTH" = (
+/obj/machinery/washing_machine,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_x = 30;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "cTJ" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -11347,6 +11520,7 @@
 "dge" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "dgo" = (
@@ -11956,6 +12130,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "dxP" = (
@@ -12178,6 +12353,7 @@
 /obj/item/bedsheet/random,
 /obj/effect/landmark/start/prisoner,
 /obj/machinery/newscaster/directional/south,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "dCS" = (
@@ -12235,6 +12411,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
@@ -12337,6 +12514,10 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
+"dFv" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "dFO" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -12837,6 +13018,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/security/brig)
+"dQs" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/iron/sepia,
+/area/service/chapel/main)
 "dQJ" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -12963,6 +13148,7 @@
 /area/hallway/primary/fore)
 "dUu" = (
 /obj/structure/closet/emcloset/anchored,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dUI" = (
@@ -13092,6 +13278,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/office/light,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "dYg" = (
@@ -13105,6 +13292,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dYm" = (
@@ -13305,6 +13493,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"eeL" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/security/brig)
 "eeM" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
@@ -13513,6 +13714,7 @@
 "elD" = (
 /obj/structure/table/wood,
 /obj/item/pen/red,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
 "elI" = (
@@ -13866,6 +14068,12 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"ewd" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/starboard/aft)
 "ewg" = (
 /obj/structure/window{
 	dir = 1
@@ -14632,6 +14840,18 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"eSZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_x = 30;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "eTf" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette/cigar,
@@ -15645,6 +15865,13 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"frM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/security/prison)
 "frN" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -15921,6 +16148,9 @@
 /obj/machinery/holopad/secure,
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/blobstart,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "fxU" = (
@@ -16090,6 +16320,14 @@
 /obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/iron,
 /area/maintenance/central)
+"fBX" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "fCn" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -16304,6 +16542,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/item/radio/intercom/directional/east,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/engine,
 /area/engineering/main)
 "fLF" = (
@@ -16427,6 +16667,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "fPw" = (
@@ -16436,6 +16677,7 @@
 /area/service/chapel/main)
 "fPC" = (
 /obj/effect/landmark/event_spawn,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "fPF" = (
@@ -16460,6 +16702,11 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"fPK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "fPN" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
 	dir = 1
@@ -16487,6 +16734,7 @@
 	dir = 8
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/engineering/main)
 "fRl" = (
@@ -16561,6 +16809,7 @@
 /area/science/mixing)
 "fSS" = (
 /obj/item/kirbyplants/random,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "fTj" = (
@@ -16819,6 +17068,14 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"fYz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port/fore)
 "fYR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -16856,6 +17113,7 @@
 "fZN" = (
 /obj/item/banner/cargo/mundane,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fZQ" = (
@@ -17114,6 +17372,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ghx" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "ghC" = (
 /obj/structure/table,
 /obj/item/kitchen/spoon/plastic,
@@ -17421,6 +17685,13 @@
 /area/security/detectives_office)
 "gqX" = (
 /obj/item/paint/anycolor,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_x = 30;
+	pixel_y = -2;
+	prison_radio = 1
+	},
 /turf/open/floor/plating,
 /area/security/prison/safe)
 "grq" = (
@@ -19229,6 +19500,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
+"hpe" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - Aux Chamber";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/engineering/atmos)
 "hpP" = (
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 8;
@@ -19407,6 +19686,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"huw" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "huR" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
@@ -19496,6 +19779,9 @@
 "hwL" = (
 /turf/closed/wall/r_wall,
 /area/science/research)
+"hwV" = (
+/turf/open/floor/iron/checker,
+/area/security/prison)
 "hxe" = (
 /obj/machinery/processor/slime,
 /turf/open/floor/iron/dark,
@@ -20269,6 +20555,10 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/command/bridge)
+"hWU" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "hWW" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -20513,6 +20803,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"ieI" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/security/prison/work)
 "ieQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -20618,6 +20913,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "ihq" = (
@@ -20663,6 +20959,13 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"iiS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/blobstart,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron/checker,
+/area/security/prison)
 "ijy" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -20719,6 +21022,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/exam_room)
+"imi" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - CO2";
+	dir = 10;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine/co2,
+/area/engineering/atmos)
 "ims" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -20991,6 +21302,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "itv" = (
@@ -21240,6 +21552,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
+"iAZ" = (
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron,
+/area/security/prison/mess)
 "iBp" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -21335,6 +21652,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/engineering/main)
+"iFc" = (
+/obj/effect/spawner/lootdrop/grille_or_trash,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iFd" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -21744,6 +22066,10 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"iSs" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "iSD" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
@@ -22293,6 +22619,7 @@
 /obj/structure/sign/poster/official/obey{
 	pixel_x = 30
 	},
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "jig" = (
@@ -22421,6 +22748,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "jms" = (
@@ -22498,6 +22826,10 @@
 	},
 /turf/open/floor/grass,
 /area/science/lab)
+"jpu" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/prison)
 "jpD" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating{
@@ -22798,6 +23130,9 @@
 /obj/item/bikehorn/rubberducky,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/structure/sign/poster/official/fruit_bowl{
+	pixel_x = -32
+	},
 /turf/open/floor/iron/freezer,
 /area/security/prison/shower)
 "jym" = (
@@ -22890,6 +23225,7 @@
 /area/cargo/office)
 "jzC" = (
 /obj/structure/closet/firecloset,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "jAb" = (
@@ -22901,6 +23237,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
 "jAq" = (
@@ -23188,6 +23525,10 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/wood,
 /area/service/bar)
+"jHS" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "jIE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -24186,6 +24527,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "knw" = (
@@ -24282,6 +24624,16 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/iron/dark,
 /area/engineering/main)
+"kqq" = (
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_x = 30;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "kqr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24318,6 +24670,7 @@
 /obj/item/plant_analyzer,
 /obj/item/reagent_containers/glass/bucket,
 /obj/machinery/airalarm/directional/north,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "krK" = (
@@ -24771,6 +25124,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "kDY" = (
@@ -24962,6 +25316,10 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
+"kHL" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/iron/sepia,
+/area/service/chapel/main)
 "kIa" = (
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
@@ -25118,12 +25476,18 @@
 	network = list("ss13","engine","turbine")
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "kKY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/cigbutt,
 /obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -25233,6 +25597,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "kNm" = (
@@ -25438,6 +25803,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "kVz" = (
@@ -25517,6 +25883,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/prisoner,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "kYD" = (
@@ -25524,6 +25891,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/solars/starboard/aft)
+"kZb" = (
+/obj/item/radio/intercom/directional/east,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark,
+/area/security/prison/visit)
 "kZr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -27087,6 +27459,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/science/storage)
 "lSx" = (
@@ -27157,6 +27530,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_y = -31;
+	prison_radio = 1
 	},
 /turf/open/floor/plating,
 /area/security/prison/work)
@@ -27748,6 +28127,7 @@
 	dir = 8
 	},
 /obj/machinery/status_display/evac/directional/south,
+/obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/engineering/main)
 "mjT" = (
@@ -27761,6 +28141,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "mkc" = (
+/obj/structure/grille,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -28034,7 +28415,6 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
-/obj/machinery/firealarm/directional/east,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
@@ -28085,6 +28465,13 @@
 "mrq" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
+"mrT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/turf/open/floor/iron/checker,
+/area/security/prison)
 "msF" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -28449,6 +28836,10 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"mEI" = (
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/security/prison)
 "mEX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/blue{
@@ -28746,6 +29137,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "mNW" = (
@@ -28845,6 +29237,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/service/bar)
+"mQD" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/grille/broken,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "mQN" = (
 /obj/structure/sign/warning{
 	pixel_x = -32;
@@ -28909,6 +29309,10 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
+"mSF" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/turf/open/floor/iron,
+/area/command/bridge)
 "mSU" = (
 /obj/structure/sign/poster/official/obey,
 /turf/closed/wall,
@@ -29207,6 +29611,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"mZo" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/ai_monitored/command/storage/eva)
 "nab" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Server Room";
@@ -29538,6 +29947,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"nia" = (
+/obj/item/radio/intercom/directional/east,
+/turf/open/floor/iron,
+/area/cargo/office)
 "nio" = (
 /obj/machinery/camera{
 	c_tag = "Command - Ian's Room";
@@ -29718,6 +30131,19 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"npu" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/iron,
+/area/security/brig)
 "npv" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -30092,6 +30518,14 @@
 "nAA" = (
 /turf/closed/wall,
 /area/commons/storage/primary)
+"nBf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/security/prison)
 "nBn" = (
 /obj/machinery/stasis,
 /obj/machinery/defibrillator_mount{
@@ -30485,6 +30919,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet/black,
 /area/security/prison/workout)
 "nKt" = (
@@ -30603,6 +31038,12 @@
 /obj/item/storage/box/matches,
 /obj/item/reagent_containers/food/drinks/flask/gold,
 /obj/item/clothing/mask/cigarette/cigar,
+/obj/item/radio/intercom/directional/west{
+	freerange = 1;
+	name = "Captain's Intercom";
+	pixel_x = 0;
+	pixel_y = -28
+	},
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "nOy" = (
@@ -30635,6 +31076,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "nPX" = (
@@ -30713,6 +31155,7 @@
 	},
 /obj/effect/mapping_helpers/iannewyear,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
 /turf/open/floor/carpet/royalblue,
 /area/command/corporate_showroom)
 "nSz" = (
@@ -30835,6 +31278,7 @@
 /area/security/brig)
 "nVl" = (
 /obj/effect/decal/cleanable/generic,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -31264,6 +31708,9 @@
 	name = "Perma Camera";
 	network = list("ss13","prison")
 	},
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "ofC" = (
@@ -31689,6 +32136,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/closet/emcloset,
+/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "osr" = (
@@ -31993,12 +32441,17 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
+"oAF" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/carpet/black,
+/area/service/bar)
 "oAN" = (
 /obj/structure/closet/crate,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/item/stack/license_plates/empty/fifty,
 /obj/effect/turf_decal/bot/right,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/textured,
 /area/security/prison/work)
 "oAU" = (
@@ -32584,6 +33037,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"oSs" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/security/brig)
 "oSt" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -32707,6 +33170,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
+"oVw" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - N2O";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine/n2o,
+/area/engineering/atmos)
 "oVO" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydroponics";
@@ -32976,7 +33447,7 @@
 /area/science/research)
 "pdg" = (
 /obj/machinery/camera{
-	c_tag = "Turbine Chamber";
+	c_tag = "Atmospherics - Turbine Chamber";
 	dir = 4;
 	network = list("turbine")
 	},
@@ -33045,6 +33516,13 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/iron/smooth,
 /area/engineering/main)
+"pfA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "pfI" = (
 /obj/machinery/bounty_board/directional/west,
 /turf/open/floor/iron,
@@ -33239,6 +33717,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "plT" = (
@@ -33559,6 +34038,10 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2,
 /area/engineering/atmos)
+"puM" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "puR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33575,6 +34058,16 @@
 "puT" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/command/storage/eva)
+"pvd" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/security/brig)
 "pvj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -34148,6 +34641,19 @@
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"pNB" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_x = 30;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison)
 "pOa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -35022,6 +35528,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
+"qpc" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "qpi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35060,6 +35576,7 @@
 	dir = 4;
 	network = list("ss13","engine")
 	},
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/engineering/main)
 "qqd" = (
@@ -35215,6 +35732,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/captain)
 "qtf" = (
@@ -35375,6 +35893,7 @@
 /area/cargo/storage)
 "qzX" = (
 /obj/structure/cable,
+/obj/machinery/light_switch/directional/south,
 /turf/open/floor/carpet/black,
 /area/security/prison/workout)
 "qzZ" = (
@@ -35690,6 +36209,7 @@
 /obj/item/paint/anycolor,
 /obj/item/storage/crayons,
 /obj/structure/cable,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/grimy,
 /area/security/prison/rec)
 "qKs" = (
@@ -35755,6 +36275,18 @@
 	dir = 1
 	},
 /area/command/heads_quarters/ce)
+"qMC" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"qMH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/blobstart,
+/turf/open/floor/iron,
+/area/security/brig)
 "qMT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -35793,6 +36325,7 @@
 /area/maintenance/port/aft)
 "qOk" = (
 /obj/machinery/suit_storage_unit/captain,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "qPA" = (
@@ -35859,6 +36392,7 @@
 /area/maintenance/starboard/aft)
 "qQu" = (
 /obj/machinery/restaurant_portal/bar,
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /turf/open/floor/wood,
 /area/service/bar)
 "qQD" = (
@@ -36042,6 +36576,7 @@
 /area/engineering/atmos)
 "qXX" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -36836,6 +37371,14 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"rtx" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - Pure Chamber";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "rtF" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
@@ -37219,8 +37762,23 @@
 /area/security/office)
 "rHj" = (
 /obj/effect/landmark/blobstart,
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
+"rHo" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/computer/security/telescreen/interrogation{
+	dir = 8;
+	pixel_x = 30
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "rHu" = (
 /obj/structure/chair{
 	dir = 4
@@ -37302,6 +37860,16 @@
 /obj/structure/flora/rock/pile,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
+"rKK" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera{
+	c_tag = "Cargo - Shuttle Exterior";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rKM" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -37458,6 +38026,14 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"rRo" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - Mix Chamber";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine/vacuum,
+/area/engineering/atmos)
 "rRy" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio5";
@@ -37753,6 +38329,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron,
 /area/command/bridge)
 "rYC" = (
@@ -38112,6 +38689,14 @@
 	dir = 1
 	},
 /area/engineering/break_room)
+"siR" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/iron,
+/area/security/brig)
 "sjT" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -38417,6 +39002,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/cargo/storage)
+"srt" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "srC" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room";
@@ -38447,6 +39036,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
+"ssn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ssp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -38624,6 +39220,10 @@
 "sxP" = (
 /turf/open/floor/grass,
 /area/medical/virology)
+"sxT" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron,
+/area/security/prison/rec)
 "sye" = (
 /obj/structure/sign/poster/official/love_ian{
 	pixel_y = 32
@@ -38913,6 +39513,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"sGh" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "sGv" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -38963,6 +39567,7 @@
 "sHJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot/right,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/plating,
 /area/security/prison/work)
 "sHP" = (
@@ -39015,6 +39620,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "sIx" = (
@@ -39262,6 +39868,14 @@
 "sOf" = (
 /turf/closed/wall/r_wall,
 /area/engineering/engine_smes)
+"sOg" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - O2";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine/n2,
+/area/engineering/atmos)
 "sOp" = (
 /obj/structure/rack,
 /obj/item/paicard,
@@ -39529,6 +40143,10 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/starboard)
+"sUk" = (
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/security/prison)
 "sUA" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -39927,6 +40545,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"tfk" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "tfD" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom"
@@ -39967,7 +40596,7 @@
 /area/engineering/supermatter)
 "thl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/checker,
 /area/security/prison)
 "thn" = (
 /obj/structure/cable,
@@ -40799,6 +41428,12 @@
 /area/maintenance/starboard)
 "tAy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_y = 24;
+	prison_radio = 1
+	},
 /turf/open/floor/iron,
 /area/security/prison/rec)
 "tAP" = (
@@ -40807,6 +41442,7 @@
 	pixel_y = -10
 	},
 /obj/item/camera,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "tAU" = (
@@ -40879,6 +41515,12 @@
 	name = "black plastitanium floor"
 	},
 /area/service/bar)
+"tBS" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/fore)
 "tCm" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -41293,6 +41935,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "tOn" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -41746,6 +42389,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /obj/effect/landmark/start/prisoner,
+/obj/effect/spawner/lootdrop/prison_contraband,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "ucg" = (
@@ -42050,6 +42694,8 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/blobstart,
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
 "ujF" = (
@@ -42314,6 +42960,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
+"uoM" = (
+/obj/machinery/hydroponics/constructable,
+/obj/item/radio/intercom/directional/north{
+	desc = "A station intercom. It looks like it has been modified to not broadcast.";
+	name = "prison intercom";
+	pixel_y = -31;
+	prison_radio = 1
+	},
+/turf/open/floor/iron,
+/area/security/prison/garden)
 "upp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -42468,6 +43124,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
+"utO" = (
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/security/prison)
 "utV" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -42656,6 +43316,7 @@
 	c_tag = "Security - EVA Storage";
 	dir = 10
 	},
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/office)
 "uAk" = (
@@ -43676,6 +44337,11 @@
 	},
 /turf/open/floor/iron,
 /area/security/brig)
+"uYf" = (
+/obj/effect/loot_site_spawner,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
 "uYh" = (
 /obj/machinery/modular_computer/console/preset/id,
 /obj/machinery/button/door{
@@ -43986,6 +44652,11 @@
 "viD" = (
 /turf/open/floor/iron/cafeteria,
 /area/maintenance/central)
+"viH" = (
+/obj/machinery/duct,
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "vjx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -44423,6 +45094,14 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"vsB" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - Plasma";
+	dir = 10;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine/plasma,
+/area/engineering/atmos)
 "vsH" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -44451,6 +45130,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"vta" = (
+/obj/effect/turf_decal,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/blobstart,
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/iron/dark,
+/area/engineering/atmos)
 "vtp" = (
 /obj/machinery/computer/cargo,
 /turf/open/floor/iron,
@@ -44862,6 +45548,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "vBh" = (
@@ -45124,6 +45811,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/prison)
+"vIc" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "vIg" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat - Teleporter";
@@ -45180,6 +45871,7 @@
 "vJx" = (
 /obj/machinery/light/small,
 /obj/structure/closet/emcloset,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "vJI" = (
@@ -45206,6 +45898,18 @@
 /obj/item/stamp/law,
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
+"vJR" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
+/obj/item/poster/random_contraband,
+/obj/machinery/camera{
+	c_tag = "Security - Evidence";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/iron,
+/area/security/brig)
 "vKj" = (
 /turf/closed/wall,
 /area/service/lawoffice)
@@ -45971,6 +46675,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"wgZ" = (
+/obj/effect/landmark/xeno_spawn,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/iron,
+/area/security/prison)
 "whm" = (
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/stripes/box,
@@ -46231,6 +46940,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
+"woL" = (
+/obj/machinery/camera{
+	c_tag = "Atmospherics Tank - Air";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine/air,
+/area/engineering/atmos)
 "wpl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -46545,7 +47262,9 @@
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
-/obj/machinery/status_display/evac/directional/south,
+/obj/item/radio/intercom/directional/south{
+	pixel_y = -40
+	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "wyR" = (
@@ -46651,6 +47370,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison)
 "wBI" = (
@@ -46918,6 +47638,11 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
+"wJH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "wKb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -47139,6 +47864,9 @@
 "wNU" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/chair/stool,
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/blobstart,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
 "wOk" = (
@@ -47997,6 +48725,17 @@
 /obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"xjY" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "xkc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -48071,8 +48810,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "xlX" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/grille,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -48207,6 +48946,13 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"xpW" = (
+/obj/machinery/camera{
+	c_tag = "Security - Escape Pod";
+	network = list("ss13","prison")
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "xqi" = (
 /obj/structure/window{
 	dir = 8
@@ -48347,7 +49093,6 @@
 /area/ai_monitored/command/nuke_storage)
 "xst" = (
 /obj/machinery/computer/security/telescreen/rd{
-	pixel_x = 3;
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -48838,6 +49583,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
 "xDB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -49029,6 +49775,7 @@
 	dir = 1
 	},
 /obj/machinery/mineral/equipment_vendor,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "xIp" = (
@@ -49127,6 +49874,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/security/prison/work)
 "xMg" = (
@@ -49186,6 +49934,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "xOz" = (
@@ -49652,6 +50401,9 @@
 /area/security/office)
 "ybc" = (
 /obj/machinery/rnd/bepis,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
 "ybn" = (
@@ -57751,6 +58503,7 @@ gfQ
 gfQ
 gfQ
 gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -57758,8 +58511,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -58188,7 +58940,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -58938,7 +59690,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -59223,7 +59975,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -59530,7 +60282,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -60604,7 +61356,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -60752,7 +61504,7 @@ gfQ
 cOF
 alw
 alQ
-kuZ
+sxT
 szK
 anq
 apI
@@ -60792,7 +61544,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -61040,7 +61792,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -61272,7 +62024,7 @@ krw
 qPW
 asT
 lIR
-pMF
+uoM
 jCO
 fsz
 fsz
@@ -62039,7 +62791,7 @@ wxu
 wxu
 wxu
 amy
-osZ
+frM
 jev
 jev
 dnN
@@ -62559,7 +63311,7 @@ jev
 xlD
 sDA
 qct
-dNM
+ieI
 dNM
 gmq
 gfQ
@@ -62598,6 +63350,7 @@ gfQ
 gfQ
 gfQ
 gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -62605,8 +63358,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -63057,7 +63809,7 @@ gfQ
 fsz
 gfQ
 pce
-aga
+aOL
 nKc
 ahs
 kMo
@@ -63428,7 +64180,7 @@ gfQ
 gfQ
 fsz
 bnA
-jUQ
+hpe
 jUQ
 jUQ
 bnA
@@ -63587,7 +64339,7 @@ qLq
 xlD
 ygB
 arZ
-xlD
+wgZ
 xlD
 awL
 yin
@@ -63922,15 +64674,15 @@ blf
 bnA
 cES
 vSM
-qFh
+rRo
 gSP
 qFh
 vSM
-qFh
+rtx
 gSP
 qFh
 vSM
-fOQ
+oVw
 ifx
 fOQ
 vSM
@@ -64072,7 +64824,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -64089,7 +64841,7 @@ qtb
 qtb
 qtb
 qtb
-meJ
+iAZ
 szK
 srQ
 srQ
@@ -64101,7 +64853,7 @@ jev
 xlD
 ygB
 avf
-awE
+cTH
 awE
 yin
 yin
@@ -64135,7 +64887,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-xAV
+gfQ
 gfQ
 gfQ
 gfQ
@@ -64607,8 +65359,8 @@ cRO
 oXQ
 xlD
 xlD
-amM
-xlD
+cnB
+utO
 xlD
 nrR
 jev
@@ -64628,7 +65380,7 @@ vyj
 uUm
 mFB
 asr
-asr
+qMH
 kGh
 aIM
 aLT
@@ -64902,14 +65654,14 @@ vla
 xrN
 gfQ
 gfQ
+xAV
 gfQ
 gfQ
 gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -65100,7 +65852,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -65485,7 +66237,7 @@ iuZ
 iuZ
 uiJ
 iQn
-cZH
+pfA
 gTe
 cZH
 iRr
@@ -65503,7 +66255,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -65902,7 +66654,7 @@ jbw
 jbw
 jbw
 jbw
-jbw
+eSZ
 jbw
 jbw
 ayG
@@ -66149,13 +66901,13 @@ jxE
 ygB
 alD
 jbw
-xlD
+kqq
 amM
 xlD
-xlD
+jpu
 cJQ
-xlD
-jbw
+hwV
+cjd
 hTK
 yin
 yin
@@ -66412,8 +67164,8 @@ qDw
 qDw
 cJQ
 thl
-jbw
-xlD
+cjd
+sUk
 yin
 caT
 aOm
@@ -66427,7 +67179,7 @@ dEG
 hmb
 wyY
 vkj
-iYh
+npu
 vff
 xIr
 xIr
@@ -66668,8 +67420,8 @@ jMr
 uce
 qDw
 kdY
-xlD
-jbw
+hwV
+cjd
 tSe
 yin
 uea
@@ -66682,7 +67434,7 @@ iKG
 qAw
 llM
 hmb
-iKG
+kZb
 vkj
 azA
 fDa
@@ -66925,8 +67677,8 @@ knl
 wVI
 qDw
 cJQ
-xlD
-jbw
+hwV
+iiS
 asZ
 yin
 iYi
@@ -67025,7 +67777,7 @@ czQ
 kJf
 rGH
 urS
-urS
+imi
 vSM
 joR
 bnA
@@ -67182,13 +67934,13 @@ qDw
 mDZ
 qDw
 cJQ
-xlD
-jbw
+hwV
+cjd
 xlD
 lNw
 asl
 ldL
-xlD
+mEI
 lNw
 wZE
 ouN
@@ -67196,7 +67948,7 @@ hPS
 oPr
 aCA
 aFk
-gQW
+oSs
 eDb
 azD
 fDa
@@ -67437,10 +68189,10 @@ jev
 jev
 jev
 jev
+nBf
 jev
-jev
-jev
-jev
+mrT
+mrT
 xyS
 sIv
 jev
@@ -67545,7 +68297,7 @@ joR
 bnA
 itf
 qqt
-gIp
+vta
 xzY
 nDS
 wfV
@@ -67666,7 +68418,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -67692,7 +68444,7 @@ yin
 xlD
 jbw
 oqT
-xlD
+kqq
 jbw
 asP
 arz
@@ -67953,7 +68705,7 @@ qDw
 dSh
 ygB
 aUK
-auR
+pNB
 auR
 aUK
 yin
@@ -68567,7 +69319,7 @@ czQ
 kJf
 fPN
 tJM
-tJM
+vsB
 vSM
 joR
 bnA
@@ -68994,10 +69746,10 @@ gfQ
 gfQ
 avT
 xke
-fRl
-fRl
+xpW
+ghx
 xke
-azA
+eeL
 ttL
 xIr
 rhI
@@ -69537,7 +70289,7 @@ mhS
 nQs
 bfv
 bfv
-bfv
+pvd
 fHW
 xke
 waV
@@ -69771,8 +70523,8 @@ xke
 lgV
 imN
 kOK
+rHo
 liH
-blG
 blG
 mFB
 aYR
@@ -69973,7 +70725,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -70044,7 +70796,7 @@ bVO
 jdC
 jdC
 bdX
-iMd
+siR
 lWE
 iMd
 klF
@@ -70642,7 +71394,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -71118,15 +71870,15 @@ uYy
 bnA
 cES
 vSM
-cJC
+bti
 nxk
 cJC
 vSM
-xBJ
+sOg
 jKs
 xBJ
 vSM
-mML
+woL
 gac
 mML
 vSM
@@ -72147,7 +72899,7 @@ pmS
 yax
 ozZ
 aof
-dAn
+iFc
 vZs
 sdM
 uPm
@@ -72597,7 +73349,7 @@ xyp
 uJa
 aAa
 xke
-kIP
+vJR
 aSR
 kIP
 xke
@@ -72662,7 +73414,7 @@ sxe
 rAG
 muZ
 sxe
-sxe
+rKK
 sxe
 sxe
 sxe
@@ -72800,7 +73552,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -73647,7 +74399,7 @@ pLL
 vTq
 kMs
 pLL
-kWh
+fBX
 goW
 nrZ
 oAn
@@ -73874,7 +74626,7 @@ xhd
 xUQ
 uxJ
 vUW
-wyf
+kHL
 aqJ
 avk
 ajS
@@ -74155,7 +74907,7 @@ vYu
 drZ
 vYu
 xct
-vYu
+cLa
 fSS
 vYu
 hXc
@@ -74215,7 +74967,7 @@ xjx
 vZs
 vZs
 vZs
-mmM
+ssn
 vsQ
 naC
 sKk
@@ -74241,7 +74993,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -74964,7 +75716,7 @@ urr
 oPk
 vYu
 wAv
-vYu
+jHS
 vZs
 xlX
 jpD
@@ -75497,7 +76249,7 @@ bYN
 bYN
 bYN
 vQC
-dAn
+iFc
 jls
 cvJ
 vqR
@@ -76150,7 +76902,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -76429,7 +77181,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -77041,7 +77793,7 @@ gVQ
 rCl
 bYN
 iuu
-tuj
+srt
 rfR
 kUI
 kUI
@@ -77193,7 +77945,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -77325,7 +78077,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -77441,7 +78193,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -77509,7 +78261,7 @@ wXl
 kHB
 aGw
 eeS
-xGY
+huw
 uMp
 vqo
 wWn
@@ -77736,7 +78488,7 @@ xOo
 oAw
 ybL
 aAs
-wyf
+aCs
 vUW
 vUW
 aTf
@@ -77993,8 +78745,8 @@ rPO
 rPO
 rPO
 rPO
-wyf
-wyf
+aCs
+dQs
 wyf
 mfJ
 wyf
@@ -78263,7 +79015,7 @@ hyd
 uJa
 hqh
 xyp
-ybn
+cdf
 jUZ
 ybn
 xvt
@@ -78507,7 +79259,7 @@ xyp
 xyp
 rIH
 rIH
-lSd
+ckL
 sVb
 adr
 aVf
@@ -78758,7 +79510,7 @@ uJa
 uJa
 uJa
 xUQ
-uJa
+lDb
 aca
 agh
 xyp
@@ -78770,7 +79522,7 @@ sVb
 sVb
 sVb
 sVb
-uJa
+qMC
 rIH
 rSo
 rSo
@@ -78829,7 +79581,7 @@ pjf
 pjf
 acz
 acE
-pjf
+nia
 pjf
 hsV
 qUi
@@ -78965,7 +79717,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -79015,13 +79767,13 @@ xhd
 xhd
 xyp
 xUQ
-lDb
+uJa
 uJa
 rIH
 uJa
 dea
 uJa
-adt
+fYz
 uJa
 uJa
 dea
@@ -79068,7 +79820,7 @@ laS
 yfY
 sZt
 ibr
-sZt
+oAF
 yfY
 tVc
 xGY
@@ -79279,7 +80031,7 @@ fRK
 xyp
 uJa
 uJa
-uJa
+qMC
 uJa
 xyp
 aDf
@@ -79528,13 +80280,13 @@ nrY
 nrY
 nrY
 xhd
-atb
-uJa
+mQD
+lDb
 xyp
 xyp
 xyp
 xyp
-nrT
+uYf
 rIH
 xyp
 xyp
@@ -80304,8 +81056,8 @@ uJa
 xyp
 kzr
 uJa
-adt
-uJa
+ake
+adu
 uJa
 xyp
 uJa
@@ -80361,7 +81113,7 @@ gvi
 wSC
 cfI
 rLe
-exH
+xjY
 rxU
 vtp
 mLP
@@ -80674,7 +81426,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -81604,7 +82356,7 @@ bDt
 bDt
 bjz
 nAA
-dak
+wJH
 jUZ
 ybn
 exn
@@ -82946,7 +83698,7 @@ stt
 qde
 qde
 ulu
-ulu
+iSs
 ulu
 iJM
 gPP
@@ -83452,7 +84204,7 @@ mXI
 cWu
 rAx
 mXI
-mXI
+mZo
 hGr
 aEw
 mXt
@@ -83959,7 +84711,7 @@ aKN
 xcl
 hJP
 rLe
-uio
+tfk
 puT
 ezQ
 tFV
@@ -83981,7 +84733,7 @@ meV
 yam
 yam
 vmQ
-vmQ
+hWU
 cxf
 kvM
 azc
@@ -84875,7 +85627,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -85268,8 +86020,8 @@ gRo
 tJB
 tJB
 vmQ
-vmQ
-vmQ
+hWU
+hWU
 vcX
 yam
 yam
@@ -85453,7 +86205,7 @@ oBl
 fHL
 aVQ
 feW
-nTh
+viH
 tGp
 tGp
 tGp
@@ -86842,7 +87594,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -88069,7 +88821,7 @@ lyG
 lyG
 myY
 qol
-cfI
+vIc
 rLe
 gRN
 mph
@@ -88084,7 +88836,7 @@ prw
 dka
 cND
 qAe
-cND
+mSF
 orD
 pIs
 xch
@@ -88750,7 +89502,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -89042,7 +89794,7 @@ nGL
 nGL
 ybK
 hIq
-kbg
+tBS
 wrE
 wEK
 etj
@@ -89533,6 +90285,7 @@ gfQ
 gfQ
 gfQ
 gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -89545,8 +90298,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -89571,7 +90323,7 @@ yaE
 yaE
 yaE
 etj
-ybn
+sGh
 aOA
 bdO
 eCi
@@ -89662,7 +90414,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -90106,7 +90858,7 @@ tsG
 uWM
 phb
 wnI
-uWM
+puM
 gio
 bgD
 bgQ
@@ -90286,6 +91038,7 @@ gfQ
 gfQ
 gfQ
 gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -90294,8 +91047,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -90635,7 +91387,7 @@ tin
 lOx
 gUp
 cfz
-tin
+qpc
 tin
 xuR
 iTt
@@ -90787,7 +91539,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -92107,7 +92859,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -92135,7 +92887,7 @@ bjA
 bjA
 aYM
 bje
-aNs
+czJ
 blr
 jyY
 eJV
@@ -92450,7 +93202,7 @@ wse
 wLS
 mFL
 mFL
-dKw
+ewd
 xsd
 gfQ
 gfQ
@@ -92602,7 +93354,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -92848,7 +93600,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -93266,7 +94018,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -93474,7 +94226,7 @@ tmj
 qhx
 yal
 tOn
-yal
+dFv
 xsd
 yal
 mxm
@@ -93611,7 +94363,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -93746,7 +94498,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-xAV
+gfQ
 gfQ
 adm
 iiy
@@ -94003,7 +94755,7 @@ fsz
 fsz
 fsz
 gfQ
-gfQ
+xAV
 gfQ
 adm
 dZb
@@ -94889,7 +95641,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -95527,7 +96279,7 @@ uDR
 tmj
 tmj
 tmj
-hvE
+fPK
 xsd
 yal
 nzb
@@ -95580,7 +96332,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -97208,7 +97960,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -97972,7 +98724,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -99013,7 +99765,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -99265,7 +100017,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -99799,7 +100551,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -101077,7 +101829,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -101227,7 +101979,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -101718,7 +102470,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -101901,7 +102653,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -102097,6 +102849,7 @@ gfQ
 gfQ
 gfQ
 gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -102136,8 +102889,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -102888,7 +103640,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -104505,7 +105257,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -106081,7 +106833,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -108367,7 +109119,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -108857,7 +109609,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -108900,7 +109652,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ
@@ -109405,7 +110157,7 @@ gfQ
 gfQ
 gfQ
 gfQ
-gfQ
+xAV
 gfQ
 gfQ
 gfQ

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -539,6 +539,7 @@
 /area/commons/toilet)
 "adF" = (
 /obj/machinery/vending/coffee,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "adG" = (
@@ -791,6 +792,7 @@
 /area/space)
 "aeZ" = (
 /obj/effect/spawner/randomsnackvend,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -821,6 +823,9 @@
 /area/hallway/primary/fore)
 "afb" = (
 /obj/machinery/vending/cigarette,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/iron/white/side{
 	dir = 8
 	},
@@ -921,6 +926,7 @@
 "afY" = (
 /obj/structure/chair/sofa/left,
 /obj/item/toy/plush/moth,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "afZ" = (
@@ -1156,6 +1162,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "ahR" = (
@@ -1347,6 +1354,7 @@
 /obj/item/food/grown/poppy,
 /obj/item/food/grown/poppy,
 /obj/item/food/grown/poppy,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/main)
 "ajZ" = (
@@ -1485,6 +1493,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ald" = (
@@ -1537,6 +1546,7 @@
 	c_tag = "Arrivals West";
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "als" = (
@@ -2288,6 +2298,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aqu" = (
@@ -2917,6 +2928,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
 "avI" = (
@@ -3050,6 +3062,7 @@
 	dir = 8
 	},
 /obj/item/flashlight/lamp,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "awD" = (
@@ -3439,6 +3452,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "azM" = (
@@ -4127,6 +4141,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "aHG" = (
@@ -4370,6 +4385,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "aKd" = (
@@ -4671,6 +4687,7 @@
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "aNh" = (
@@ -4886,6 +4903,7 @@
 	c_tag = "Bridge";
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/command/bridge)
 "aOQ" = (
@@ -4894,6 +4912,7 @@
 "aOR" = (
 /obj/structure/chair/sofa,
 /obj/machinery/vending/wallmed/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
 "aOT" = (
@@ -5515,10 +5534,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
-"aTy" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/engineering/storage/tech)
 "aTz" = (
 /obj/structure/bodycontainer/morgue,
 /obj/structure/window/reinforced,
@@ -5710,6 +5725,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
 /area/security/brig)
 "aUI" = (
@@ -6877,8 +6893,8 @@
 	pixel_x = 32
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/turf/open/floor/plating,
+/area/commons/fitness/recreation)
 "bdu" = (
 /obj/item/radio/intercom{
 	pixel_x = 29
@@ -7443,6 +7459,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/engineering/main)
 "bhD" = (
@@ -7563,6 +7580,7 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/multitool,
 /obj/item/clothing/glasses/meson,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "bir" = (
@@ -8233,6 +8251,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"bpU" = (
+/obj/structure/table,
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/mineral/plastitanium{
+	name = "black plastitanium floor"
+	},
+/area/service/bar)
 "bqb" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8287,6 +8312,7 @@
 	pixel_y = 32
 	},
 /obj/item/flashlight/lamp,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "brg" = (
@@ -8361,6 +8387,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "brO" = (
@@ -8470,6 +8497,7 @@
 /obj/structure/table/wood,
 /obj/effect/landmark/start/hangover,
 /obj/item/flashlight/lamp,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "btz" = (
@@ -8530,6 +8558,10 @@
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"buC" = (
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/wood,
+/area/maintenance/starboard/aft)
 "buH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -8633,6 +8665,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "bwn" = (
@@ -9129,6 +9162,7 @@
 "bPu" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "bQg" = (
@@ -9235,6 +9269,12 @@
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"bSU" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/engineering/break_room)
 "bTh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -9754,6 +9794,7 @@
 /obj/structure/chair/wood{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/service/bar)
 "cgJ" = (
@@ -9778,6 +9819,7 @@
 	},
 /obj/machinery/duct,
 /obj/machinery/light/cold/directional/south,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "chj" = (
@@ -10173,6 +10215,8 @@
 /area/hallway/primary/port)
 "cwH" = (
 /obj/structure/closet,
+/obj/machinery/newscaster/directional/south,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cwS" = (
@@ -10192,6 +10236,13 @@
 "cxf" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
+"cxh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "cxs" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -10226,6 +10277,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"cyQ" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "czj" = (
 /obj/structure/cable,
 /obj/structure/chair/office,
@@ -10472,6 +10537,13 @@
 	name = "black plastitanium floor"
 	},
 /area/service/bar)
+"cJo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "cJB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10513,6 +10585,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"cLX" = (
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "cMa" = (
 /obj/structure/window{
 	dir = 8
@@ -10615,9 +10691,6 @@
 /obj/item/book/manual/wiki/detective,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
-"cQk" = (
-/turf/closed/wall,
-/area/hallway/primary/starboard)
 "cQt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -10646,7 +10719,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/area/commons/fitness/recreation)
 "cQC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -10673,12 +10746,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/cryopods)
-"cQP" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Fitness"
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "cQR" = (
 /obj/machinery/door/window/southleft{
 	name = "Test Chamber";
@@ -11085,6 +11152,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "dcD" = (
@@ -11358,6 +11426,10 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
 /area/command/bridge)
+"dkR" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "dld" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
@@ -11399,9 +11471,6 @@
 /obj/item/stock_parts/manipulator,
 /obj/item/stock_parts/manipulator,
 /obj/structure/table,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/item/electronics/airlock,
 /obj/item/electronics/airlock,
 /turf/open/floor/iron/dark,
@@ -11830,6 +11899,7 @@
 /obj/item/pickaxe{
 	pixel_x = 5
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "dxv" = (
@@ -12190,9 +12260,6 @@
 /area/space/nearstation)
 "dEa" = (
 /obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/item/stock_parts/subspace/crystal,
 /obj/item/stock_parts/subspace/crystal,
 /obj/item/stock_parts/subspace/crystal,
@@ -12202,6 +12269,7 @@
 /obj/item/stock_parts/subspace/amplifier,
 /obj/item/stock_parts/subspace/amplifier,
 /obj/item/stock_parts/subspace/amplifier,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "dEk" = (
@@ -12277,6 +12345,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "dGd" = (
@@ -12617,6 +12686,7 @@
 /obj/item/book/manual/wiki/tcomms,
 /obj/item/radio/off,
 /obj/item/multitool,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "dNn" = (
@@ -12797,6 +12867,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/service,
+/obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "dRO" = (
@@ -13456,6 +13527,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/bounty_board/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "enk" = (
@@ -13886,6 +13958,11 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/grass,
 /area/command/bridge)
+"ezL" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "ezQ" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -13905,6 +13982,7 @@
 	pixel_x = 8;
 	pixel_y = 8
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "eAk" = (
@@ -14165,6 +14243,7 @@
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 17
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "eJJ" = (
@@ -14481,10 +14560,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"eRs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "eRz" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -14509,6 +14584,7 @@
 /area/engineering/transit_tube)
 "eSn" = (
 /obj/effect/spawner/bundle/hobo_squat,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "eSp" = (
@@ -14811,6 +14887,7 @@
 /obj/structure/chair/sofa/corner{
 	name = "plush sofa"
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
 "fcB" = (
@@ -15179,6 +15256,7 @@
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/disposalpipe/trunk,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "fiG" = (
@@ -15286,6 +15364,7 @@
 "fkC" = (
 /obj/structure/chair/sofa/right,
 /obj/item/toy/plush/beeplushie,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "fkL" = (
@@ -15312,6 +15391,7 @@
 	},
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "flO" = (
@@ -15382,6 +15462,7 @@
 /area/security/execution/education)
 "fng" = (
 /obj/structure/chair/sofa/right,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/medical/break_room)
 "fnr" = (
@@ -15515,6 +15596,7 @@
 /area/security/detectives_office)
 "frl" = (
 /obj/structure/closet/l3closet,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "frN" = (
@@ -15538,6 +15620,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"fsv" = (
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "fsz" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -15684,6 +15770,7 @@
 	network = list("ss13","rd")
 	},
 /obj/structure/closet/l3closet/scientist,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
 "fwo" = (
@@ -15742,6 +15829,7 @@
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/cable/multilayer/connected,
 /obj/machinery/power/port_gen/pacman,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
 "fxo" = (
@@ -15828,6 +15916,7 @@
 /obj/item/pipe_dispenser{
 	pixel_y = -2
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/engineering/main)
 "fyr" = (
@@ -16372,6 +16461,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/engineering/storage/tech)
 "fSP" = (
@@ -16636,10 +16726,6 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
-"fYC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron,
-/area/commons/fitness/recreation)
 "fYR" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -16679,9 +16765,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fZQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = -22
@@ -16744,6 +16827,7 @@
 	pixel_y = 4
 	},
 /obj/machinery/light,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/rd)
 "gbw" = (
@@ -16803,6 +16887,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/glass,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "gdx" = (
@@ -16818,9 +16903,7 @@
 	desc = "Used to grind things up into raw materials and liquids.";
 	pixel_y = 5
 	},
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "gdX" = (
@@ -16972,6 +17055,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/pharmacy)
+"gio" = (
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "giB" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
@@ -17230,6 +17317,11 @@
 /obj/item/paint/anycolor,
 /turf/open/floor/plating,
 /area/security/prison/safe)
+"grx" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "grH" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
@@ -17428,6 +17520,10 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"gwP" = (
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "gxf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -18007,6 +18103,7 @@
 /area/security/courtroom)
 "gPg" = (
 /obj/effect/spawner/randomsnackvend,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "gPo" = (
@@ -18199,6 +18296,7 @@
 	req_one_access_txt = "5; 33"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "gTe" = (
@@ -18506,6 +18604,7 @@
 	dir = 1
 	},
 /obj/machinery/meter,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/engine,
 /area/engineering/main)
 "hbZ" = (
@@ -18998,6 +19097,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "hqF" = (
@@ -19565,6 +19665,10 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
+"hJi" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "hJH" = (
 /obj/machinery/air_sensor/atmos/mix_tank{
 	id_tag = "mix2_sensor"
@@ -20309,6 +20413,11 @@
 "iiy" = (
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"iiD" = (
+/obj/effect/landmark/start/hangover,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/commons/dorms)
 "ijy" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -20626,6 +20735,7 @@
 /area/service/hydroponics)
 "itf" = (
 /obj/structure/closet/radiation,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "ito" = (
@@ -20732,6 +20842,7 @@
 /area/space)
 "iwe" = (
 /obj/machinery/announcement_system,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "iwg" = (
@@ -20873,7 +20984,7 @@
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/main)
 "izW" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
@@ -20943,21 +21054,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"iDa" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "iDj" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21265,8 +21361,10 @@
 	},
 /area/maintenance/port)
 "iOp" = (
-/obj/structure/table,
 /obj/structure/cable,
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/prison)
 "iOP" = (
@@ -21307,6 +21405,7 @@
 	pixel_y = 30
 	},
 /obj/item/book/manual/wiki/tcomms,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "iQl" = (
@@ -21909,6 +22008,7 @@
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 17
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "jhM" = (
@@ -22097,12 +22197,17 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/cargo/qm)
 "jnT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/break_room)
+"joz" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/carpet/red,
+/area/service/chapel/main)
 "joO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22565,6 +22670,7 @@
 /obj/machinery/computer/security/telescreen/ce{
 	pixel_y = 28
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "jAT" = (
@@ -22738,6 +22844,7 @@
 	dir = 8
 	},
 /obj/structure/closet/emcloset/anchored,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "jGM" = (
@@ -22871,6 +22978,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"jLR" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "jMb" = (
 /obj/structure/closet/secure_closet/captains,
 /turf/open/floor/carpet/royalblue,
@@ -23047,6 +23161,12 @@
 	},
 /turf/open/floor/wood,
 /area/command/heads_quarters/hop)
+"jRs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white,
+/area/science/research)
 "jRI" = (
 /obj/structure/sink{
 	dir = 4;
@@ -23323,6 +23443,7 @@
 /area/medical/surgery)
 "jYK" = (
 /obj/structure/table,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/security/execution/transfer)
 "jYL" = (
@@ -24046,6 +24167,7 @@
 /obj/structure/chair/office{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "ktq" = (
@@ -24376,6 +24498,7 @@
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "kEt" = (
@@ -24525,6 +24648,7 @@
 /area/science/robotics/lab)
 "kHG" = (
 /obj/effect/spawner/randomsnackvend,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "kHI" = (
@@ -24759,6 +24883,11 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
+"kMs" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "kML" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
 	dir = 8
@@ -25083,6 +25212,7 @@
 	},
 /obj/item/storage/box/lights/mixed,
 /obj/item/paicard,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "laS" = (
@@ -25161,6 +25291,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
 "leO" = (
@@ -25313,6 +25444,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small,
 /obj/structure/closet/crate,
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "lie" = (
@@ -25658,6 +25790,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/engine,
 /area/engineering/main)
 "lqj" = (
@@ -25743,6 +25876,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "lsN" = (
@@ -25836,6 +25970,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "lvR" = (
@@ -25931,6 +26066,7 @@
 /area/science/mixing)
 "lyY" = (
 /obj/structure/closet/emcloset/anchored,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
 "lzo" = (
@@ -26021,6 +26157,7 @@
 	pixel_x = -24
 	},
 /obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "lDb" = (
@@ -26293,6 +26430,7 @@
 	pixel_y = -30
 	},
 /obj/structure/tank_dispenser,
+/obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "lLY" = (
@@ -26323,14 +26461,14 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lMI" = (
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Permabrig Prisoner Processing";
 	dir = 1;
 	name = "Perma Camera";
 	network = list("ss13","prison")
+	},
+/obj/structure/reagent_dispensers/plumbed{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/security/prison)
@@ -26504,6 +26642,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "lQK" = (
@@ -26784,6 +26923,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "lZx" = (
@@ -27467,6 +27607,7 @@
 	network = list("ss13","prison")
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron,
 /area/security/brig)
 "mqn" = (
@@ -27814,6 +27955,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/smooth_corner,
 /area/cargo/drone_boy)
 "mDy" = (
@@ -28188,6 +28330,17 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
+"mNW" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/south,
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "mNX" = (
 /obj/structure/table/wood,
 /obj/item/hand_tele,
@@ -28884,6 +29037,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
 "ngr" = (
@@ -29631,6 +29785,7 @@
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "nCU" = (
@@ -29830,6 +29985,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/engineering/transit_tube)
+"nIx" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "nIB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31041,9 +31206,6 @@
 /turf/open/floor/iron,
 /area/security/brig)
 "osr" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/ai,
 /turf/open/floor/iron/dark/textured,
@@ -31418,6 +31580,7 @@
 /area/cargo/miningdock)
 "oDu" = (
 /obj/machinery/atmospherics/components/unary/bluespace_sender,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "oDA" = (
@@ -31833,6 +31996,7 @@
 "oPa" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
@@ -32346,6 +32510,9 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "pfr" = (
@@ -32617,9 +32784,7 @@
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "pnf" = (
-/obj/machinery/newscaster{
-	pixel_x = -32
-	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "png" = (
@@ -32902,6 +33067,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/command/teleporter)
 "pwe" = (
@@ -33318,6 +33484,10 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"pJM" = (
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/ai_monitored/turret_protected/aisat/foyer)
 "pJW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/sorting/mail{
@@ -33859,6 +34029,7 @@
 	name = "plush sofa"
 	},
 /obj/machinery/bounty_board/directional/east,
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
 "qcW" = (
@@ -34230,6 +34401,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars/starboard/aft)
+"qmS" = (
+/obj/machinery/computer/nanite_cloud_controller,
+/obj/effect/turf_decal/bot,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/dark,
+/area/science/nanite)
 "qnh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34257,9 +34434,6 @@
 "qoc" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
@@ -34778,6 +34952,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
 "qEP" = (
@@ -34908,6 +35083,15 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/grass,
 /area/service/hydroponics)
+"qIW" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/mineral/plastitanium{
+	name = "black plastitanium floor"
+	},
+/area/service/bar)
 "qJJ" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/junglebush/c,
@@ -35025,11 +35209,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "qNv" = (
@@ -35863,10 +36045,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"rnj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "rny" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -36127,6 +36305,7 @@
 /area/hallway/primary/aft)
 "rvp" = (
 /obj/effect/spawner/randomcolavend,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/starboard)
 "rvE" = (
@@ -36307,6 +36486,7 @@
 /area/science/robotics/mechbay)
 "rCW" = (
 /obj/structure/closet/emcloset,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "rDp" = (
@@ -36435,6 +36615,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "rGG" = (
@@ -36502,6 +36683,7 @@
 	pixel_y = 10
 	},
 /obj/item/storage/toolbox/artistic,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/commons/storage/art)
 "rHA" = (
@@ -36650,8 +36832,8 @@
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "rNE" = (
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
@@ -36712,6 +36894,7 @@
 "rPL" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/commons/dorms)
 "rPO" = (
@@ -37222,6 +37405,10 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"sdZ" = (
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/wood,
+/area/commons/vacant_room/office)
 "seW" = (
 /obj/machinery/camera{
 	c_tag = "Science Hallway";
@@ -37503,6 +37690,7 @@
 "snf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
 "snh" = (
@@ -37960,6 +38148,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
+"sAI" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron/freezer,
+/area/commons/cryopods)
 "sBb" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -38246,6 +38448,7 @@
 	},
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/circuit,
 /area/engineering/engine_smes)
 "sIR" = (
@@ -38343,6 +38546,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/bounty_board/directional/west,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "sKk" = (
@@ -38396,6 +38600,12 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
+"sLH" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/status_display/evac/directional/west,
+/turf/open/floor/iron,
+/area/science/mixing)
 "sLM" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -38615,6 +38825,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "sSG" = (
@@ -39512,6 +39723,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "tqB" = (
@@ -39797,8 +40009,16 @@
 /obj/item/circuitboard/machine/exoscanner{
 	pixel_y = 3
 	},
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
+"txy" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron,
+/area/hallway/secondary/exit/departure_lounge)
 "txA" = (
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -40035,6 +40255,11 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"tCK" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/half,
+/area/service/hydroponics)
 "tCO" = (
 /obj/effect/spawner/randomcolavend,
 /obj/structure/sign/poster/official/random{
@@ -40100,6 +40325,17 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"tEN" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "tFb" = (
 /obj/machinery/air_sensor/atmos/incinerator_tank{
 	pixel_x = -32;
@@ -41904,6 +42140,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"uCE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/machinery/status_display/evac/directional/north,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "uCK" = (
 /turf/open/floor/wood/large,
 /area/service/library)
@@ -42382,6 +42628,7 @@
 /obj/machinery/camera{
 	c_tag = "Tech Storage"
 	},
+/obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
 "uPl" = (
@@ -42455,6 +42702,7 @@
 "uRw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "uRW" = (
@@ -42736,6 +42984,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "uYy" = (
@@ -42784,6 +43033,7 @@
 /obj/effect/mapping_helpers/dead_body_placer,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "uZu" = (
@@ -43528,6 +43778,12 @@
 	},
 /turf/open/floor/iron,
 /area/command/heads_quarters/ce)
+"vud" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/newscaster/directional/north,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "vul" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock";
@@ -43855,6 +44111,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/security/brig)
 "vAS" = (
@@ -44393,8 +44650,14 @@
 	pixel_x = -2;
 	pixel_y = -2
 	},
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"vPJ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/newscaster/directional/east,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "vPK" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -44960,6 +45223,7 @@
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/stripes/box,
 /obj/structure/cable,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
 "whG" = (
@@ -44972,6 +45236,7 @@
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "whJ" = (
@@ -45051,6 +45316,7 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/upper)
 "wjE" = (
@@ -45173,6 +45439,10 @@
 /area/hallway/secondary/entry)
 "wmO" = (
 /obj/structure/transit_tube/station/reverse/flipped,
+/turf/open/floor/iron/showroomfloor,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"wnD" = (
+/obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "wnE" = (
@@ -45514,6 +45784,7 @@
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood,
 /area/command/heads_quarters/captain)
 "wyR" = (
@@ -45527,6 +45798,7 @@
 /area/science/mixing/chamber)
 "wyW" = (
 /obj/machinery/icecream_vat,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "wyY" = (
@@ -45822,6 +46094,7 @@
 /area/security/brig)
 "wHI" = (
 /obj/machinery/research/explosive_compressor,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "wHJ" = (
@@ -46185,6 +46458,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/bridge)
+"wQP" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/newscaster/directional/west,
+/turf/open/floor/iron,
+/area/engineering/main)
 "wQR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -46977,6 +47259,7 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/newscaster/security_unit/directional/south,
+/obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/upper)
 "xlD" = (
@@ -47466,9 +47749,7 @@
 /area/science/robotics/lab)
 "xvK" = (
 /obj/structure/cable,
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "xvP" = (
@@ -47773,9 +48054,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
+/obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "xEA" = (
@@ -48262,6 +48541,8 @@
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable,
+/obj/machinery/light/cold/directional/north,
+/obj/machinery/newscaster/directional/north,
 /turf/open/floor/circuit,
 /area/engineering/engine_smes)
 "xUQ" = (
@@ -66353,7 +66634,7 @@ oCT
 csI
 aEk
 bbf
-lca
+wQP
 dmq
 bgY
 lca
@@ -66821,7 +67102,7 @@ auR
 auR
 aUK
 yin
-auR
+xlD
 iOp
 lMI
 yin
@@ -68686,7 +68967,7 @@ unP
 hSL
 hSL
 wth
-aTy
+wth
 qQH
 wth
 wth
@@ -68899,7 +69180,7 @@ kji
 sHE
 kcR
 jdC
-bVO
+jdC
 bVO
 bVO
 ctz
@@ -69720,7 +70001,7 @@ gAC
 biy
 bio
 wth
-rqg
+cyQ
 uYy
 bnA
 cES
@@ -70701,7 +70982,7 @@ jdC
 bVO
 bVO
 jdC
-lVS
+uCE
 vYu
 vYu
 dPh
@@ -71250,7 +71531,7 @@ iwN
 wVb
 ljS
 nhw
-aiQ
+bSU
 aiQ
 cuq
 rrv
@@ -71729,7 +72010,7 @@ xke
 vHv
 vHv
 xke
-lVS
+uCE
 vYu
 uqd
 tIA
@@ -72509,7 +72790,7 @@ pLL
 pLL
 pLL
 vTq
-pLL
+kMs
 pLL
 kWh
 goW
@@ -72760,7 +73041,7 @@ eCf
 aRT
 vYu
 drd
-iDa
+lAk
 kEt
 orB
 orB
@@ -73034,7 +73315,7 @@ vYu
 vYu
 vYu
 wAv
-xct
+vPJ
 llA
 vYu
 vYu
@@ -73571,7 +73852,7 @@ beC
 oiT
 vYu
 wAv
-vYu
+gwP
 vZs
 tuj
 lib
@@ -74578,7 +74859,7 @@ xGY
 ucy
 xsR
 vBY
-yiA
+sdZ
 ffN
 kyx
 jdA
@@ -74801,7 +75082,7 @@ kAB
 rNp
 kAB
 sVb
-vUW
+joz
 vUW
 vUW
 vUW
@@ -77384,9 +77665,9 @@ uJa
 fRC
 bxZ
 xyp
-php
+grx
 iwW
-php
+ezL
 xvt
 beG
 bet
@@ -78414,7 +78695,7 @@ lmz
 cMu
 jyG
 jUZ
-dfX
+jLR
 xvt
 xvt
 gas
@@ -78441,8 +78722,8 @@ xGY
 yfY
 urj
 uCP
-iDj
-tLl
+qIW
+bpU
 bhR
 erb
 sZt
@@ -79144,7 +79425,7 @@ wYX
 wYX
 wYX
 wYX
-wYX
+wmK
 wYX
 wYX
 wYX
@@ -79401,7 +79682,7 @@ ygg
 ygg
 ygg
 ygg
-ygg
+dkR
 ygg
 ygg
 ygg
@@ -79980,7 +80261,7 @@ yay
 oVO
 dMq
 pox
-uyT
+tCK
 yfY
 yfY
 aQU
@@ -80423,7 +80704,7 @@ gLT
 wYX
 wYX
 wYX
-wYX
+wmK
 wYX
 wYX
 wYX
@@ -81773,7 +82054,7 @@ bko
 kNG
 ugm
 kTF
-kTF
+tEN
 xia
 ycG
 ach
@@ -81814,7 +82095,7 @@ ulu
 ulu
 gPP
 gPP
-ulu
+cLX
 ulu
 ssG
 qCo
@@ -82076,7 +82357,7 @@ yam
 iWs
 yam
 jGd
-vtt
+txy
 kmH
 mTd
 bsp
@@ -82479,7 +82760,7 @@ wKh
 wYX
 wYX
 wYX
-wYX
+wmK
 wYX
 wYX
 wYX
@@ -83289,7 +83570,7 @@ qxD
 aZT
 aZT
 aZT
-rmK
+iiD
 tGp
 bpd
 brH
@@ -83513,7 +83794,7 @@ ygg
 ygg
 ygg
 ygg
-ygg
+hJi
 ygg
 ygg
 ygg
@@ -83770,7 +84051,7 @@ wYX
 wYX
 wYX
 wYX
-wYX
+wmK
 wYX
 wYX
 wYX
@@ -84344,8 +84625,8 @@ tcM
 ujo
 wSE
 bgj
-vNy
-vNy
+cxh
+cJo
 ent
 vNy
 gGb
@@ -84622,7 +84903,7 @@ qYz
 pnn
 aiS
 rLe
-uio
+mNW
 wmw
 cOX
 wmw
@@ -85597,7 +85878,7 @@ ljc
 ejX
 aLi
 hUx
-hUx
+sAI
 aMq
 jSi
 uJv
@@ -85632,7 +85913,7 @@ vYE
 xrq
 yea
 ygp
-jIV
+vud
 mjV
 lMp
 shF
@@ -86121,7 +86402,7 @@ xrI
 xrI
 xrI
 xrI
-fYC
+yaE
 ybn
 bjU
 lNJ
@@ -86141,7 +86422,7 @@ nFu
 rUN
 tkv
 jYJ
-mjV
+fsv
 mjV
 mjV
 vNy
@@ -86378,7 +86659,7 @@ xrI
 xrI
 xrI
 xrI
-fYC
+yaE
 ybn
 bjU
 sRL
@@ -86892,7 +87173,7 @@ xrI
 xrI
 xrI
 xrI
-eRs
+yaE
 ybn
 bjU
 xbT
@@ -87149,7 +87430,7 @@ xrI
 xrI
 xrI
 xrI
-eRs
+yaE
 ybn
 bjU
 hPr
@@ -87663,7 +87944,7 @@ xrI
 xrI
 xrI
 xrI
-cQk
+etj
 ybn
 bjU
 ybn
@@ -87920,7 +88201,7 @@ xrI
 xrI
 xrI
 xrI
-rnj
+yaE
 ybn
 bjU
 ybn
@@ -88177,7 +88458,7 @@ xrI
 xrI
 xrI
 xrI
-rnj
+yaE
 dak
 bjU
 lHp
@@ -88434,7 +88715,7 @@ aNm
 yaE
 yaE
 yaE
-cQk
+etj
 ybn
 aOA
 bdO
@@ -88948,7 +89229,7 @@ jtc
 sLV
 vzM
 uJv
-cQP
+bdj
 uWM
 dCM
 uWM
@@ -88971,7 +89252,7 @@ uWM
 phb
 wnI
 uWM
-uWM
+gio
 bgD
 bgQ
 uWM
@@ -89205,7 +89486,7 @@ etj
 etj
 etj
 etj
-cQk
+etj
 uWM
 dCO
 ydj
@@ -89485,7 +89766,7 @@ tin
 dfT
 dfT
 tin
-tin
+nIx
 slI
 sWJ
 uWM
@@ -92613,7 +92894,7 @@ gfQ
 xAV
 gfQ
 khn
-iiy
+pJM
 fJZ
 wmO
 iiy
@@ -93131,7 +93412,7 @@ gYL
 mJl
 iiy
 fwg
-iiy
+wnD
 eqS
 khn
 khn
@@ -93320,7 +93601,7 @@ xxF
 xII
 fBE
 dJf
-nbL
+qmS
 rMn
 anN
 anO
@@ -93885,7 +94166,7 @@ xsd
 oxx
 iTL
 xsd
-ahf
+buC
 xXv
 ilZ
 fFL
@@ -94876,7 +95157,7 @@ nZN
 ppC
 qiv
 xiq
-uAk
+jRs
 tvm
 iAb
 lMh
@@ -97453,7 +97734,7 @@ vBA
 vBA
 xEA
 pyP
-iQM
+sLH
 lpi
 rYf
 iQM

--- a/jollystation.dme
+++ b/jollystation.dme
@@ -3543,6 +3543,7 @@
 #include "jollystation_modules\code\datums\quirks\good.dm"
 #include "jollystation_modules\code\datums\quirks\negative.dm"
 #include "jollystation_modules\code\datums\quirks\neutral.dm"
+#include "jollystation_modules\code\game\area\space_station_13_areas.dm"
 #include "jollystation_modules\code\game\objects\unique_examine_items.dm"
 #include "jollystation_modules\code\game\objects\items\card_ids.dm"
 #include "jollystation_modules\code\game\objects\items\devices\PDA\PDA_types.dm"

--- a/jollystation.dme
+++ b/jollystation.dme
@@ -3550,6 +3550,7 @@
 #include "jollystation_modules\code\game\objects\items\devices\PDA\PDA_types.dm"
 #include "jollystation_modules\code\game\objects\items\devices\radio\encryptionkey.dm"
 #include "jollystation_modules\code\game\objects\items\devices\radio\headset.dm"
+#include "jollystation_modules\code\game\objects\items\structures\static_plaques.dm"
 #include "jollystation_modules\code\game\objects\items\structures\crate_lockers\crates.dm"
 #include "jollystation_modules\code\modules\antagonists\_common\advanced_antag.dm"
 #include "jollystation_modules\code\modules\antagonists\_common\advanced_objective.dm"

--- a/jollystation.dme
+++ b/jollystation.dme
@@ -3545,6 +3545,7 @@
 #include "jollystation_modules\code\datums\quirks\neutral.dm"
 #include "jollystation_modules\code\game\area\space_station_13_areas.dm"
 #include "jollystation_modules\code\game\objects\unique_examine_items.dm"
+#include "jollystation_modules\code\game\objects\effects\landmarks.dm"
 #include "jollystation_modules\code\game\objects\items\card_ids.dm"
 #include "jollystation_modules\code\game\objects\items\devices\PDA\PDA_types.dm"
 #include "jollystation_modules\code\game\objects\items\devices\radio\encryptionkey.dm"

--- a/jollystation_modules/code/game/area/space_station_13_areas.dm
+++ b/jollystation_modules/code/game/area/space_station_13_areas.dm
@@ -1,0 +1,6 @@
+/// -- Modular areas, for ruins/modular maps/etc --
+// Drone Bay Area
+/area/cargo/drone_boy
+	name = "Drone Bay"
+	icon_state = "cargo_warehouse"
+	sound_environment = SOUND_AREA_LARGE_ENCLOSED

--- a/jollystation_modules/code/game/objects/effects/landmarks.dm
+++ b/jollystation_modules/code/game/objects/effects/landmarks.dm
@@ -1,0 +1,15 @@
+/// -- Modular landmarks. --
+// XB start location
+/obj/effect/landmark/start/xenobiologist
+	name = "Xenobiologist"
+	icon_state = "Scientist"
+
+// Toxins start location
+/obj/effect/landmark/start/toxicologist
+	name = "Toxicologist"
+	icon_state = "Scientist"
+
+// BO start location
+/obj/effect/landmark/start/bridge_officer
+	name = "Bridge Officer"
+	icon_state = "Head of Security"

--- a/jollystation_modules/code/game/objects/items/structures/static_plaques.dm
+++ b/jollystation_modules/code/game/objects/items/structures/static_plaques.dm
@@ -1,0 +1,4 @@
+/// -- Modular map commission plaques --
+// Limastation. Originally added Jan 27, 2020, added here Jan 28, 2021
+/obj/structure/plaque/static_plaque/golden/commission/lima
+	desc = "Spinward Sector Station SS-13\n'Lima' Class Outpost (Revision 2)\nCommissioned 27/01/2560, Recommissioned 28/01/2561\n'Present Memories'"


### PR DESCRIPTION
Many many many hours of blood, sweat, tears, and a file corruption that deleted a day of work has lead to Lima: Functioning & Up-to-date (for now?)

closes #90

- **The entire station was re-piped.**
- **The entire camera net was redone.**
- All the departments now have cargobus consoles.
- There is now a drone bay.
![image](https://user-images.githubusercontent.com/51863163/120120106-eb156080-c160-11eb-816b-837850c373b3.png)
- There is now a cryogenics room.
![image](https://user-images.githubusercontent.com/51863163/120120112-f4063200-c160-11eb-87ce-bf47fa3dd79e.png)
- Medbay, Dorms, the Kitchen, Permabrig, and a few other areas are now plumbed.
![image](https://user-images.githubusercontent.com/51863163/120120127-04b6a800-c161-11eb-9121-ebfd345e320f.png)
- A shit ton of wall mounted items were converted to directionals and a shit ton of wall mounted items were added (newscasters, intercoms, entertainment monitors, etc etc)
- A ton of holo-pads were installed.
- A large amount of maintenance loot was added or revamped.
- Cargo bay received a small expansion for a mech bay.
![image](https://user-images.githubusercontent.com/51863163/120120153-26b02a80-c161-11eb-930c-4e301f065844.png)
- Meteor shields were added around a few places, and telecomms recieved some slight adjustments.
- **A large amount of engineering was remapped.**
- Atmos's office was enlarged slightly.
![image](https://user-images.githubusercontent.com/51863163/120120186-53644200-c161-11eb-82af-3b12bf45a510.png)
- The SMESs now no longer need multilayer cable terminals, as the SM cabling was redone.
- The lower part of engineering was turned into an equipment room.
![image](https://user-images.githubusercontent.com/51863163/120120209-6ecf4d00-c161-11eb-9814-598f966d91df.png)
- The central part of engineering was redone with new tiles. 
- The gravity generator was moved to where tech storage was.
![image](https://user-images.githubusercontent.com/51863163/120120225-8ad2ee80-c161-11eb-8b2d-2c9c2898e208.png)
- ...And Tech Storage was moved to where the gravity generator was, giving it a ""public"" access door.
![image](https://user-images.githubusercontent.com/51863163/120120233-93c3c000-c161-11eb-883b-5d6f283b0e75.png)
- Made the solar panels actual use their proper area instead of maintenance area.
- Made the bridge use a real actual area instead of the abstract 'command' area.
- Made Ian's Room use the corporate showroom area.
- Permabrig's area's were redone with the new work / rec / etc area.
- Overall, more places use the new textured and alternative floor tiling. 
- Spawn locations for a few modular jobs were added. 
- ...And probably more I missed?
